### PR TITLE
fix(proxy): prevent duplicate upstreams

### DIFF
--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
@@ -20,6 +20,8 @@ public final class Utils {
    *
    * @param servers List of Servers
    * @return return List of filtered servers
+   * @author Keshav Bhatt
+   * @since 22.7.0
    */
   public static List<Server> getUniqueServersList(List<Server> servers) {
     return servers.stream()

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
@@ -1,0 +1,35 @@
+package com.zimbra.cs.util.proxyconfgen;
+
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.cs.account.Server;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public final class Utils {
+
+  private Utils() {
+    throw new java.lang.UnsupportedOperationException("Utility class and cannot be instantiated");
+  }
+
+  /**
+   * Get Unique list of servers, removes duplicate servers from passed server list using A_zimbraId
+   * as unique identifier
+   *
+   * @param servers List of Servers
+   * @return return List of filtered servers
+   */
+  public static List<Server> getUniqueServersList(List<Server> servers) {
+    return servers.stream()
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toCollection(
+                    () ->
+                        new TreeSet<>(
+                            Comparator.comparing(
+                                server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                ArrayList::new));
+  }
+}

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamAdminClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamAdminClientServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebAdminUpstreamAdminClientServersVar extends ProxyConfVar {
 
@@ -28,15 +25,7 @@ class WebAdminUpstreamAdminClientServersVar extends ProxyConfVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyAdminPortAttribute, "");
 
     List<Server> uniqueAdminClientServers =
-        mProv.getAllAdminClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllAdminClientServers());
 
     for (Server server : uniqueAdminClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamAdminClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamAdminClientServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebAdminUpstreamAdminClientServersVar extends ProxyConfVar {
 
@@ -24,8 +27,18 @@ class WebAdminUpstreamAdminClientServersVar extends ProxyConfVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyAdminPortAttribute, "");
 
-    List<Server> adminClientServers = mProv.getAllAdminClientServers();
-    for (Server server : adminClientServers) {
+    List<Server> uniqueAdminClientServers =
+        mProv.getAllAdminClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueAdminClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebAdminUpstreamServersVar extends ServersVar {
 
@@ -25,15 +22,7 @@ class WebAdminUpstreamServersVar extends ServersVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyAdminPortAttribute, "");
 
     List<Server> uniqueMailClientServers =
-        mProv.getAllMailClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllMailClientServers());
 
     for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebAdminUpstreamServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebAdminUpstreamServersVar extends ServersVar {
 
@@ -21,8 +24,18 @@ class WebAdminUpstreamServersVar extends ServersVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyAdminPortAttribute, "");
 
-    List<Server> mailClientServers = mProv.getAllMailClientServers();
-    for (Server server : mailClientServers) {
+    List<Server> uniqueMailClientServers =
+        mProv.getAllMailClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamClientServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebSSLUpstreamClientServersVar extends ProxyConfVar {
 
@@ -24,8 +27,18 @@ class WebSSLUpstreamClientServersVar extends ProxyConfVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpSSLPortAttribute, "");
 
-    List<Server> webClientServers = mProv.getAllWebClientServers();
-    for (Server server : webClientServers) {
+    List<Server> uniqueWebClientServers =
+        mProv.getAllWebClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueWebClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamClientServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebSSLUpstreamClientServersVar extends ProxyConfVar {
 
@@ -28,15 +25,7 @@ class WebSSLUpstreamClientServersVar extends ProxyConfVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpSSLPortAttribute, "");
 
     List<Server> uniqueWebClientServers =
-        mProv.getAllWebClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllWebClientServers());
 
     for (Server server : uniqueWebClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebSSLUpstreamServersVar extends ServersVar {
 
@@ -22,8 +25,18 @@ class WebSSLUpstreamServersVar extends ServersVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpSSLPortAttribute, "");
 
-    List<Server> mailclientservers = mProv.getAllMailClientServers();
-    for (Server server : mailclientservers) {
+    List<Server> uniqueMailClientServers =
+        mProv.getAllMailClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSSLUpstreamServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebSSLUpstreamServersVar extends ServersVar {
 
@@ -26,15 +23,7 @@ class WebSSLUpstreamServersVar extends ServersVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpSSLPortAttribute, "");
 
     List<Server> uniqueMailClientServers =
-        mProv.getAllMailClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllMailClientServers());
 
     for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSslUpstreamZxServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSslUpstreamZxServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebSslUpstreamZxServersVar extends ServersVar {
 
@@ -20,8 +23,18 @@ class WebSslUpstreamZxServersVar extends ServersVar {
   public void update() throws ServiceException {
     ArrayList<String> directives = new ArrayList<>();
 
-    List<Server> mailclientservers = mProv.getAllMailClientServers();
-    for (Server server : mailclientservers) {
+    List<Server> uniqueMailClientServers =
+        mProv.getAllMailClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSslUpstreamZxServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebSslUpstreamZxServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebSslUpstreamZxServersVar extends ServersVar {
 
@@ -24,15 +21,7 @@ class WebSslUpstreamZxServersVar extends ServersVar {
     ArrayList<String> directives = new ArrayList<>();
 
     List<Server> uniqueMailClientServers =
-        mProv.getAllMailClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllMailClientServers());
 
     for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamClientServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebUpstreamClientServersVar extends ProxyConfVar {
 
@@ -28,15 +25,7 @@ class WebUpstreamClientServersVar extends ProxyConfVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpPortAttribute, "");
 
     List<Server> uniqueWebClientServers =
-        mProv.getAllWebClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllWebClientServers());
 
     for (Server server : uniqueWebClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamClientServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamClientServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebUpstreamClientServersVar extends ProxyConfVar {
 
@@ -24,8 +27,18 @@ class WebUpstreamClientServersVar extends ProxyConfVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpPortAttribute, "");
 
-    List<Server> webClientServers = mProv.getAllWebClientServers();
-    for (Server server : webClientServers) {
+    List<Server> uniqueWebClientServers =
+        mProv.getAllWebClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueWebClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamServersVar.java
@@ -4,7 +4,10 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 class WebUpstreamServersVar extends ServersVar {
 
@@ -22,8 +25,18 @@ class WebUpstreamServersVar extends ServersVar {
     String portName =
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpPortAttribute, "");
 
-    List<Server> mailClientServers = mProv.getAllMailClientServers();
-    for (Server server : mailClientServers) {
+    List<Server> uniqueMailClientServers =
+        mProv.getAllMailClientServers().stream()
+            .collect(
+                Collectors.collectingAndThen(
+                    Collectors.toCollection(
+                        () ->
+                            new TreeSet<>(
+                                Comparator.comparing(
+                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
+                    ArrayList::new));
+
+    for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");
 
       if (isValidUpstream(server, serverName)) {

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebUpstreamServersVar extends ServersVar {
 
@@ -26,15 +23,7 @@ class WebUpstreamServersVar extends ServersVar {
         configSource.getAttr(ZAttrProvisioning.A_zimbraReverseProxyHttpPortAttribute, "");
 
     List<Server> uniqueMailClientServers =
-        mProv.getAllMailClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllMailClientServers());
 
     for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamZxServersVar.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/WebUpstreamZxServersVar.java
@@ -4,10 +4,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Server;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 class WebUpstreamZxServersVar extends ServersVar {
 
@@ -24,15 +21,7 @@ class WebUpstreamZxServersVar extends ServersVar {
     ArrayList<String> directives = new ArrayList<>();
 
     List<Server> uniqueMailClientServers =
-        mProv.getAllMailClientServers().stream()
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toCollection(
-                        () ->
-                            new TreeSet<>(
-                                Comparator.comparing(
-                                    server -> server.getAttr(ZAttrProvisioning.A_zimbraId)))),
-                    ArrayList::new));
+        Utils.getUniqueServersList(mProv.getAllMailClientServers());
 
     for (Server server : uniqueMailClientServers) {
       String serverName = server.getAttr(ZAttrProvisioning.A_zimbraServiceHostname, "");


### PR DESCRIPTION
- prevent duplicate upstream servers in generated nginx conf.

**Test:** 
Manually invoking zmproxyconfgen and generating config from templates skips duplicate entries of upstream servers.