### PR TITLE
chore: add carbonio-files intention to allow access on mailbox

### DIFF
--- a/packages/appserver-service/carbonio-mailbox
+++ b/packages/appserver-service/carbonio-mailbox
@@ -67,6 +67,10 @@ cat <<EOF | consul config write -
     {
       "name": "carbonio-user-management",
       "action": "allow"
+    },
+    {
+      "name": "carbonio-files",
+      "action": "allow"
     }
   ]
 }


### PR DESCRIPTION
### Goal
Allow Files to access mailbox

###Tests
Tested with pending-setups: allow intention carbonio-files -> carbonio-mailbox is registered