### PR TITLE
feat: [CO-89] user attribute cannot be part of their password

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -12057,6 +12057,13 @@ public class ZAttrProvisioning {
     public static final String A_zimbraPasswordLocked = "zimbraPasswordLocked";
 
     /**
+     * block personal data in password string
+     */
+    @ZAttr(id=3089)
+    public static final String A_zimbraBlockPersonalDataInPasswordEnabled = "zimbraBlockPersonalDataInPasswordEnabled";
+
+
+    /**
      * how long an account is locked out. Use 0 to lockout an account until
      * admin resets it. Must be in valid duration format:
      * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -

--- a/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
+++ b/soap/src/java-test/com/zimbra/soap/account/GetInfoResponse.json
@@ -225,6 +225,7 @@
       "zimbraFeatureDiscardInFiltersEnabled": "TRUE",
       "zimbraFeatureNewMailNotificationEnabled": "TRUE",
       "zimbraPasswordMinDigitsOrPuncs": "0",
+      "zimbraBlockPersonalDataInPasswordEnabled": "TRUE",
       "zimbraExternalShareLifetime": "0",
       "zimbraFeatureAdminMailEnabled": "TRUE",
       "zimbraShareLifetime": "0",

--- a/store-conf/conf/rights/rights-adminconsole.xml
+++ b/store-conf/conf/rights/rights-adminconsole.xml
@@ -1410,6 +1410,7 @@
       <a n="zimbraPasswordMinAge"/>
       <a n="zimbraPasswordMaxAge"/>
       <a n="zimbraPasswordEnforceHistory"/>
+      <a n="zimbraBlockPersonalDataInPasswordEnabled"/>
       <!-- Failed Login Policy -->
       <a n="zimbraPasswordLockoutEnabled"/>
       <a n="zimbraPasswordLockoutMaxFailures"/>
@@ -1453,6 +1454,7 @@
       <a n="zimbraPasswordMinAge"/>
       <a n="zimbraPasswordMaxAge"/>
       <a n="zimbraPasswordEnforceHistory"/>
+      <a n="zimbraBlockPersonalDataInPasswordEnabled"/>
       <!-- Failed Login Policy -->
       <a n="zimbraPasswordLockoutEnabled"/>
       <a n="zimbraPasswordLockoutMaxFailures"/>

--- a/store-conf/conf/rights/rights-domainadmin.xml
+++ b/store-conf/conf/rights/rights-domainadmin.xml
@@ -169,6 +169,7 @@
     <a n="zimbraPasswordAllowedChars"/>
     <a n="zimbraPasswordAllowedPunctuationChars"/>
     <a n="zimbraPasswordEnforceHistory"/>
+    <a n="zimbraBlockPersonalDataInPasswordEnabled"/>
     <a n="zimbraPasswordLocked"/>
     <a n="zimbraPasswordLockoutDuration"/>
     <a n="zimbraPasswordLockoutEnabled"/>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9757,4 +9757,10 @@ TODO: delete them permanently from here
   <defaultCOSValue>TRUE</defaultCOSValue>
   <desc>whether to use Web Client feature</desc>
 </attr>
+
+<attr id="3089" name="zimbraBlockPersonalDataInPasswordEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.0.0">
+  <defaultCOSValue>TRUE</defaultCOSValue>
+  <desc>block personal data in password string</desc>
+</attr>
+
 </attrs>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9758,9 +9758,9 @@ TODO: delete them permanently from here
   <desc>whether to use Web Client feature</desc>
 </attr>
 
-<attr id="3089" name="zimbraBlockPersonalDataInPasswordEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.0.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
-  <desc>block personal data in password string</desc>
-</attr>
+<!--<attr id="3089" name="zimbraBlockPersonalDataInPasswordEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="9.0.0">-->
+<!--  <defaultCOSValue>TRUE</defaultCOSValue>-->
+<!--  <desc>block personal data in password string</desc>-->
+<!--</attr>-->
 
 </attrs>

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -34784,6 +34784,68 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
+     * personal data allowed in password
+     *
+     * @return zimbraBlockPersonalDataInPasswordEnabled, or true if unset
+     */
+    @ZAttr(id=3089)
+    public boolean isBlockPersonalDataInPasswordEnabled() {
+      return getBooleanAttr(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, true, true);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param zimbraBlockPersonalDataInPasswordEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     */
+    @ZAttr(id=3089)
+    public void setBlockPersonalDataInPasswordEnabled(boolean zimbraBlockPersonalDataInPasswordEnabled) throws com.zimbra.common.service.ServiceException {
+      HashMap<String,Object> attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, zimbraBlockPersonalDataInPasswordEnabled ? TRUE : FALSE);
+      getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param zimbraBlockPersonalDataInPasswordEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> setBlockPersonalDataInPasswordEnabled(boolean zimbraBlockPersonalDataInPasswordEnabled, Map<String,Object> attrs) {
+      if (attrs == null) attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, zimbraBlockPersonalDataInPasswordEnabled ? TRUE : FALSE);
+      return attrs;
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     */
+    @ZAttr(id=3089)
+    public void unsetBlockPersonalDataInPasswordEnabled() throws com.zimbra.common.service.ServiceException {
+      HashMap<String,Object> attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, "");
+      getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> unsetBlockPersonalDataInPasswordEnabled(Map<String,Object> attrs) {
+      if (attrs == null) attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, "");
+      return attrs;
+    }
+
+    /**
      * regex of allowed punctuation characters in password
      *
      * @return zimbraPasswordAllowedPunctuationChars, or null if unset

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -27288,6 +27288,68 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
+     * personal data allowed in password
+     *
+     * @return zimbraBlockPersonalDataInPasswordEnabled, or false if unset
+     */
+    @ZAttr(id=3089)
+    public boolean isBlockPersonalDataInPasswordEnabled() {
+      return getBooleanAttr(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, false, true);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param zimbraBlockPersonalDataInPasswordEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     */
+    @ZAttr(id=3089)
+    public void setBlockPersonalDataInPasswordEnabled(boolean zimbraBlockPersonalDataInPasswordEnabled) throws com.zimbra.common.service.ServiceException {
+      HashMap<String,Object> attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, zimbraBlockPersonalDataInPasswordEnabled ? TRUE : FALSE);
+      getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param zimbraBlockPersonalDataInPasswordEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> setBlockPersonalDataInPasswordEnabled(boolean zimbraBlockPersonalDataInPasswordEnabled, Map<String,Object> attrs) {
+      if (attrs == null) attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, zimbraBlockPersonalDataInPasswordEnabled ? TRUE : FALSE);
+      return attrs;
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     */
+    @ZAttr(id=3089)
+    public void unsetBlockPersonalDataInPasswordEnabled() throws com.zimbra.common.service.ServiceException {
+      HashMap<String,Object> attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, "");
+      getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * personal data allowed in password
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     */
+    @ZAttr(id=3089)
+    public Map<String,Object> unsetBlockPersonalDataInPasswordEnabled(Map<String,Object> attrs) {
+      if (attrs == null) attrs = new HashMap<String,Object>();
+      attrs.put(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, "");
+      return attrs;
+    }
+
+    /**
      * how long an account is locked out. Use 0 to lockout an account until
      * admin resets it. Must be in valid duration format:
      * {digits}{time-unit}. digits: 0-9, time-unit: [hmsd]|ms. h - hours, m -

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5,33 +5,6 @@
 
 package com.zimbra.cs.account.ldap;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
-
-import java.util.stream.Stream;
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringUtils;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -47,7 +20,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.service.ServiceException.Argument;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.UnmodifiableBloomFilter;
 import com.zimbra.common.util.Constants;
 import com.zimbra.common.util.EmailUtil;
 import com.zimbra.common.util.L10nUtil;
@@ -221,6 +193,31 @@ import com.zimbra.soap.type.AutoProvPrincipalBy;
 import com.zimbra.soap.type.GalSearchType;
 import com.zimbra.soap.type.NamedValue;
 import com.zimbra.soap.type.TargetBy;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -6243,38 +6240,41 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         }
     }
 
-    // validate that user is not using personal data in his password
-    private void validatePasswordEntropy(String password, Account acct)
-        throws AccountServiceException {
-        String username = acct.getAttr(Provisioning.A_sn); // "Natalie";
-        String fullname = acct.getAttr(Provisioning.A_cn); // "Natalie Leesa";
-        String initials = acct.getAttr(Provisioning.A_initials); // "Rose";
-        String email = acct.getAttr(Provisioning.A_mail); // "natalie.leesa@example.com";
+  // validate that user is not using personal data in his password
+  private void validatePasswordEntropy(String password, Account acct)
+      throws AccountServiceException {
+    String username = acct.getAttr(Provisioning.A_sn);
+    String fullname = acct.getAttr(Provisioning.A_cn);
+    String initials = acct.getAttr(Provisioning.A_initials);
+    String email = acct.getAttr(Provisioning.A_mail);
 
-        String[] fullNameExploded = fullname.toLowerCase().split(" ");
-        String[] emailExploded = email.split("[@._]");
-        String[] cleanEmailExploded = Arrays.copyOf(emailExploded,emailExploded.length -1 ); // remove the top level domain(TLD)
-        String passwordLower = password.toLowerCase();
+    String[] fullNameExploded = fullname.toLowerCase().split(" ");
+    String[] emailExploded = email.split("[@._]");
+    String[] cleanEmailExploded =
+        Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
+    String passwordLower = password.toLowerCase();
 
-        String[] personalDataImploded = {
-            username.toLowerCase(),
-            fullname.toLowerCase(),
-            fullname.replace(" ", "").toLowerCase(),
-            initials.toLowerCase()
-        };
+    String[] personalDataImploded = {
+      username.toLowerCase(),
+      fullname.toLowerCase(),
+      fullname.replace(" ", "").toLowerCase(),
+      initials.toLowerCase()
+    };
 
-        String[] dictionary = Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
+    String[] dictionary =
+        Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
             .flatMap(Stream::of)
             .toArray(String[]::new);
 
-        for (String part : dictionary) {
-            if (part.length() > 2 && (part.contains(passwordLower) || passwordLower.contains(part))) {
-                throw AccountServiceException.INVALID_PASSWORD(
-                    "password contains username or other personal data: " + part,
-                    new Argument(Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, part, Argument.Type.STR));
-            }
-        }
+    for (String part : dictionary) {
+      if (part.length() > 2 && (part.contains(passwordLower) || passwordLower.contains(part))) {
+        throw AccountServiceException.INVALID_PASSWORD(
+            "password contains username or other personal data: " + part,
+            new Argument(
+                Provisioning.A_zimbraBlockPersonalDataInPasswordEnabled, part, Argument.Type.STR));
+      }
     }
+  }
 
     private boolean isAsciiPunc(char ch) {
         return

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6243,21 +6243,21 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   // validate that user is not using personal data in his password
   private void validatePasswordEntropy(String password, Account acct)
       throws AccountServiceException {
-    String username = acct.getAttr(Provisioning.A_sn);
-    String fullname = acct.getAttr(Provisioning.A_cn);
-    String initials = acct.getAttr(Provisioning.A_initials);
+    String s_name = acct.getAttr(Provisioning.A_sn) == null ? "" : acct.getAttr(Provisioning.A_sn);
+    String c_name = acct.getAttr(Provisioning.A_cn) == null ? "" : acct.getAttr(Provisioning.A_cn);
+    String initials = acct.getAttr(Provisioning.A_initials) == null ? "" : acct.getAttr(Provisioning.A_initials); //could be null
     String email = acct.getAttr(Provisioning.A_mail);
 
-    String[] fullNameExploded = fullname.toLowerCase().split(" ");
+    String[] fullNameExploded = c_name.toLowerCase().split(" ");
     String[] emailExploded = email.split("[@._]");
     String[] cleanEmailExploded =
         Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
     String passwordLower = password.toLowerCase();
 
     String[] personalDataImploded = {
-      username.toLowerCase(),
-      fullname.toLowerCase(),
-      fullname.replace(" ", "").toLowerCase(),
+      s_name.toLowerCase(),
+      c_name.toLowerCase(),
+      c_name.replace(" ", "").toLowerCase(),
       initials.toLowerCase()
     };
 


### PR DESCRIPTION
- added new password policy which will prevent user from adding their
personal data in their passowrd string
- this policy is enforced by default and can be set to false in COS
or per user like other password restriction that are already in place