### PR TITLE
Fix/co 284 global admin fallback

### DIFF
--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6372,10 +6372,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
       boolean allowFallback = true;
       if (!authMech.isDefaultAuth()) {
-        allowFallback =
-            domain.getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, true)
-                || acct.getBooleanAttr(Provisioning.A_zimbraIsAdminAccount, false)
-                || acct.getBooleanAttr(Provisioning.A_zimbraIsDomainAdminAccount, false);
+        allowFallback = domain.getBooleanAttr(Provisioning.A_zimbraAuthFallbackToLocal, true);
       }
 
       try {

--- a/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -6377,7 +6377,6 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
       try {
         authMech.doAuth(this, domain, acct, password, context);
-        AuthMech authedByMech = authMech.getMechanism();
         // indicate the authed by mech in the auth context
         // context.put(AuthContext.AC_AUTHED_BY_MECH, authedByMech); TODO
         return;


### PR DESCRIPTION
Fixes admin fallback logic.
Previously admin could always login with local credentials, now the decision is based on zimbraAuthFallbackToLocal value, like a regular user.