### PR TITLE
New Password policy without LDAP attribute

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -2,30 +2,23 @@ package com.zimbra.cs.account.ldap;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-
-/**
- * Unit test for {@link LdapProvisioning}.
- *
- */
+/** Unit test for {@link LdapProvisioning}. */
 public class LdapProvisioningTest {
 
   @BeforeClass
   public static void init() throws Exception {
     MailboxTestUtil.initServer();
     Provisioning prov = Provisioning.getInstance();
-    HashMap<String,Object> attrs;
+    HashMap<String, Object> attrs;
     attrs = new HashMap<>();
     attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
     attrs.put(Provisioning.A_sn, "Leesa");
@@ -33,6 +26,15 @@ public class LdapProvisioningTest {
     attrs.put(Provisioning.A_initials, "James");
     attrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
     prov.createAccount("natalie.leesa@example.com", "testpassword", attrs);
+
+    HashMap<String, Object> attrs2;
+    attrs2 = new HashMap<>();
+    attrs2.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+    attrs2.put(Provisioning.A_sn, "Lamborghini");
+    attrs2.put(Provisioning.A_cn, "Milano");
+    attrs2.put(Provisioning.A_initials, "Cars");
+    attrs2.put(Provisioning.A_mail, "milano@lamborghini");
+    prov.createAccount("milano@lamborghini", "testpassword", attrs2);
   }
 
   @Before
@@ -41,58 +43,47 @@ public class LdapProvisioningTest {
   }
 
   /**
-   * This test is to validate functionality of
-   * ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String, Account)})
-   * @throws ServiceException */
-  @Test
+   * This test is to validate functionality of ({@link
+   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * Account)})
+   *
+   * @throws ServiceException
+   */
+  @Test(expected = AccountServiceException.class)
   public void shouldFindPersonalDataInPassword() throws ServiceException {
 
     Account acct = Provisioning.getInstance().getAccount("natalie.leesa@example.com");
 
-    //fake passwords for test against created user account
-    String[] testPasswords = {"natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"};
-
-    // get possible personal data for account
-    Optional<String> sName =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_sn)).orElse(""));
-    Optional<String> cName =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse(""));
-    Optional<String> initials =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse(""));
-    Optional<String> email =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse(""));
-
-    // prepare dictionary
-    String[] fullNameExploded = cName.get().toLowerCase().split(" ");
-    String[] emailExploded = email.get().split("[@._]");
-    String[] cleanEmailExploded =
-        Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
-    Arrays.stream(cleanEmailExploded)
-        .forEach(
-            em -> {
-              System.out.println("email element" + em);
-            });
-
-    // find match in dictionary and password
-    Arrays.stream(testPasswords).map(String::toLowerCase).forEach(passwordLower -> {
-      String[] personalDataImploded = {
-          sName.get().toLowerCase(),
-          cName.get().toLowerCase(),
-          cName.get().replace(" ", "").toLowerCase(),
-          initials.get().toLowerCase()
-      };
-      Optional<String> matchedSensitivePart =
-          Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
-              .flatMap(Stream::of)
-              .parallel()
-              .filter(
-                  part ->
-                      (part.length() > 2
-                          && (part.contains(passwordLower) || passwordLower.contains(part))))
-              .findAny();
-      Assert.assertTrue("matching against password:" + passwordLower,
-          matchedSensitivePart.isPresent());
-    });
+    // fake passwords for test against created user account
+    String[] testPasswords = {
+      "natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"
+    };
+    for (String testPassword : testPasswords) {
+      String passwordLower = testPassword.toLowerCase();
+      LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+    }
   }
-  
+
+  /**
+   * This test is to validate functionality of ({@link
+   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * Account)}) for specific case in which user might be using a dotless domain
+   *
+   * @throws ServiceException
+   */
+  @Test(expected = AccountServiceException.class)
+  public void shouldFindPersonalDataInPasswordForDotLessDomainsEmails() throws ServiceException {
+
+    Account acct = Provisioning.getInstance().getAccount("milano@lamborghini");
+
+    // fake passwords for test against created user account
+    String[] testPasswords = {
+      "milano", "Lamborghini123", "Milano34", "lamborghini01", "Milano.Lamborghini", "lAmbOrgHini", "2022cars"
+    };
+
+    for (String testPassword : testPasswords) {
+      String passwordLower = testPassword.toLowerCase();
+      LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+    }
+  }
 }

