### PR TITLE
fix(LC.java): set localized_client_msgs_dir to load locales from admin path

### DIFF
--- a/common/src/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/java/com/zimbra/common/localconfig/LC.java
@@ -125,7 +125,7 @@ public final class LC {
 
     @Supported
     public static final KnownKey localized_client_msgs_directory =
-        KnownKey.newKey("${mailboxd_directory}/webapps/zimbra/WEB-INF/classes/messages");
+        KnownKey.newKey("${mailboxd_directory}/webapps/zimbraAdmin/WEB-INF/classes/messages");
 
     @Supported
     public static final KnownKey skins_directory = KnownKey.newKey("${mailboxd_directory}/webapps/zimbra/skins");


### PR DESCRIPTION
Admin console requests locales by SOAP call on mailbox.
Mailbox is loading locales from a directory that is not provided by the admin package.

This is a fix to make mailbox return locales provided by carbonio-appserver-admin-console-war package.

### Update
I've done more tests on this. The changes I made should impact only a method that returns a list of Language Codes and that works this way:
* Scans the stated directory and **infer** language codes based on file names. Note that matching file names are only the ones
like AjxMsg, and couple others (see WebClientL10nUtil.java line 60)

Further tests I made:
* Change location of localization client directory to point to admin directory: 
     * observe admin languages dropdown is working;
     * change language and see admin panel changes languages;
     * see also webclient panel changes language
* Change location of localization client directory to point to a custom directory
     * include only AjxMsg* files inside this directory (e.g.: /opt/zextras/jetty_base/webapps/myCustomDir/WEB-INF/classes/messages (needs restart)
     * observe admin is working, languages list loads, translations works
     * observe webclient translation is working
     * remove .properties files from /opt/zextras/jetty_base/webapps/myCustomDir/WEB-INF/classes/messages and restart and observe translations are still working for both admin and webclient, but languages list includes just English.

**Future consideration**
If the admin package will be updated to not include the locales, then mailbox SOAP API won't return the full list of language codes. Unfortunately this is kind of the same problem we're dealing with now, so better keep it in mind.
 