### PR TITLE
fix(carbonio-mailbox): user-management to carbonio-user-management

### DIFF
--- a/packages/appserver-service/carbonio-mailbox
+++ b/packages/appserver-service/carbonio-mailbox
@@ -65,7 +65,7 @@ cat <<EOF | consul config write -
   "name": "carbonio-mailbox",
   "sources": [
     {
-      "name": "user-management",
+      "name": "carbonio-user-management",
       "action": "allow"
     }
   ]


### PR DESCRIPTION
Naming of user-management service is carbonio-user-management.
With user-management the intention wouldn't work.