--- a/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -1,0 +1,99 @@
+package com.zimbra.cs.account.ldap;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+/**
+ * Unit test for {@link LdapProvisioning}.
+ *
+ */
+public class LdapProvisioningTest {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    Provisioning prov = Provisioning.getInstance();
+    HashMap<String,Object> attrs;
+    attrs = new HashMap<>();
+    attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+    attrs.put(Provisioning.A_sn, "Leesa");
+    attrs.put(Provisioning.A_cn, "Natalie Leesa");
+    attrs.put(Provisioning.A_initials, "James");
+    attrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
+    prov.createAccount("natalie.leesa@example.com", "testpassword", attrs);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  /**
+   * This test is to validate functionality of
+   * ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String, Account)})
+   * @throws ServiceException */
+  @Test
+  public void shouldFindPersonalDataInPassword() throws ServiceException {
+
+    //Account acct = Provisioning.getInstance().get(AccountBy.id, "natalie.leesa@example.com");
+    Account acct = Provisioning.getInstance().getAccount("natalie.leesa@example.com");
+
+    //fake passwords for test against created user account
+    String[] testPasswords = {"natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"};
+
+    // get possible personal data for account
+    Optional<String> sName =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_sn)).orElse(""));
+    Optional<String> cName =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse(""));
+    Optional<String> initials =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse(""));
+    Optional<String> email =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse(""));
+
+    // prepare dictionary
+    String[] fullNameExploded = cName.get().toLowerCase().split(" ");
+    String[] emailExploded = email.get().split("[@._]");
+    String[] cleanEmailExploded =
+        Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
+    Arrays.stream(cleanEmailExploded)
+        .forEach(
+            em -> {
+              System.out.println("email element" + em);
+            });
+
+    // find match in dictionary and password
+    Arrays.stream(testPasswords).map(String::toLowerCase).forEach(passwordLower -> {
+      String[] personalDataImploded = {
+          sName.get().toLowerCase(),
+          cName.get().toLowerCase(),
+          cName.get().replace(" ", "").toLowerCase(),
+          initials.get().toLowerCase()
+      };
+      Optional<String> matchedSensitivePart =
+          Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
+              .flatMap(Stream::of)
+              .parallel()
+              .filter(
+                  part ->
+                      (part.length() > 2
+                          && (part.contains(passwordLower) || passwordLower.contains(part))))
+              .findAny();
+      Assert.assertTrue("matching against password:" + passwordLower,
+          matchedSensitivePart.isPresent());
+    });
+  }
+  
+}

