### PR TITLE
chore: [CO-288] add support for ngnix templates override

### DIFF
--- a/store/src/java-test/com/zimbra/cs/util/proxyconfgen/ProxyConfGenTest.java
+++ b/store/src/java-test/com/zimbra/cs/util/proxyconfgen/ProxyConfGenTest.java
@@ -1,0 +1,30 @@
+package com.zimbra.cs.util.proxyconfgen;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import org.junit.Test;
+
+public class ProxyConfGenTest {
+
+  @Test
+  public void shouldUseOverrideTemplatePathWhenOverrideConditionMatches() {
+    File exampleTemplateFile = new File(ProxyConfGen.mTemplateDir + "/nginx.conf.web.http.default");
+    final String overrideTemplateFilePath =
+        ProxyConfGen.OVERRIDE_TEMPLATE_DIR + File.separator + exampleTemplateFile.getName();
+    final String templateFilePath =
+        ProxyConfGen.getTemplateFilePath(exampleTemplateFile, overrideTemplateFilePath, true);
+    assertEquals(
+        ProxyConfGen.OVERRIDE_TEMPLATE_DIR + "/nginx.conf.web.http.default", templateFilePath);
+  }
+
+  @Test
+  public void shouldUseDefaultTemplatePathWhenOverrideConditionDoNotMatches() {
+    File exampleTemplateFile = new File(ProxyConfGen.mTemplateDir + "/nginx.conf.web.http.default");
+    final String overrideTemplateFilePath =
+        ProxyConfGen.OVERRIDE_TEMPLATE_DIR + File.separator + exampleTemplateFile.getName();
+    final String templateFilePath =
+        ProxyConfGen.getTemplateFilePath(exampleTemplateFile, overrideTemplateFilePath, false);
+    assertEquals(ProxyConfGen.mTemplateDir + "/nginx.conf.web.http.default", templateFilePath);
+  }
+}

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -27,6 +27,8 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,16 +68,17 @@ public class ProxyConfGen {
   private static final int DEFAULT_SERVERS_NAME_HASH_MAX_SIZE = 512;
   private static final int DEFAULT_SERVERS_NAME_HASH_BUCKET_SIZE = 64;
   private static final Log LOG = LogFactory.getLog(ProxyConfGen.class);
+  private static final Options mOptions = new Options();
   private static final String SSL_CRT_EXT = ".crt";
   private static final String SSL_KEY_EXT = ".key";
   private static final String SSL_CLIENT_CERT_CA_EXT = ".client.ca.crt";
   private static final String TEMPLATE_SUFFIX = ".template";
-  private static final Options mOptions = new Options();
   private static final Map<String, ProxyConfVar> mConfVars = new HashMap<>();
   private static final Map<String, String> mVars = new HashMap<>();
   private static final Map<String, ProxyConfVar> mDomainConfVars = new HashMap<>();
   /** the pattern for custom header cmd, such as "!{explode domain} */
-  private static final Pattern cmdPattern = Pattern.compile("(.*)!\\{([^}]+)}(.*)", Pattern.DOTALL);
+  private static final Pattern CMD_PATTERN =
+      Pattern.compile("(.*)!\\{([^}]+)}(.*)", Pattern.DOTALL);
 
   static List<DomainAttrItem> mDomainReverseProxyAttrs;
   static List<ServerAttrItem> mServerAttrs;
@@ -83,6 +86,7 @@ public class ProxyConfGen {
   private static boolean mDryRun = false;
   private static boolean mEnforceDNSResolution = false;
   private static String mWorkingDir = "/opt/zextras";
+  private static final String OVERRIDE_TEMPLATE_DIR = mWorkingDir + "/conf/nginx/templates_custom";
   private static String mTemplateDir = mWorkingDir + "/conf/nginx/templates";
   private static String mConfDir = mWorkingDir + "/conf";
   private static final String DOMAIN_SSL_DIR = mConfDir + File.separator + "domaincerts";
@@ -97,6 +101,7 @@ public class ProxyConfGen {
   private static String mTemplatePrefix = mConfPrefix;
   private static Provisioning mProv = null;
   private static boolean mGenConfPerVhn = false;
+  private static boolean hasCustomTemplateLocationArg = false;
 
   static {
     mOptions.addOption("h", "help", false, "show this usage text");
@@ -395,8 +400,15 @@ public class ProxyConfGen {
 
   public static void expandTemplate(File templateFile, File configFile) throws ProxyConfException {
 
-    String templateFilePath = templateFile.getAbsolutePath();
     String configFilePath = configFile.getAbsolutePath();
+
+    final String templateFileName = templateFile.getName();
+    final String overrideTemplateFilePath =
+        OVERRIDE_TEMPLATE_DIR + File.separator + templateFileName;
+    final boolean usingCustomTemplateOverride =
+        !hasCustomTemplateLocationArg && Files.exists(Paths.get(overrideTemplateFilePath));
+    final String templateFilePath =
+        usingCustomTemplateOverride ? overrideTemplateFilePath : templateFile.getAbsolutePath();
 
     // return if DryRun
     if (mDryRun) {
@@ -424,7 +436,9 @@ public class ProxyConfGen {
         return;
       }
 
-      Matcher cmdMatcher = cmdPattern.matcher(line);
+      addCustomTemplateWarningHeader(usingCustomTemplateOverride, templateFilePath, bufferedWriter);
+
+      Matcher cmdMatcher = CMD_PATTERN.matcher(line);
       if (cmdMatcher.matches()) {
         // the command is found
         String[] cmdArg = cmdMatcher.group(2).split("[ \t]+", 2);
@@ -467,6 +481,33 @@ public class ProxyConfGen {
     } catch (IOException | SecurityException ie) {
       throw new ProxyConfException("Cannot expand template file: " + ie.getMessage());
     }
+  }
+
+  /**
+   * If using a custom override template from CUSTOM_TEMPLATE_DIR
+   * ($workdir/conf/nginx/templates_custom) prefix the resulting conf with warning comment
+   *
+   * @param usingCustomTemplateOverride either using custom template override
+   * @param templateFilePath template file path
+   * @param bufferedWriter buffered writer
+   * @throws IOException IO exception while write
+   */
+  private static void addCustomTemplateWarningHeader(
+      boolean usingCustomTemplateOverride, String templateFilePath, BufferedWriter bufferedWriter)
+      throws IOException {
+    if (!usingCustomTemplateOverride) {
+      return;
+    }
+    String sb =
+        "# WARNING: This conf is generated using the custom template overload located at "
+            + templateFilePath
+            + "\n"
+            + "# To avoid this and use the default template from "
+            + mTemplateDir
+            + ", just delete the override template file from "
+            + OVERRIDE_TEMPLATE_DIR
+            + "\n#\n";
+    bufferedWriter.write(sb);
   }
 
   /**
@@ -2070,6 +2111,7 @@ public class ProxyConfGen {
     }
 
     if (cl.hasOption('t')) {
+      hasCustomTemplateLocationArg = true;
       mTemplateDir = cl.getOptionValue('t');
     }
 

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -86,8 +86,8 @@ public class ProxyConfGen {
   private static boolean mDryRun = false;
   private static boolean mEnforceDNSResolution = false;
   private static String mWorkingDir = "/opt/zextras";
-  private static final String OVERRIDE_TEMPLATE_DIR = mWorkingDir + "/conf/nginx/templates_custom";
-  private static String mTemplateDir = mWorkingDir + "/conf/nginx/templates";
+  static final String OVERRIDE_TEMPLATE_DIR = mWorkingDir + "/conf/nginx/templates_custom";
+  static String mTemplateDir = mWorkingDir + "/conf/nginx/templates";
   private static String mConfDir = mWorkingDir + "/conf";
   private static final String DOMAIN_SSL_DIR = mConfDir + File.separator + "domaincerts";
   private static final String DEFAULT_SSL_CRT = mConfDir + File.separator + "nginx.crt";
@@ -408,7 +408,7 @@ public class ProxyConfGen {
     final boolean usingCustomTemplateOverride =
         !hasCustomTemplateLocationArg && Files.exists(Paths.get(overrideTemplateFilePath));
     final String templateFilePath =
-        usingCustomTemplateOverride ? overrideTemplateFilePath : templateFile.getAbsolutePath();
+        getTemplateFilePath(templateFile, overrideTemplateFilePath, usingCustomTemplateOverride);
 
     // return if DryRun
     if (mDryRun) {
@@ -481,6 +481,11 @@ public class ProxyConfGen {
     } catch (IOException | SecurityException ie) {
       throw new ProxyConfException("Cannot expand template file: " + ie.getMessage());
     }
+  }
+
+  static String getTemplateFilePath(
+      File templateFile, String overrideTemplateFilePath, boolean usingCustomTemplateOverride) {
+    return usingCustomTemplateOverride ? overrideTemplateFilePath : templateFile.getAbsolutePath();
   }
 
   /**


### PR DESCRIPTION
### What's new
The custom template override location that proxyConfGen will  use is set to `/opt/zextras/conf/nginx/templates_custom`

**Config generation flow:** If one or more template overrides are found in the custom templates location(`/opt/zextras/conf/nginx/templates_custom`), the proxyconfgen util will now use those templates to generate the config and will override the default ones that exist in the default template location (`/opt/zextras/conf/nginx/templates`) at the proxyxonfgen step while services start or by manual invocation of the tool.

**Warning header:** A warning header is written to all generated configuration files.

NOTE: The above flow won't work if a custom template path is specified explicitly to the proxyconfgen command using its -t flag. This ensures the backward compatibility of proxyconfgen’s behavior. 




### Changes in other repositories:

- **carbonio-nginx-conf** create template override dir  ->  https://github.com/Zextras/carbonio-nginx-conf/pull/22

- **carbonio-core-utils** zmfixperm support  ->  https://github.com/Zextras/carbonio-core-utils/pull/16