### PR TITLE
Included template expansion for messaging configs

### DIFF
--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -3227,10 +3227,11 @@ public class ProxyConfGen
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("docs.common")), new File(mConfIncludesDir, getConfFileName("docs.common")));
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("docs.upstream")), new File(mConfIncludesDir, getConfFileName("docs.upstream")));
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.carbonio.admin.default")), new File(mConfIncludesDir, getConfFileName("web.carbonio.admin.default")));
-            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpp.default")), new File(mConfIncludesDir, getConfFileName("web.xmpp.default")));
-            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpps.default")), new File(mConfIncludesDir, getConfFileName("web.xmpps.default")));
-            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpp")), new File(mConfIncludesDir, getConfFileName("web.xmpp")));
-            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpps")), new File(mConfIncludesDir, getConfFileName("web.xmpps")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("messaging")), new File(mConfIncludesDir, getConfFileName("messaging")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("messaging.xmpp.default")), new File(mConfIncludesDir, getConfFileName("messaging.xmpp.default")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps.default")), new File(mConfIncludesDir, getConfFileName("messaging.xmpps.default")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("messaging.xmpp")), new File(mConfIncludesDir, getConfFileName("messaging.xmpp")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps")), new File(mConfIncludesDir, getConfFileName("messaging.xmpps")));
         } catch (ProxyConfException pe) {
             handleException(pe);
             exitCode = 1;

--- a/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/ProxyConfGen.java
@@ -3227,6 +3227,10 @@ public class ProxyConfGen
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("docs.common")), new File(mConfIncludesDir, getConfFileName("docs.common")));
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("docs.upstream")), new File(mConfIncludesDir, getConfFileName("docs.upstream")));
             expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.carbonio.admin.default")), new File(mConfIncludesDir, getConfFileName("web.carbonio.admin.default")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpp.default")), new File(mConfIncludesDir, getConfFileName("web.xmpp.default")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpps.default")), new File(mConfIncludesDir, getConfFileName("web.xmpps.default")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpp")), new File(mConfIncludesDir, getConfFileName("web.xmpp")));
+            expandTemplate(new File(mTemplateDir, getConfTemplateFileName("web.xmpps")), new File(mConfIncludesDir, getConfFileName("web.xmpps")));
         } catch (ProxyConfException pe) {
             handleException(pe);
             exitCode = 1;


### PR DESCRIPTION
Chats messaging configs for nginx were added to the templates list to allow for expansion
with the proxy restart