--- a/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -47,7 +47,6 @@ public class LdapProvisioningTest {
   @Test
   public void shouldFindPersonalDataInPassword() throws ServiceException {
 
-    //Account acct = Provisioning.getInstance().get(AccountBy.id, "natalie.leesa@example.com");
     Account acct = Provisioning.getInstance().getAccount("natalie.leesa@example.com");
 
     //fake passwords for test against created user account

--- a/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -36,6 +36,15 @@ public class LdapProvisioningTest {
     exampleAccountAttrs2.put(Provisioning.A_initials, "Cars");
     exampleAccountAttrs2.put(Provisioning.A_mail, "milano@lamborghini");
     prov.createAccount("milano@lamborghini", "testpassword", exampleAccountAttrs2);
+
+    HashMap<String, Object> exampleAccountAttrs3;
+    exampleAccountAttrs3 = new HashMap<>();
+    exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+    exampleAccountAttrs3.put(Provisioning.A_sn, "Lamborghini");
+    exampleAccountAttrs3.put(Provisioning.A_cn, "Milano");
+    exampleAccountAttrs3.put(Provisioning.A_initials, "Cars");
+    exampleAccountAttrs3.put(Provisioning.A_mail, "milano@lamborghini-europe.com");
+    prov.createAccount("milano@lamborghini-europe.com", "testpassword", exampleAccountAttrs3);
   }
 
   @Before
@@ -46,7 +55,7 @@ public class LdapProvisioningTest {
   /**
    * This test is to validate functionality of ({@link
    * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
-   * Account)})
+   * Account)}) for personal data
    *
    * @throws ServiceException
    */
@@ -68,7 +77,7 @@ public class LdapProvisioningTest {
   /**
    * This test is to validate functionality of ({@link
    * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
-   * Account)}) for specific case in which user might be using a dotless domain
+   * Account)}) for specific case in which user might be <b>using a dotless domain</b>
    *
    * @throws ServiceException
    */
@@ -80,6 +89,29 @@ public class LdapProvisioningTest {
     // fake passwords for test against created user account
     String[] testPasswords = {
       "milano", "Lamborghini123", "Milano34", "lamborghini01", "Milano.Lamborghini", "lAmbOrgHini", "2022cars"
+    };
+
+    for (String testPassword : testPasswords) {
+      String passwordLower = testPassword.toLowerCase();
+      LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+    }
+  }
+
+  /**
+   * This test is to validate functionality of ({@link
+   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * Account)}) for specific case in which user's <b>domain name contains special chars</b>
+   *
+   * @throws ServiceException
+   */
+  @Test(expected = AccountServiceException.class)
+  public void shouldFindPersonalDataInPasswordForDomainsContainingSpecialChars() throws ServiceException {
+
+    Account acct = Provisioning.getInstance().getAccount("milano@lamborghini-europe.com");
+
+    // fake passwords for test against created user account
+    String[] testPasswords = {
+        "Adjbiuhkl2022europe", "Lamborghini123"
     };
 
     for (String testPassword : testPasswords) {

--- a/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -18,23 +18,24 @@ public class LdapProvisioningTest {
   public static void init() throws Exception {
     MailboxTestUtil.initServer();
     Provisioning prov = Provisioning.getInstance();
-    HashMap<String, Object> attrs;
-    attrs = new HashMap<>();
-    attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    attrs.put(Provisioning.A_sn, "Leesa");
-    attrs.put(Provisioning.A_cn, "Natalie Leesa");
-    attrs.put(Provisioning.A_initials, "James");
-    attrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
-    prov.createAccount("natalie.leesa@example.com", "testpassword", attrs);
 
-    HashMap<String, Object> attrs2;
-    attrs2 = new HashMap<>();
-    attrs2.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    attrs2.put(Provisioning.A_sn, "Lamborghini");
-    attrs2.put(Provisioning.A_cn, "Milano");
-    attrs2.put(Provisioning.A_initials, "Cars");
-    attrs2.put(Provisioning.A_mail, "milano@lamborghini");
-    prov.createAccount("milano@lamborghini", "testpassword", attrs2);
+    HashMap<String, Object> exampleAccountAttrs;
+    exampleAccountAttrs = new HashMap<>();
+    exampleAccountAttrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+    exampleAccountAttrs.put(Provisioning.A_sn, "Leesa");
+    exampleAccountAttrs.put(Provisioning.A_cn, "Natalie Leesa");
+    exampleAccountAttrs.put(Provisioning.A_initials, "James");
+    exampleAccountAttrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
+    prov.createAccount("natalie.leesa@example.com", "testpassword", exampleAccountAttrs);
+
+    HashMap<String, Object> exampleAccountAttrs2;
+    exampleAccountAttrs2 = new HashMap<>();
+    exampleAccountAttrs2.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+    exampleAccountAttrs2.put(Provisioning.A_sn, "Lamborghini");
+    exampleAccountAttrs2.put(Provisioning.A_cn, "Milano");
+    exampleAccountAttrs2.put(Provisioning.A_initials, "Cars");
+    exampleAccountAttrs2.put(Provisioning.A_mail, "milano@lamborghini");
+    prov.createAccount("milano@lamborghini", "testpassword", exampleAccountAttrs2);
   }
 
   @Before

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6267,7 +6267,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       throw AccountServiceException.INVALID_PASSWORD(
           "password contains username or other personal data: " + matchedSensitivePart.get(),
           new Argument(
-              "BlockPersonalDataInPasswordPolicy", matchedSensitivePart.get(), Argument.Type.STR));
+              "blockPersonalDataInPasswordPolicy", matchedSensitivePart.get(), Argument.Type.STR));
     }
   }
 

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6235,26 +6235,22 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   public static void validatePasswordEntropyForPersonalData(String password, Account acct)
       throws AccountServiceException {
     // get possible personal data for account
-    Optional<String> sName =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_sn)).orElse(""));
-    Optional<String> cName =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse(""));
-    Optional<String> initials =
-        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse(""));
-    Optional<String> email =
-      Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse(""));
+    String sName = Optional.ofNullable(acct.getAttr(Provisioning.A_sn)).orElse("");
+    String cName = Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse("");
+    String initials = Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse("");
+    String email = Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse("");
 
     // prepare dictionary
