### PR TITLE
chore: prevent passing zimbraId attribute in LDAP & SOAP prov

### DIFF
--- a/soap/src/java/com/zimbra/soap/admin/type/AdminAttrsImpl.java
+++ b/soap/src/java/com/zimbra/soap/admin/type/AdminAttrsImpl.java
@@ -5,101 +5,90 @@
 
 package com.zimbra.soap.admin.type;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.soap.json.jackson.annotate.ZimbraKeyValuePairs;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
 /**
- * Note: Any subclasses that have fields for elements MUST either omit {@link XmlType} or specify a propOrder in it
- *       naming all fields related to elements.  This is required to ensure correctly generated WSDL.
- *       Failure to do so will result in an error similar to the following from "ant wsdl-client-support"'s wsimport:
- *           [WARNING] cos-all-limited.1.2: An all model group must appear in a particle with {min occurs} =
- *           {max occurs} = 1, and that particle must be part of a pair which constitutes the {content type} of
- *           a complex type definition.
+ * Note: Any subclasses that have fields for elements MUST either omit {@link XmlType} or specify a
+ * propOrder in it naming all fields related to elements. This is required to ensure correctly
+ * generated WSDL. Failure to do so will result in an error similar to the following from "ant
+ * wsdl-client-support"'s wsimport: [WARNING] cos-all-limited.1.2: An all model group must appear in
+ * a particle with {min occurs} = {max occurs} = 1, and that particle must be part of a pair which
+ * constitutes the {content type} of a complex type definition.
  */
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"attrs"})
 public class AdminAttrsImpl implements AdminAttrs {
 
-    /**
-     * @zm-api-field-description Attributes
-     */
-    @ZimbraKeyValuePairs
-    @XmlElement(name=AdminConstants.E_A /* a */, required=false)
-    private final List<Attr> attrs = Lists.newArrayList();
+  /** @zm-api-field-description Attributes */
+  @ZimbraKeyValuePairs
+  @XmlElement(name = AdminConstants.E_A /* a */, required = false)
+  private final List<Attr> attrs = Lists.newArrayList();
 
-    public AdminAttrsImpl() {
-    }
+  public AdminAttrsImpl() {}
 
-    public AdminAttrsImpl (Iterable<Attr> attrs) {
-        this.setAttrs(attrs);
-    }
+  public AdminAttrsImpl(Iterable<Attr> attrs) {
+    this.setAttrs(attrs);
+  }
 
-    public AdminAttrsImpl (Map<String, ? extends Object> attrs)
-    throws ServiceException {
-        this.setAttrs(attrs);
-    }
+  public AdminAttrsImpl(Map<String, ? extends Object> attrs) throws ServiceException {
+    this.setAttrs(attrs);
+  }
 
-    @Override
-    public void setAttrs(Iterable<Attr> attrs) {
-        this.attrs.clear();
-        if (attrs != null) {
-            Iterables.addAll(this.attrs,attrs);
-        }
-    }
+  @Override
+  public void addAttr(Attr attr) {
+    this.attrs.add(attr);
+  }
 
-    @Override
-    public void setAttrs(Map<String, ? extends Object> attrs)
-    throws ServiceException {
-        this.setAttrs(Attr.mapToList(attrs));
-    }
+  @Override
+  public void addAttr(String n, String value) {
+    this.attrs.add(Attr.fromNameValue(n, value));
+  }
 
-    @Override
-    public void addAttr(Attr attr) {
-        this.attrs.add(attr);
-    }
+  @Override
+  public List<Attr> getAttrs() {
+    return Collections.unmodifiableList(attrs);
+  }
 
-    @Override
-    public void addAttr(String n, String value) {
-        this.attrs.add(Attr.fromNameValue(n, value));
+  @Override
+  public void setAttrs(Iterable<Attr> attrs) {
+    this.attrs.clear();
+    if (attrs != null) {
+      Iterables.addAll(this.attrs, attrs);
     }
+  }
 
-    @Override
-    public List<Attr> getAttrs() {
-        return Collections.unmodifiableList(attrs);
-    }
+  @Override
+  public void setAttrs(Map<String, ? extends Object> attrs) throws ServiceException {
+    this.setAttrs(Attr.mapToList(attrs));
+  }
 
-    public Map<String, Object> getAttrsAsOldMultimap()
-    throws ServiceException {
-        return Attr.collectionToMap(this.getAttrs());
-    }
+  public Map<String, Object> getAttrsAsOldMultimap() throws ServiceException {
+    return Attr.collectionToMap(this.getAttrs());
+  }
 
-    public Map<String, Object> getAttrsAsOldMultimap(boolean ignoreEmptyValues)
-    throws ServiceException {
-        return Attr.collectionToMap(this.getAttrs(), ignoreEmptyValues);
-    }
+  public Map<String, Object> getAttrsAsOldMultimap(boolean ignoreEmptyValues)
+      throws ServiceException {
+    return Attr.collectionToMap(this.getAttrs(), ignoreEmptyValues);
+  }
 
-    public MoreObjects.ToStringHelper addToStringInfo(
-                MoreObjects.ToStringHelper helper) {
-        return helper
-            .add("attrs", attrs);
-    }
+  public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {
+    return helper.add("attrs", attrs);
+  }
 
-    @Override
-    public String toString() {
-        return addToStringInfo(MoreObjects.toStringHelper(this))
-                .toString();
-    }
+  @Override
+  public String toString() {
+    return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+  }
 }

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1373,7 +1373,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             //fail account creation if zimbraId attribute is passed in create account(ca) command
             if (uuid != null) {
                 throw ServiceException.FAILURE(
-                    "Sailed to create account,  passing account zimbraId in attributes is not allowed.", null);
+                    "Failed to create account, passing account zimbraId in attributes is not allowed.", null);
             }
 
             String zimbraIdStr = LdapUtil.generateUUID();

--- a/store/src/java/com/zimbra/cs/service/admin/CreateAccount.java
+++ b/store/src/java/com/zimbra/cs/service/admin/CreateAccount.java
@@ -5,6 +5,8 @@
 
 package com.zimbra.cs.service.admin;
 
+import static com.zimbra.common.account.ZAttrProvisioning.A_zimbraId;
+
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +54,12 @@ public class CreateAccount extends AdminDocumentHandler {
 
         String name = req.getName().toLowerCase();
         Map<String, Object> attrs = req.getAttrsAsOldMultimap(true /* ignoreEmptyValues */);
+
+        //fail account creation if zimbraId attribute is passed in CreateAccountRequest
+        if(attrs.containsKey(A_zimbraId)){
+            throw ServiceException.INVALID_REQUEST(
+                "Failed to create account, passing account zimbraId in attributes is not allowed.", null);
+        }
 
         checkDomainRightByEmail(zsc, name, Admin.R_createAccount);
         checkSetAttrsOnCreate(zsc, TargetType.account, name, attrs);


### PR DESCRIPTION
- this avoids forcing the account UUID(zimbraId attribute) while account creation using "zmprov" util and SOAP API
- other little enhancements in LDAP prov