### PR TITLE
fix: [CO-365] start preview servlet at mailbox boot

### DIFF
--- a/store/conf/web.xml.production
+++ b/store/conf/web.xml.production
@@ -333,6 +333,7 @@
       <param-name>allowed.ports</param-name>
       <param-value>%%zimbraMailPort%%, %%zimbraMailSSLPort%%, %%zimbraAdminPort%%, 7070, 7443, 7071</param-value>
     </init-param>
+    <load-on-startup>13</load-on-startup>
   </servlet>
 
   <servlet>


### PR DESCRIPTION
**Goal:** The servlet is currently set to start when the first request is received. As a result of the startup time and preview processing time, the response to the initial request is delayed by a few more seconds.

**Key changes:** During mailbox startup, PreviewServlet is scheduled to start in the 13th position in the queue.