-    String[] fullNameExploded = cName.get().toLowerCase().split(" ");
-    String[] emailExploded = email.get().split("[@._]");
+    String[] fullNameExploded = cName.toLowerCase().split(" ");
+    String[] emailExploded = email.split("[@._]");
     String[] cleanEmailExploded =
         Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
     String passwordLower = password.toLowerCase();
     String[] personalDataImploded = {
-      sName.get().toLowerCase(),
-      cName.get().toLowerCase(),
-      cName.get().replace(" ", "").toLowerCase(),
-      initials.get().toLowerCase()
+      sName.toLowerCase(),
+      cName.toLowerCase(),
+      cName.replace(" ", "").toLowerCase(),
+      initials.toLowerCase()
     };
 
     // find match in dictionary and password

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6137,7 +6137,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             }
         }
 
-        validatePasswordEntropyForPersonalData(password, acct);
+        if(acct != null){
+            validatePasswordEntropyForPersonalData(password, acct);
+        }
 
         String allowedPuncChars = getString(acct, cos, entry, Provisioning.A_zimbraPasswordAllowedPunctuationChars);
         Pattern allowedPuncCharsPattern = null;

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6241,6 +6241,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     String cName = Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse("");
     String initials = Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse("");
     String email = Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse("");
+    String domain = Optional.ofNullable(acct.getDomainName()).orElse("");
 
     // prepare dictionary
     String[] fullNameExploded = cName.toLowerCase().split(" ");
@@ -6252,7 +6253,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       sName.toLowerCase(),
       cName.toLowerCase(),
       cName.replace(" ", "").toLowerCase(),
-      initials.toLowerCase()
+      initials.toLowerCase(),
+      domain.toLowerCase()
     };
 
     // find match in dictionary and password

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6232,7 +6232,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
    *     and email address({@value Provisioning#A_mail}) will be compared
    * @throws AccountServiceException
    */
-  private void validatePasswordEntropyForPersonalData(String password, Account acct)
+  public static void validatePasswordEntropyForPersonalData(String password, Account acct)
       throws AccountServiceException {
     // get possible personal data for account
     Optional<String> sName =

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5,32 +5,6 @@
 
 package com.zimbra.cs.account.ldap;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
-
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringUtils;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -46,7 +20,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.service.ServiceException.Argument;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.util.UnmodifiableBloomFilter;
 import com.zimbra.common.util.Constants;
 import com.zimbra.common.util.EmailUtil;
 import com.zimbra.common.util.L10nUtil;
@@ -220,6 +193,32 @@ import com.zimbra.soap.type.AutoProvPrincipalBy;
 import com.zimbra.soap.type.GalSearchType;
 import com.zimbra.soap.type.NamedValue;
 import com.zimbra.soap.type.TargetBy;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -6137,6 +6136,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                         " is not valid regex: " + e.getMessage());
             }
         }
+
+        validatePasswordEntropyForPersonalData(password, acct);
+
         String allowedPuncChars = getString(acct, cos, entry, Provisioning.A_zimbraPasswordAllowedPunctuationChars);
         Pattern allowedPuncCharsPattern = null;
         if (allowedPuncChars != null) {
@@ -6218,6 +6220,56 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
                     new Argument(Provisioning.A_zimbraPasswordMinDigitsOrPuncs, minNumOrPunc, Argument.Type.NUM));
         }
     }
