### PR TITLE
feat(carbonio-mailbox.hcl): add carbonio-files

### DIFF
--- a/packages/appserver-service/carbonio-mailbox.hcl
+++ b/packages/appserver-service/carbonio-mailbox.hcl
@@ -17,6 +17,11 @@ services {
             destination_name   = "carbonio-preview"
             local_bind_port    = 20001
             local_bind_address = "127.78.0.7"
+          },
+          {
+            destination_name   = "carbonio-files"
+            local_bind_port    = 20002
+            local_bind_address = "127.78.0.7"
           }
         ]
       }


### PR DESCRIPTION
Carbonio-mailbox-hcl has been updated in order to let mailbox communicate with files forsaving chats' attachments on files.