### PR TITLE
fix: zimbraAuthFallbackToLocal default to true when not defined

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1460,11 +1460,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     /**
      * fallback to local auth if external mech fails
      *
-     * @return zimbraAuthFallbackToLocal, or false if unset
+     * @return zimbraAuthFallbackToLocal, or true if unset
      */
     @ZAttr(id=257)
     public boolean isAuthFallbackToLocal() {
-        return getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, false, true);
+        return getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, true, true);
     }
 
     /**


### PR DESCRIPTION
zimbraAuthFallbackToLocal will default to true when not defined.

Fixes an authentication problem when installing a new infrastructure.