### PR TITLE
chore: [TEAMS-3737] Renamed video server recording ldap attribute

### DIFF
--- a/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2631,12 +2631,12 @@ public class ZAttrProvisioning {
     public static final String A_carbonioAllowFeedback = "carbonioAllowFeedback";
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public static final String A_carbonioChatsVideoServerRecordingEnabled = "carbonioChatsVideoServerRecordingEnabled";
+    public static final String A_carbonioVideoServerRecordingEnabled = "carbonioVideoServerRecordingEnabled";
 
     /**
      * Whether Carbonio can send analytics reports

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9768,7 +9768,7 @@ TODO: delete them permanently from here
   <desc>block common keywords in password string</desc>
 </attr>
 
-<attr id="3091" name="carbonioChatsVideoServerRecordingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo,domainInfo" since="9.0.0">
+<attr id="3091" name="carbonioVideoServerRecordingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo,domainInfo" since="9.0.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <desc>Enable video server recording for Carbonio chats</desc>
 </attr>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9770,7 +9770,7 @@ TODO: delete them permanently from here
 
 <attr id="3091" name="carbonioVideoServerRecordingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountCosDomainInherited,accountInfo,domainInfo" since="9.0.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
-  <desc>Enable video server recording for Carbonio chats</desc>
+  <desc>Enable video server recording for Carbonio</desc>
 </attr>
 
 <attr id="3092" name="carbonioSendFullErrorStack" type="boolean" cardinality="single" optionalIn="globalConfig" since="9.0.0">

--- a/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -94,64 +94,64 @@ public abstract class ZAttrAccount  extends MailTarget {
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @return carbonioChatsVideoServerRecordingEnabled, or false if unset
+     * @return carbonioVideoServerRecordingEnabled, or false if unset
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public boolean isCarbonioChatsVideoServerRecordingEnabled() {
-        return getBooleanAttr(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, false, true);
+    public boolean isCarbonioVideoServerRecordingEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioVideoServerRecordingEnabled, false, true);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
+    public void setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled, Map<String,Object> attrs) {
+    public Map<String,Object> setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         return attrs;
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void unsetCarbonioChatsVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
+    public void unsetCarboniVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -159,9 +159,9 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> unsetCarbonioChatsVideoServerRecordingEnabled(Map<String,Object> attrs) {
+    public Map<String,Object> unsetCarboniVideoServerRecordingEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrCos.java
@@ -35,64 +35,64 @@ public abstract class ZAttrCos extends NamedEntry {
     ///// BEGIN-AUTO-GEN-REPLACE
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @return carbonioChatsVideoServerRecordingEnabled, or false if unset
+     * @return carbonioVideoServerRecordingEnabled, or false if unset
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public boolean isCarbonioChatsVideoServerRecordingEnabled() {
-        return getBooleanAttr(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, false, true);
+    public boolean isCarbonioVideoServerRecordingEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioVideoServerRecordingEnabled, false, true);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
+    public void setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled, Map<String,Object> attrs) {
+    public Map<String,Object> setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         return attrs;
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void unsetCarbonioChatsVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
+    public void unsetCarbonioVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -100,9 +100,9 @@ public abstract class ZAttrCos extends NamedEntry {
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> unsetCarbonioChatsVideoServerRecordingEnabled(Map<String,Object> attrs) {
+    public Map<String,Object> unsetCarbonioVideoServerRecordingEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         return attrs;
     }
 

--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -13,7 +13,6 @@ package com.zimbra.cs.account;
 import static com.zimbra.common.account.ProvisioningConstants.FALSE;
 import static com.zimbra.common.account.ProvisioningConstants.TRUE;
 
-import com.zimbra.cs.mailclient.smtp.SmtpConfig;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,64 +36,64 @@ public abstract class ZAttrDomain extends NamedEntry {
     ///// BEGIN-AUTO-GEN-REPLACE
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @return carbonioChatsVideoServerRecordingEnabled, or false if unset
+     * @return carbonioVideoServerRecordingEnabled, or false if unset
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public boolean isCarbonioChatsVideoServerRecordingEnabled() {
-        return getBooleanAttr(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, false, true);
+    public boolean isCarbonioVideoServerRecordingEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioVideoServerRecordingEnabled, false, true);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
+    public void setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
-     * @param carbonioChatsVideoServerRecordingEnabled new value
+     * @param carbonioVideoServerRecordingEnabled new value
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> setCarbonioChatsVideoServerRecordingEnabled(boolean carbonioChatsVideoServerRecordingEnabled, Map<String,Object> attrs) {
+    public Map<String,Object> setCarbonioVideoServerRecordingEnabled(boolean carbonioVideoServerRecordingEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, carbonioChatsVideoServerRecordingEnabled ? TRUE : FALSE);
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, carbonioVideoServerRecordingEnabled ? TRUE : FALSE);
         return attrs;
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public void unsetCarbonioChatsVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
+    public void unsetCarbonioVideoServerRecordingEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         getProvisioning().modifyAttrs(this, attrs);
     }
 
     /**
-     * Enable video server recording for Carbonio chats
+     * Enable video server recording for Carbonio
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -102,9 +101,9 @@ public abstract class ZAttrDomain extends NamedEntry {
      * @since ZCS 9.0.0
      */
     @ZAttr(id=3091)
-    public Map<String,Object> unsetCarbonioChatsVideoServerRecordingEnabled(Map<String,Object> attrs) {
+    public Map<String,Object> unsetCarbonioVideoServerRecordingEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
-        attrs.put(Provisioning.A_carbonioChatsVideoServerRecordingEnabled, "");
+        attrs.put(Provisioning.A_carbonioVideoServerRecordingEnabled, "");
         return attrs;
     }
 


### PR DESCRIPTION
Renamed **carbonioChatsVideoServerRecordingEnabled** attribute into **carbonioVideoServerRecordingEnabled**.
This is made to not link the product name with the ldap attribute directly. So, even if we will decide to change the product name in the future, we can still use the attribute correctly.

Support PR for: https://github.com/Zextras/carbonio-ldap-utilities/pull/10