### PR TITLE
Feat/co 184 authentication

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/auth/ZimbraCustomAuthTest.java
+++ b/store/src/java-test/com/zimbra/cs/account/auth/ZimbraCustomAuthTest.java
@@ -1,0 +1,38 @@
+package com.zimbra.cs.account.auth;
+
+
+import static org.junit.Assert.*;
+
+import com.zimbra.cs.account.Account;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Test;
+
+public class ZimbraCustomAuthTest {
+
+  /**
+   * A Custom Auth class for testing purposes.
+   */
+  private class TestCustomAuth extends ZimbraCustomAuth {
+
+    @Override
+    public void authenticate(Account acct, String password, Map<String, Object> context,
+        List<String> args) throws Exception {
+        // Huh, I do nothing.
+    }
+  }
+
+  @Test
+  public void shouldVerifyCustomAuthHandlerIsRegistered() {
+    String testHandler = "testHandler";
+    ZimbraCustomAuth.register(testHandler, new TestCustomAuth());
+    assertTrue(ZimbraCustomAuth.handlerIsRegistered(testHandler));
+  }
+
+  @Test
+  public void shouldVerifyCustomAuthHandlerNotRegisered() {
+    String testHandler = UUID.randomUUID().toString();
+    assertFalse(ZimbraCustomAuth.handlerIsRegistered(testHandler));
+  }
+}

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1388,7 +1388,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * fallback to local auth if external mech fails
      *
-     * @return zimbraAuthFallbackToLocal, or false if unset
+     * @return zimbraAuthFallbackToLocal, or true if unset
      */
     @ZAttr(id=257)
     public boolean isAuthFallbackToLocal() {

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1392,7 +1392,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      */
     @ZAttr(id=257)
     public boolean isAuthFallbackToLocal() {
-        return getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, true, true);
     }
 
     /**

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -38,6 +38,11 @@ public abstract class AuthMechanism {
         zimbra,
 
         /**
+         * default authentication for carbonio advanced
+         */
+        carbonioAdvanced,
+
+        /**
          * zimbraAuthMech type of "ldap" means use configured LDAP attrs
          * (zimbraAuthLdapURL, zimbraAuthLdapBindDn)
          */
@@ -125,6 +130,8 @@ public abstract class AuthMechanism {
                 switch (authMech) {
                     case zimbra:
                         return new ZimbraAuth(authMech);
+                    case carbonioAdvanced:
+                        return new CustomAuth(AuthMech.carbonioAdvanced, authMechStr);
                     case ldap:
                     case ad:
                         return new LdapAuth(authMech);

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -38,7 +38,7 @@ public abstract class AuthMechanism {
         zimbra,
 
         /**
-         * default authentication for carbonio advanced
+         * zimbraAuthMech type of "carbonioAdvanced"
          */
         carbonioAdvanced,
 

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -93,6 +93,10 @@ public abstract class AuthMechanism {
     public static AuthMechanism newInstance(Account acct, Map<String, Object> context)
     throws ServiceException {
         String authMechStr = AuthMech.zimbra.name();
+        // if carbonioAdvanced is registered set it as default
+        if (ZimbraCustomAuth.handlerIsRegistered(AuthMech.carbonioAdvanced.name())) {
+            authMechStr = AuthMech.carbonioAdvanced.name();
+        }
 
         // bypass domain AuthMech and always use Zimbra auth for external virtual accounts
 

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -93,8 +93,6 @@ public abstract class AuthMechanism {
     public static AuthMechanism newInstance(Account acct, Map<String, Object> context)
     throws ServiceException {
         String authMechStr = AuthMech.zimbra.name();
-
-
         // bypass domain AuthMech and always use Zimbra auth for external virtual accounts
 
         if (!acct.isIsExternalVirtualAccount()) {
@@ -135,7 +133,7 @@ public abstract class AuthMechanism {
                     case zimbra:
                         return new ZimbraAuth(authMech);
                     case carbonioAdvanced:
-                        return new CustomAuth(AuthMech.carbonioAdvanced, authMechStr);
+                        return new CustomAuth(AuthMech.custom, AuthMech.custom.name() + ":" + authMechStr);
                     case ldap:
                     case ad:
                         return new LdapAuth(authMech);

--- a/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
+++ b/store/src/java/com/zimbra/cs/account/auth/AuthMechanism.java
@@ -93,19 +93,19 @@ public abstract class AuthMechanism {
     public static AuthMechanism newInstance(Account acct, Map<String, Object> context)
     throws ServiceException {
         String authMechStr = AuthMech.zimbra.name();
-        // if carbonioAdvanced is registered set it as default
-        if (ZimbraCustomAuth.handlerIsRegistered(AuthMech.carbonioAdvanced.name())) {
-            authMechStr = AuthMech.carbonioAdvanced.name();
-        }
+
 
         // bypass domain AuthMech and always use Zimbra auth for external virtual accounts
 
         if (!acct.isIsExternalVirtualAccount()) {
             Provisioning prov = Provisioning.getInstance();
             Domain domain = prov.getDomain(acct);
-
             // see if it specifies an alternate auth
             if (domain != null) {
+                // when domain defined if carbonioAdvanced is registered set it as default
+                if (ZimbraCustomAuth.handlerIsRegistered(AuthMech.carbonioAdvanced.name())) {
+                    authMechStr = AuthMech.carbonioAdvanced.name();
+                }
                 String am;
                 Boolean asAdmin = context == null ? null : (Boolean) context.get(AuthContext.AC_AS_ADMIN);
                 if (asAdmin != null && asAdmin) {

--- a/store/src/java/com/zimbra/cs/account/auth/ZimbraCustomAuth.java
+++ b/store/src/java/com/zimbra/cs/account/auth/ZimbraCustomAuth.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
+import java.util.Objects;
 
 public abstract class ZimbraCustomAuth {
     
@@ -43,7 +44,18 @@ public abstract class ZimbraCustomAuth {
         }
         mHandlers.put(handlerName, handler);
     }
-    
+
+    /**
+     * Returns if handler is registered.
+     * Given name must not be null + must be registered.
+     *
+     * @param handlerName name of the handler
+     * @return if handler registered
+     */
+    public static boolean handlerIsRegistered(String handlerName) {
+        return !Objects.isNull(handlerName) && mHandlers.containsKey(handlerName);
+    }
+
     public synchronized static ZimbraCustomAuth getHandler(String handlerName) {
         if (mHandlers == null)
             return null;

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5920,7 +5920,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             boolean allowFallback = true;
             if (!authMech.isZimbraAuth()) {
                 allowFallback =
-                    domain.getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, false) ||
+                    domain.getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, true) ||
                     acct.getBooleanAttr(Provisioning.A_zimbraIsAdminAccount, false) ||
                     acct.getBooleanAttr(Provisioning.A_zimbraIsDomainAdminAccount, false);
             }


### PR DESCRIPTION
### Goal
The Goal of this PR is to enable Carbonio Advanced auth mechanism as default when registered.

### What's changed
Carbonio Advanced authentication mechanism will be picked up by default if registered and if authenticating user belongs to a domain. Default authentication mechanism can still be overridden by setting a value to authMech configuration parameter.
Also fallback to local authentication defaults to true when not set.