### PR TITLE
refactor(packages): CO-37: enable multiserver installations

### DIFF
--- a/packages/appserver-conf/PKGBUILD
+++ b/packages/appserver-conf/PKGBUILD
@@ -12,9 +12,6 @@ pkgdesclong=(
 arch="amd64"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"
-depends=(
-  "carbonio-appserver"
-)
 section="mail"
 priority="optional"
 

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -12,17 +12,6 @@ pkgdesclong=(
 arch="amd64"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"
-depends=(
-  "carbonio-common-core-jar"
-  "carbonio-common-appserver-conf"
-  "carbonio-common-appserver-db"
-  "carbonio-common-appserver-native-lib"
-  "carbonio-appserver-conf"
-  "carbonio-appserver-war"
-  "carbonio-appserver"
-  "service-discover"
-  "pending-setups"
-)
 optdepends=(
   "carbonio-common-appserver-docs"
 )

--- a/packages/appserver-war/PKGBUILD
+++ b/packages/appserver-war/PKGBUILD
@@ -8,9 +8,6 @@ pkgrel="1"
 arch="amd64"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"
-depends=(
-  "carbonio-appserver"
-)
 makedepends=(
   "unzip"
 )


### PR DESCRIPTION
service-discover and pending setups should be carbonio-core dependencies, because shared between multiple components. This also fix some issues on files and folders detection during the postinst phase
Please have a look also [here](https://github.com/Zextras/carbonio-nginx-conf/pull/7)