+
+  /**
+   * @param password Password string against which checks to be performed
+   * @param acct {@link Account} from where personal data like: last name({@value
+   *     Provisioning#A_sn}), common name({@value Provisioning#A_cn}), initials of some or all
+   *     names, but not the surname({@value Provisioning#A_initials}) and email address({@value
+   *     Provisioning#A_mail}) will be compared
+   * @throws AccountServiceException
+   */
+  private void validatePasswordEntropyForPersonalData(String password, Account acct)
+      throws AccountServiceException {
+    // get possible personal data for account
+    Optional<String> sName =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_sn)).orElse(""));
+    Optional<String> cName =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse(""));
+    Optional<String> initials =
+        Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse(""));
+    String email = acct.getAttr(Provisioning.A_mail);
+
+    // prepare dictionary
+    String[] fullNameExploded = cName.get().toLowerCase().split(" ");
+    String[] emailExploded = email.split("[@._]");
+    String[] cleanEmailExploded =
+        Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
+    String passwordLower = password.toLowerCase();
+    String[] personalDataImploded = {
+      sName.get().toLowerCase(),
+      cName.get().toLowerCase(),
+      cName.get().replace(" ", "").toLowerCase(),
+      initials.get().toLowerCase()
+    };
+
+    // find match in dictionary and password
+    Optional<String> matchedSensitivePart =
+        Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
+            .flatMap(Stream::of)
+            .parallel()
+            .filter(
+                part ->
+                    (part.length() > 2
+                        && (part.contains(passwordLower) || passwordLower.contains(part))))
+            .findAny();
+    if (matchedSensitivePart.isPresent()) {
+      throw AccountServiceException.INVALID_PASSWORD(
+          "password contains username or other personal data: " + matchedSensitivePart.get(),
+          new Argument(
+              "BlockPersonalDataInPasswordPolicy", matchedSensitivePart.get(), Argument.Type.STR));
+    }
+  }
 
     private boolean isAsciiPunc(char ch) {
         return

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6222,11 +6222,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     }
 
   /**
+   * Validate user password and fails if passed password string contains any of their personal data
+   *
    * @param password Password string against which checks to be performed
-   * @param acct {@link Account} from where personal data like: last name({@value
-   *     Provisioning#A_sn}), common name({@value Provisioning#A_cn}), initials of some or all
-   *     names, but not the surname({@value Provisioning#A_initials}) and email address({@value
-   *     Provisioning#A_mail}) will be compared
+   * @param acct {@link Account} from where personal data like:
+   *     last name({@value Provisioning#A_sn});
+   *     common name({@value Provisioning#A_cn});
+   *     initials of some or all names, but not the surname({@value Provisioning#A_initials})
+   *     and email address({@value Provisioning#A_mail}) will be compared
    * @throws AccountServiceException
    */
   private void validatePasswordEntropyForPersonalData(String password, Account acct)
@@ -6238,11 +6241,12 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_cn)).orElse(""));
     Optional<String> initials =
         Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_initials)).orElse(""));
-    String email = acct.getAttr(Provisioning.A_mail);
+    Optional<String> email =
+      Optional.of(Optional.ofNullable(acct.getAttr(Provisioning.A_mail)).orElse(""));
 
     // prepare dictionary
     String[] fullNameExploded = cName.get().toLowerCase().split(" ");
-    String[] emailExploded = email.split("[@._]");
+    String[] emailExploded = email.get().split("[@._]");
     String[] cleanEmailExploded =
         Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
     String passwordLower = password.toLowerCase();

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6248,7 +6248,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     String[] emailExploded = email.split("[@._]");
     String[] cleanEmailExploded =
         Arrays.copyOf(emailExploded, emailExploded.length - 1); // remove the top level domain(TLD)
+    String[] domainExploded = domain.split("[\\s@&.?$+-_]+");
     String passwordLower = password.toLowerCase();
+
     String[] personalDataImploded = {
       sName.toLowerCase(),
       cName.toLowerCase(),
@@ -6259,7 +6261,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     // find match in dictionary and password
     Optional<String> matchedSensitivePart =
-        Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded)
+        Stream.of(personalDataImploded, cleanEmailExploded, fullNameExploded, domainExploded)
             .flatMap(Stream::of)
             .parallel()
             .filter(


### PR DESCRIPTION
user attribute cannot be part of their password

added new password policy which will prevent users from adding their
personal data in their password string

this policy is enforced by default 