### PR TITLE
feat(carbonio-mailbox.hcl): add carbonio-preview (#18)

### DIFF
--- a/packages/appserver-service/carbonio-mailbox.hcl
+++ b/packages/appserver-service/carbonio-mailbox.hcl
@@ -12,6 +12,11 @@ services {
             destination_name   = "carbonio-storages"
             local_bind_port    = 20000
             local_bind_address = "127.78.0.7"
+          },
+          {
+            destination_name   = "carbonio-preview"
+            local_bind_port    = 20001
+            local_bind_address = "127.78.0.7"
           }
         ]
       }


### PR DESCRIPTION
Since the previewer service has to be integrated with the mailbox in Carbonio, the carbonio-preview has been added to the carbonio-mailbox.hcl file to allow mailbox to communicate with preview via consul.