### PR TITLE
fix(carbonio-mailbox.hcl): proxy port as default

### DIFF
--- a/packages/appserver-service/carbonio-mailbox.hcl
+++ b/packages/appserver-service/carbonio-mailbox.hcl
@@ -6,7 +6,6 @@ services {
   }
   connect {
     sidecar_service {
-      port = 10000
       proxy {
         upstreams = [
           {


### PR DESCRIPTION
* Leave envoy proxy port as default instead of manually assign it