### PR TITLE
Feature/co 362 proxy ip trusted

### DIFF
--- a/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/java-test/com/zimbra/cs/account/MockProvisioning.java
@@ -37,8 +37,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Mock implementation of {@link Provisioning} for testing.
@@ -556,7 +558,10 @@ public final class MockProvisioning extends Provisioning {
 
   @Override
   public List<Server> getAllServers(String service) {
-    throw new UnsupportedOperationException();
+    return servers.values().stream()
+        .filter(
+            server -> Objects.equals(service, server.getAttr(Provisioning.A_zimbraServiceEnabled)))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/java-test/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -5,24 +5,6 @@
 
 package com.zimbra.cs.mailbox;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.List;
-
-import javax.activation.DataHandler;
-import javax.mail.MessagingException;
-import javax.mail.Part;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpRequestBase;
-
 import com.google.common.base.Strings;
 import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
 import com.zimbra.common.localconfig.LC;
@@ -54,280 +36,307 @@ import com.zimbra.cs.store.http.HttpStoreManagerTest.MockHttpStoreManager;
 import com.zimbra.cs.store.http.MockHttpStore;
 import com.zimbra.cs.util.JMSession;
 import com.zimbra.soap.DocumentHandler;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+import javax.activation.DataHandler;
+import javax.mail.MessagingException;
+import javax.mail.Part;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.mockito.Mockito;
 
 public final class MailboxTestUtil {
 
-    private MailboxTestUtil() {
-    }
+  private MailboxTestUtil() {}
 
-    /**
-     * Initializes the provisioning.
-     */
-    public static void initProvisioning() throws Exception {
-        initProvisioning("");
-    }
+  /** Initializes the provisioning. */
+  public static void initProvisioning() throws Exception {
+    initProvisioning("");
+  }
 
-    /**
-     * Initializes the provisioning.
-     *
-     * @param zimbraServerDir the directory that contains the ZimbraServer project
-     * @throws Exception
-     */
-    public static void initProvisioning(String zimbraServerDir) throws Exception {
-        zimbraServerDir = getZimbraServerDir(zimbraServerDir);
-        System.setProperty("log4j.configuration", "log4j-test.properties");
-        System.setProperty("zimbra.config", zimbraServerDir + "src/java-test/localconfig-test.xml");
-        LC.reload();
-        //substitute test TZ file
-        String timezonefilePath = zimbraServerDir + "src/java-test/timezones-test.ics";
-        File d = new File(timezonefilePath);
-        if (!d.exists()) {
-            throw new FileNotFoundException("timezones-test.ics not found in " + timezonefilePath);
+  /**
+   * Initializes the provisioning.
+   *
+   * @param zimbraServerDir the directory that contains the ZimbraServer project
+   * @throws Exception
+   */
+  public static void initProvisioning(String zimbraServerDir) throws Exception {
+    zimbraServerDir = getZimbraServerDir(zimbraServerDir);
+    System.setProperty("log4j.configuration", "log4j-test.properties");
+    System.setProperty("zimbra.config", zimbraServerDir + "src/java-test/localconfig-test.xml");
+    LC.reload();
+    // substitute test TZ file
+    String timezonefilePath = zimbraServerDir + "src/java-test/timezones-test.ics";
+    File d = new File(timezonefilePath);
+    if (!d.exists()) {
+      throw new FileNotFoundException("timezones-test.ics not found in " + timezonefilePath);
+    }
+    LC.timezone_file.setDefault(timezonefilePath);
+    LC.zimbra_rights_directory.setDefault(
+        StringUtils.removeEnd(zimbraServerDir, "/") + "-conf" + "/conf/rights");
+    LC.zimbra_attrs_directory.setDefault(zimbraServerDir + "conf/attrs");
+    LC.zimbra_tmp_directory.setDefault(zimbraServerDir + "tmp");
+    // substitute test DS config file
+    String dsfilePath = zimbraServerDir + "src/java-test/datasource-test.xml";
+    d = new File(dsfilePath);
+    if (!d.exists()) {
+      throw new FileNotFoundException("datasource-test.xml not found in " + dsfilePath);
+    }
+    LC.data_source_config.setDefault(dsfilePath);
+    // default MIME handlers are now set up in MockProvisioning constructor
+    Provisioning.setInstance(new MockProvisioning());
+  }
+
+  /**
+   * This method will set the provisioning singleton as {@link Mockito#mock} of {@link Provisioning}
+   */
+  public static void setMockitoProvisioning() {
+    Provisioning.setInstance(Mockito.mock(Provisioning.class));
+  }
+
+  public static String getZimbraServerDir(String zimbraServerDir) {
+    String serverDir = zimbraServerDir;
+    if (StringUtil.isNullOrEmpty(serverDir)) {
+      serverDir = Strings.nullToEmpty(System.getProperty("server.dir"));
+      if (serverDir.isEmpty()) {
+        serverDir = Strings.nullToEmpty(System.getProperty("user.dir"));
+      }
+    }
+    if (!serverDir.endsWith("/")) {
+      serverDir = serverDir + "/";
+    }
+    return serverDir;
+  }
+
+  /** Initializes the provisioning, database, index and store manager. */
+  public static void initServer() throws Exception {
+    initServer(MockStoreManager.class);
+  }
+
+  /**
+   * Initializes the provisioning, database, index and store manager.
+   *
+   * @param zimbraServerDir the directory that contains the ZimbraServer project
+   * @throws Exception
+   */
+  public static void initServer(String zimbraServerDir) throws Exception {
+    initServer(MockStoreManager.class, zimbraServerDir);
+  }
+
+  public static void initServer(Class<? extends StoreManager> storeManagerClass) throws Exception {
+    initServer(storeManagerClass, "");
+  }
+
+  public static void initServer(
+      Class<? extends StoreManager> storeManagerClass,
+      String zimbraServerDir,
+      boolean OctopusInstance)
+      throws Exception {
+    MigrationInfo.setFactory(InMemoryMigrationInfo.Factory.class);
+    EphemeralStore.setFactory(InMemoryEphemeralStore.Factory.class);
+    initProvisioning(zimbraServerDir);
+
+    LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
+    DbPool.startup();
+    HSQLDB.createDatabase(zimbraServerDir, OctopusInstance);
+
+    MailboxManager.setInstance(null);
+    IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
+
+    LC.zimbra_class_store.setDefault(storeManagerClass.getName());
+    StoreManager.getInstance().startup();
+  }
+
+  public static void initServer(
+      Class<? extends StoreManager> storeManagerClass, String zimbraServerDir) throws Exception {
+    MigrationInfo.setFactory(InMemoryMigrationInfo.Factory.class);
+    EphemeralStore.setFactory(InMemoryEphemeralStore.Factory.class);
+    initProvisioning(zimbraServerDir);
+
+    LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
+    DbPool.startup();
+    HSQLDB.createDatabase(zimbraServerDir, false);
+
+    MailboxManager.setInstance(null);
+    IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
+
+    LC.zimbra_class_store.setDefault(storeManagerClass.getName());
+    StoreManager.getInstance().startup();
+  }
+
+  /** Clears the database and index. */
+  public static void clearData() throws Exception {
+    clearData("");
+    MailboxManager.getInstance().clearAdditionalQuotaProviders();
+  }
+
+  /**
+   * Clears the database and index.
+   *
+   * @param zimbraServerDir the directory that contains the ZimbraServer project
+   */
+  public static void clearData(String zimbraServerDir) throws Exception {
+    HSQLDB.clearDatabase(zimbraServerDir);
+    MailboxManager.getInstance().clearCache();
+    MailboxIndex.shutdown();
+    File index = new File("build/test/index");
+    if (index.isDirectory()) {
+      deleteDirContents(index);
+    }
+    StoreManager sm = StoreManager.getInstance();
+    if (sm instanceof MockStoreManager) {
+      ((MockStoreManager) sm).purge();
+    } else if (sm instanceof MockHttpStoreManager) {
+      MockHttpStore.purge();
+    }
+    DocumentHandler.resetLocalHost();
+    EphemeralStore.getFactory().shutdown();
+  }
+
+  private static void deleteDirContents(File dir) throws IOException {
+    deleteDirContents(dir, 0);
+  }
+
+  private static void deleteDirContents(File dir, int recurCount) throws IOException {
+    try {
+      FileUtils.deleteDirectory(dir);
+    } catch (IOException ioe) {
+      if (recurCount > 10) {
+        throw new IOException("Gave up after multiple IOExceptions", ioe);
+      }
+      ZimbraLog.test.info(
+          "delete dir='%s' failed due to IOException '%s' (probably files still in use)."
+              + "Waiting a moment and trying again",
+          dir, ioe.getMessage());
+      // wait a moment and try again; this can bomb if files still being written by some thread
+      try {
+        Thread.sleep(2500);
+      } catch (InterruptedException ie) {
+
+      }
+      deleteDirContents(dir, recurCount + 1);
+    }
+  }
+
+  public static void cleanupIndexStore(Mailbox mbox) {
+    IndexStore index = mbox.index.getIndexStore();
+    if (index instanceof ElasticSearchIndex) {
+      String key = mbox.getAccountId();
+      String indexUrl = String.format("%s%s/", LC.zimbra_index_elasticsearch_url_base.value(), key);
+      HttpRequestBase method = new HttpDelete(indexUrl);
+      try {
+        ElasticSearchConnector connector = new ElasticSearchConnector();
+        int statusCode = connector.executeMethod(method);
+        if (statusCode == HttpStatus.SC_OK) {
+          boolean ok = connector.getBooleanAtJsonPath(new String[] {"ok"}, false);
+          boolean acknowledged =
+              connector.getBooleanAtJsonPath(new String[] {"acknowledged"}, false);
+          if (!ok || !acknowledged) {
+            ZimbraLog.index.debug("Delete index status ok=%b acknowledged=%b", ok, acknowledged);
+          }
+        } else {
+          String error = connector.getStringAtJsonPath(new String[] {"error"});
+          if (error != null && error.startsWith("IndexMissingException")) {
+            ZimbraLog.index.debug("Unable to delete index for key=%s.  Index is missing", key);
+          } else {
+            ZimbraLog.index.error("Problem deleting index for key=%s error=%s", key, error);
+          }
         }
-        LC.timezone_file.setDefault(timezonefilePath);
-        LC.zimbra_rights_directory.setDefault(StringUtils.removeEnd(zimbraServerDir, "/") +"-conf" + "/conf/rights");
-        LC.zimbra_attrs_directory.setDefault(zimbraServerDir + "conf/attrs");
-        LC.zimbra_tmp_directory.setDefault(zimbraServerDir + "tmp");
-        //substitute test DS config file
-        String dsfilePath = zimbraServerDir + "src/java-test/datasource-test.xml";
-        d = new File(dsfilePath);
-        if (!d.exists()) {
-            throw new FileNotFoundException("datasource-test.xml not found in " + dsfilePath);
-        }
-        LC.data_source_config.setDefault(dsfilePath);
-        // default MIME handlers are now set up in MockProvisioning constructor
-        Provisioning.setInstance(new MockProvisioning());
+      } catch (IOException e) {
+        ZimbraLog.index.error("Problem Deleting index with key=" + key, e);
+      }
     }
+  }
 
-    public static String getZimbraServerDir(String zimbraServerDir) {
-        String serverDir = zimbraServerDir;
-        if (StringUtil.isNullOrEmpty(serverDir)) {
-            serverDir = Strings.nullToEmpty(System.getProperty("server.dir"));
-            if (serverDir.isEmpty()) {
-                serverDir = Strings.nullToEmpty(System.getProperty("user.dir"));
-            }
-        }
-        if (!serverDir.endsWith("/")) {
-            serverDir = serverDir + "/";
-        }
-        return serverDir;
+  public static void setFlag(Mailbox mbox, int itemId, Flag.FlagInfo flag) throws ServiceException {
+    MailItem item = mbox.getItemById(null, itemId, MailItem.Type.UNKNOWN);
+    int flags = item.getFlagBitmask() | flag.toBitmask();
+    mbox.setTags(null, itemId, item.getType(), flags, null, null);
+  }
+
+  public static void unsetFlag(Mailbox mbox, int itemId, Flag.FlagInfo flag)
+      throws ServiceException {
+    MailItem item = mbox.getItemById(null, itemId, MailItem.Type.UNKNOWN);
+    int flags = item.getFlagBitmask() & ~flag.toBitmask();
+    mbox.setTags(null, itemId, item.getType(), flags, null, null);
+  }
+
+  public static void index(Mailbox mbox) throws ServiceException {
+    mbox.index.indexDeferredItems();
+  }
+
+  public static ParsedMessage generateMessage(String subject) throws Exception {
+    MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+    mm.setHeader("From", "Bob Evans <bob@example.com>");
+    mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
+    mm.setHeader("Subject", subject);
+    mm.setText("nothing to see here");
+    return new ParsedMessage(mm, false);
+  }
+
+  public static ParsedMessage generateHighPriorityMessage(String subject) throws Exception {
+    MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+    mm.setHeader("From", "Hi Bob <bob@example.com>");
+    mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
+    mm.setHeader("Subject", subject);
+    mm.addHeader("Importance", "high");
+    mm.setText("nothing to see here");
+    return new ParsedMessage(mm, false);
+  }
+
+  public static ParsedMessage generateLowPriorityMessage(String subject) throws Exception {
+    MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+    mm.setHeader("From", "Lo Bob <bob@example.com>");
+    mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
+    mm.setHeader("Subject", subject);
+    mm.addHeader("Importance", "low");
+    mm.setText("nothing to see here");
+    return new ParsedMessage(mm, false);
+  }
+
+  public static ParsedMessage generateMessageWithAttachment(String subject) throws Exception {
+    MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+    mm.setHeader("From", "Vera Oliphant <oli@example.com>");
+    mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
+    mm.setHeader("Subject", subject);
+    mm.setText("Good as gold");
+    MimeMultipart multi = new ZMimeMultipart("mixed");
+    ContentDisposition cdisp = new ContentDisposition(Part.ATTACHMENT);
+    cdisp.setParameter("filename", "fun.txt");
+
+    ZMimeBodyPart bp = new ZMimeBodyPart();
+    // MimeBodyPart.setDataHandler() invalidates Content-Type and CTE if there is any, so make sure
+    // it gets called before setting Content-Type and CTE headers.
+    try {
+      bp.setDataHandler(
+          new DataHandler(new ByteArrayDataSource("Feeling attached.", "text/plain")));
+    } catch (IOException e) {
+      throw new MessagingException("could not generate mime part content", e);
     }
+    bp.addHeader("Content-Disposition", cdisp.toString());
+    bp.addHeader("Content-Type", "text/plain");
+    bp.addHeader("Content-Transfer-Encoding", MimeConstants.ET_8BIT);
+    multi.addBodyPart(bp);
 
-    /**
-     * Initializes the provisioning, database, index and store manager.
-     */
-    public static void initServer() throws Exception {
-        initServer(MockStoreManager.class);
-    }
+    mm.setContent(multi);
+    mm.saveChanges();
 
-    /**
-     * Initializes the provisioning, database, index and store manager.
-     * @param zimbraServerDir the directory that contains the ZimbraServer project
-     * @throws Exception
-     */
-    public static void initServer(String zimbraServerDir) throws Exception {
-        initServer(MockStoreManager.class, zimbraServerDir);
-    }
+    return new ParsedMessage(mm, false);
+  }
 
-    public static void initServer(Class<? extends StoreManager> storeManagerClass) throws Exception {
-        initServer(storeManagerClass, "");
-    }
+  public static Invite generateInvite(Account account, String fragment, ZVCalendar cals)
+      throws Exception {
 
-    public static void initServer(Class<? extends StoreManager> storeManagerClass, String zimbraServerDir, boolean OctopusInstance) throws Exception {
-        MigrationInfo.setFactory(InMemoryMigrationInfo.Factory.class);
-        EphemeralStore.setFactory(InMemoryEphemeralStore.Factory.class);
-        initProvisioning(zimbraServerDir);
+    List<Invite> invites = Invite.createFromCalendar(account, fragment, cals, true);
 
-        LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
-        DbPool.startup();
-        HSQLDB.createDatabase(zimbraServerDir, OctopusInstance);
-
-        MailboxManager.setInstance(null);
-        IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
-
-        LC.zimbra_class_store.setDefault(storeManagerClass.getName());
-        StoreManager.getInstance().startup();
-    }
-
-    public static void initServer(Class<? extends StoreManager> storeManagerClass, String zimbraServerDir) throws Exception {
-        MigrationInfo.setFactory(InMemoryMigrationInfo.Factory.class);
-        EphemeralStore.setFactory(InMemoryEphemeralStore.Factory.class);
-        initProvisioning(zimbraServerDir);
-
-        LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
-        DbPool.startup();
-        HSQLDB.createDatabase(zimbraServerDir, false);
-
-        MailboxManager.setInstance(null);
-        IndexStore.setFactory(LC.zimbra_class_index_store_factory.value());
-
-        LC.zimbra_class_store.setDefault(storeManagerClass.getName());
-        StoreManager.getInstance().startup();
-    }
-
-    /**
-     * Clears the database and index.
-     */
-    public static void clearData() throws Exception {
-        clearData("");
-        MailboxManager.getInstance().clearAdditionalQuotaProviders();
-    }
-
-    /**
-     * Clears the database and index.
-     * @param zimbraServerDir the directory that contains the ZimbraServer project
-     */
-    public static void clearData(String zimbraServerDir) throws Exception {
-        HSQLDB.clearDatabase(zimbraServerDir);
-        MailboxManager.getInstance().clearCache();
-        MailboxIndex.shutdown();
-        File index = new File("build/test/index");
-        if (index.isDirectory()) {
-            deleteDirContents(index);
-        }
-        StoreManager sm = StoreManager.getInstance();
-        if (sm instanceof MockStoreManager) {
-            ((MockStoreManager) sm).purge();
-        } else if (sm instanceof MockHttpStoreManager) {
-            MockHttpStore.purge();
-        }
-        DocumentHandler.resetLocalHost();
-        EphemeralStore.getFactory().shutdown();
-    }
-
-    private static void deleteDirContents(File dir) throws IOException {
-        deleteDirContents(dir, 0);
-    }
-
-    private static void deleteDirContents(File dir, int recurCount) throws IOException {
-        try {
-            FileUtils.deleteDirectory(dir);
-        } catch (IOException ioe) {
-            if (recurCount > 10) {
-                throw new IOException("Gave up after multiple IOExceptions", ioe);
-            }
-            ZimbraLog.test.info("delete dir='%s' failed due to IOException '%s' (probably files still in use)."
-                    + "Waiting a moment and trying again", dir, ioe.getMessage());
-            //wait a moment and try again; this can bomb if files still being written by some thread
-            try {
-                Thread.sleep(2500);
-            } catch (InterruptedException ie) {
-
-            }
-            deleteDirContents(dir, recurCount+1);
-        }
-
-    }
-
-    public static void cleanupIndexStore(Mailbox mbox) {
-        IndexStore index = mbox.index.getIndexStore();
-        if (index instanceof ElasticSearchIndex) {
-            String key = mbox.getAccountId();
-            String indexUrl = String.format("%s%s/", LC.zimbra_index_elasticsearch_url_base.value(), key);
-            HttpRequestBase method = new HttpDelete(indexUrl);
-            try {
-                ElasticSearchConnector connector = new ElasticSearchConnector();
-                int statusCode = connector.executeMethod(method);
-                if (statusCode == HttpStatus.SC_OK) {
-                    boolean ok = connector.getBooleanAtJsonPath(new String[] {"ok"}, false);
-                    boolean acknowledged = connector.getBooleanAtJsonPath(new String[] {"acknowledged"}, false);
-                    if (!ok || !acknowledged) {
-                        ZimbraLog.index.debug("Delete index status ok=%b acknowledged=%b", ok, acknowledged);
-                    }
-                } else {
-                    String error = connector.getStringAtJsonPath(new String[] {"error"});
-                    if (error != null && error.startsWith("IndexMissingException")) {
-                        ZimbraLog.index.debug("Unable to delete index for key=%s.  Index is missing", key);
-                    } else {
-                        ZimbraLog.index.error("Problem deleting index for key=%s error=%s", key, error);
-                    }
-                }
-            } catch (IOException e) {
-                ZimbraLog.index.error("Problem Deleting index with key=" + key, e);
-            }
-        }
-    }
-
-    public static void setFlag(Mailbox mbox, int itemId, Flag.FlagInfo flag) throws ServiceException {
-        MailItem item = mbox.getItemById(null, itemId, MailItem.Type.UNKNOWN);
-        int flags = item.getFlagBitmask() | flag.toBitmask();
-        mbox.setTags(null, itemId, item.getType(), flags, null, null);
-    }
-
-    public static void unsetFlag(Mailbox mbox, int itemId, Flag.FlagInfo flag) throws ServiceException {
-        MailItem item = mbox.getItemById(null, itemId, MailItem.Type.UNKNOWN);
-        int flags = item.getFlagBitmask() & ~flag.toBitmask();
-        mbox.setTags(null, itemId, item.getType(), flags, null, null);
-    }
-
-    public static void index(Mailbox mbox) throws ServiceException {
-        mbox.index.indexDeferredItems();
-    }
-
-    public static ParsedMessage generateMessage(String subject) throws Exception {
-        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
-        mm.setHeader("From", "Bob Evans <bob@example.com>");
-        mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
-        mm.setHeader("Subject", subject);
-        mm.setText("nothing to see here");
-        return new ParsedMessage(mm, false);
-    }
-
-    public static ParsedMessage generateHighPriorityMessage(String subject) throws Exception {
-        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
-        mm.setHeader("From", "Hi Bob <bob@example.com>");
-        mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
-        mm.setHeader("Subject", subject);
-        mm.addHeader("Importance", "high");
-        mm.setText("nothing to see here");
-        return new ParsedMessage(mm, false);
-    }
-
-    public static ParsedMessage generateLowPriorityMessage(String subject) throws Exception {
-        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
-        mm.setHeader("From", "Lo Bob <bob@example.com>");
-        mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
-        mm.setHeader("Subject", subject);
-        mm.addHeader("Importance", "low");
-        mm.setText("nothing to see here");
-        return new ParsedMessage(mm, false);
-    }
-
-    public static ParsedMessage generateMessageWithAttachment(String subject) throws Exception {
-        MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
-        mm.setHeader("From", "Vera Oliphant <oli@example.com>");
-        mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
-        mm.setHeader("Subject", subject);
-        mm.setText("Good as gold");
-        MimeMultipart multi = new ZMimeMultipart("mixed");
-        ContentDisposition cdisp = new ContentDisposition(Part.ATTACHMENT);
-        cdisp.setParameter("filename", "fun.txt");
-
-        ZMimeBodyPart bp = new ZMimeBodyPart();
-        // MimeBodyPart.setDataHandler() invalidates Content-Type and CTE if there is any, so make sure
-        // it gets called before setting Content-Type and CTE headers.
-        try {
-            bp.setDataHandler(new DataHandler(new ByteArrayDataSource("Feeling attached.", "text/plain")));
-        } catch (IOException e) {
-            throw new MessagingException("could not generate mime part content", e);
-        }
-        bp.addHeader("Content-Disposition", cdisp.toString());
-        bp.addHeader("Content-Type", "text/plain");
-        bp.addHeader("Content-Transfer-Encoding", MimeConstants.ET_8BIT);
-        multi.addBodyPart(bp);
-
-        mm.setContent(multi);
-        mm.saveChanges();
-
-        return new ParsedMessage(mm, false);
-    }
-
-    public static Invite generateInvite(Account account, String fragment,
-                ZVCalendar cals) throws Exception {
-
-        List<Invite> invites = Invite.createFromCalendar(account, fragment, cals,
-            true);
-
-        return invites.get(0);
-    }
+    return invites.get(0);
+  }
 }

--- a/store/src/java-test/com/zimbra/cs/servlet/ZimbraServletTest.java
+++ b/store/src/java-test/com/zimbra/cs/servlet/ZimbraServletTest.java
@@ -5,25 +5,69 @@
 
 package com.zimbra.cs.servlet;
 
-import java.net.URL;
+import static org.junit.Assert.*;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
+import com.zimbra.common.util.RemoteIP.TrustedIPs;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Server;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.MockHttpServletRequest;
 import com.zimbra.cs.service.MockHttpServletResponse;
-import com.zimbra.cs.servlet.ZimbraServlet;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ZimbraServletTest {
-    
-    private static String uri = "/Briefcase/上的发生的发";
 
-    @Ignore("until bug 60345 is fixed")
-    @Test
-    public void proxyTest() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("test".getBytes("UTF-8"), new URL("http://localhost:7070/user1"+uri), "");
-        MockHttpServletResponse resp = new MockHttpServletResponse();
-        ZimbraServlet.proxyServletRequest(req, resp, Provisioning.getInstance().getLocalServer(), uri, null);
-    }
+  private static String uri = "/Briefcase/上的发生的发";
+
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    MailboxTestUtil.setMockitoProvisioning();
+  }
+
+  @Ignore("until bug 60345 is fixed")
+  @Test
+  public void proxyTest() throws Exception {
+    MockHttpServletRequest req =
+        new MockHttpServletRequest(
+            "test".getBytes("UTF-8"), new URL("http://localhost:7070/user1" + uri), "");
+    MockHttpServletResponse resp = new MockHttpServletResponse();
+    ZimbraServlet.proxyServletRequest(
+        req, resp, Provisioning.getInstance().getLocalServer(), uri, null);
+  }
+
+  @Test
+  public void shouldTrustProxyIps() throws Exception {
+    String[] proxyIps = new String[] {"192.168.0.10", "192.168.0.15"};
+    String[] trustedIpsByAttr = new String[] {"192.168.0.1", "192.168.0.2", "192.168.0.3"};
+    Server localServer = Mockito.mock(Server.class);
+    Mockito.when(localServer.getMultiAttr(Provisioning.A_zimbraMailTrustedIP))
+        .thenReturn(trustedIpsByAttr);
+    // Mock proxy servers ips
+    Server proxyServer1 = Mockito.mock(Server.class);
+    Mockito.when(proxyServer1.getIPAddress()).thenReturn(proxyIps[0]);
+    Server proxyServer2 = Mockito.mock(Server.class);
+    Mockito.when(proxyServer2.getIPAddress()).thenReturn(proxyIps[1]);
+    List<Server> proxyServers =
+        new ArrayList<>() {
+          {
+            add(proxyServer1);
+            add(proxyServer2);
+          }
+        };
+    Provisioning mockProvisioning = Provisioning.getInstance();
+    // mock provisioning to return mock local server + mock proxy servers
+    Mockito.when(mockProvisioning.getLocalServer()).thenReturn(localServer);
+    Mockito.when(mockProvisioning.getAllServers(Provisioning.SERVICE_PROXY))
+        .thenReturn(proxyServers);
+    TrustedIPs trustedIPs = ZimbraServlet.getTrustedIPs();
+    Arrays.stream(proxyIps).forEach(ip -> assertTrue(trustedIPs.isIpTrusted(ip)));
+  }
 }

--- a/store/src/java/com/zimbra/cs/account/Server.java
+++ b/store/src/java/com/zimbra/cs/account/Server.java
@@ -21,7 +21,7 @@ import java.util.Map;
  */
 public class Server extends ZAttrServer {
 
-  private String ipAddress;
+  private volatile String ipAddress;
 
   public Server(
       String name,

--- a/store/src/java/com/zimbra/cs/account/Server.java
+++ b/store/src/java/com/zimbra/cs/account/Server.java
@@ -82,9 +82,8 @@ public class Server extends ZAttrServer {
   }
 
   /**
-   * This method will lazy-load the server ip address from its hostname. The first time it is called
-   * it will try to resolve the server hostname. On subsequent calls it will return the resolved
-   * value.
+   * This method will lazy-load the server ip address from its hostname and return it. Subsequent
+   * calls will return the resolved ip address.
    *
    * @return IP address of the server after resolution
    * @throws UnknownHostException exception if host cannot be resolved
@@ -92,7 +91,11 @@ public class Server extends ZAttrServer {
    */
   public String getIPAddress() throws UnknownHostException {
     if (ipAddress == null) {
-      ipAddress = InetAddress.getByName(this.getHostname()).getHostAddress();
+      synchronized (this) {
+        if (ipAddress == null) {
+          ipAddress = InetAddress.getByName(this.getHostname()).getHostAddress();
+        }
+      }
     }
     return ipAddress;
   }

--- a/store/src/java/com/zimbra/cs/account/Server.java
+++ b/store/src/java/com/zimbra/cs/account/Server.java
@@ -21,6 +21,8 @@ import java.util.Map;
  */
 public class Server extends ZAttrServer {
 
+  private String ipAddress;
+
   public Server(
       String name,
       String id,
@@ -80,14 +82,19 @@ public class Server extends ZAttrServer {
   }
 
   /**
-   * This method will try to resolve server hostname and return its address each time it is called.
+   * This method will lazy-load the server ip address from its hostname. The first time it is called
+   * it will try to resolve the server hostname. On subsequent calls it will return the resolved
+   * value.
    *
    * @return IP address of the server after resolution
    * @throws UnknownHostException exception if host cannot be resolved
    * @since 22.9.0
    */
   public String getIPAddress() throws UnknownHostException {
-    return InetAddress.getByName(this.getHostname()).getHostAddress();
+    if (ipAddress == null) {
+      ipAddress = InetAddress.getByName(this.getHostname()).getHostAddress();
+    }
+    return ipAddress;
   }
 
   public boolean hasWebClientService() {

--- a/store/src/java/com/zimbra/cs/account/Server.java
+++ b/store/src/java/com/zimbra/cs/account/Server.java
@@ -11,6 +11,8 @@
 package com.zimbra.cs.account;
 
 import com.zimbra.common.service.ServiceException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Map;
 
 /**
@@ -67,6 +69,25 @@ public class Server extends ZAttrServer {
   public boolean hasProxyService() {
     return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
         .contains(Provisioning.SERVICE_PROXY);
+  }
+
+  /**
+   * @return the server hostname
+   * @since 22.9.0
+   */
+  public String getHostname() {
+    return this.getAttr(Provisioning.A_zimbraServiceHostname);
+  }
+
+  /**
+   * This method will try to resolve server hostname and return its address each time it is called.
+   *
+   * @return IP address of the server after resolution
+   * @throws UnknownHostException exception if host cannot be resolved
+   * @since 22.9.0
+   */
+  public String getIPAddress() throws UnknownHostException {
+    return InetAddress.getByName(this.getHostname()).getHostAddress();
   }
 
   public boolean hasWebClientService() {

--- a/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
+++ b/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
@@ -8,32 +8,6 @@
  */
 package com.zimbra.cs.servlet;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.http.Header;
-import org.apache.http.HttpException;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.cookie.Cookie;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.client.BasicCookieStore;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.cookie.BasicClientCookie;
-
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.httpclient.HttpClientUtil;
@@ -61,473 +35,544 @@ import com.zimbra.cs.service.util.JWTUtil;
 import com.zimbra.cs.servlet.util.AuthUtil;
 import com.zimbra.cs.util.Zimbra;
 import com.zimbra.soap.SoapServlet;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.BasicClientCookie;
 
 /**
- * Superclass for all Zimbra servlets.  Supports port filtering and
- * provides some utility methods to subclasses.
+ * Superclass for all Zimbra servlets. Supports port filtering and provides some utility methods to
+ * subclasses.
  */
 public class ZimbraServlet extends HttpServlet {
-    private static final long serialVersionUID = 5025244890767551679L;
+  private static final long serialVersionUID = 5025244890767551679L;
 
-    private static Log mLog = LogFactory.getLog(ZimbraServlet.class);
+  private static Log mLog = LogFactory.getLog(ZimbraServlet.class);
 
-    private static final String PARAM_ALLOWED_PORTS  = "allowed.ports";
+  private static final String PARAM_ALLOWED_PORTS = "allowed.ports";
 
-    public static final String QP_ZAUTHTOKEN = "zauthtoken";
-    public static final String QP_ZJWT = "zjwt";
+  public static final String QP_ZAUTHTOKEN = "zauthtoken";
+  public static final String QP_ZJWT = "zjwt";
 
-    protected String getRealmHeader(String realm)  {
-        if (realm == null)
-            realm = "Zimbra";
-        return "BASIC realm=\"" + realm + "\"";
-    }
+  protected String getRealmHeader(String realm) {
+    if (realm == null) realm = "Zimbra";
+    return "BASIC realm=\"" + realm + "\"";
+  }
 
-    protected String getRealmHeader(HttpServletRequest req, Domain domain)  {
-        String realm = null;
+  protected String getRealmHeader(HttpServletRequest req, Domain domain) {
+    String realm = null;
 
-        if (domain == null) {
-            // get domain by virtual host
-            String host = HttpUtil.getVirtualHost(req);
-            if (host != null) {
-                // to defend against DOS attack, use the negative domain cache
-                try {
-                    domain = Provisioning.getInstance().getDomain(Key.DomainBy.virtualHostname, host.toLowerCase(), true);
-                } catch (ServiceException e) {
-                    mLog.warn("caught exception while getting domain by virtual host: " + host, e);
-                }
-            }
-        }
-
-        if (domain != null)
-            realm = domain.getBasicAuthRealm();
-
-        return getRealmHeader(realm);
-    }
-
-    public static final String ZIMBRA_FAULT_CODE_HEADER = "X-Zimbra-Fault-Code";
-    public static final String ZIMBRA_FAULT_MESSAGE_HEADER = "X-Zimbra-Fault-Message";
-
-    private static final int MAX_PROXY_HOPCOUNT = 3;
-
-    private static Map<String, ZimbraServlet> sServlets = new HashMap<String, ZimbraServlet>();
-
-    private int[] mAllowedPorts;
-
-    @Override public void init() throws ServletException {
+    if (domain == null) {
+      // get domain by virtual host
+      String host = HttpUtil.getVirtualHost(req);
+      if (host != null) {
+        // to defend against DOS attack, use the negative domain cache
         try {
-            String portsCSV = getInitParameter(PARAM_ALLOWED_PORTS);
-            if (portsCSV != null) {
-                // Split on zero-or-more spaces followed by comma followed by
-                // zero-or-more spaces.
-                String[] vals = portsCSV.split("\\s*,\\s*");
-                if (vals == null || vals.length == 0)
-                    throw new ServletException("Must specify comma-separated list of port numbers for " +
-                                               PARAM_ALLOWED_PORTS + " parameter");
-                List<Integer> allowedPorts = new ArrayList<Integer>();
-                int port;
-                for (int i = 0; i < vals.length; i++) {
-                    try {
-                	port = Integer.parseInt(vals[i]);
-                    } catch (NumberFormatException e) {
-                        throw new ServletException("Invalid port number \"" + vals[i] + "\" in " +
-                                                   PARAM_ALLOWED_PORTS + " parameter");
-                    }
-                    if (port < 0)
-                	throw new ServletException("Invalid port number " + vals[i] + " in " +
-                                                   PARAM_ALLOWED_PORTS + " parameter; port number must be greater than zero");
-                    else if (port != 0)  // 0 is a legit value for those ports that are disabled
-                	allowedPorts.add(port);
-                }
-
-                mAllowedPorts = new int[allowedPorts.size()];
-                for (int i=0; i<allowedPorts.size(); i++)
-                    mAllowedPorts[i] = allowedPorts.get(i);
-            }
-
-            // Store reference to this servlet for accessor
-            synchronized (sServlets) {
-                String name = getServletName();
-                if (sServlets.containsKey(name)) {
-                    Zimbra.halt("Attempted to instantiate a second instance of " + name);
-                }
-                sServlets.put(getServletName(), this);
-                mLog.debug("Added " + getServletName() + " to the servlet list");
-            }
-        } catch (Throwable t) {
-            Zimbra.halt("Unable to initialize servlet " + getServletName() + "; halting", t);
-        }
-    }
-
-    public static ZimbraServlet getServlet(String name) {
-        synchronized (sServlets) {
-            return sServlets.get(name);
-        }
-    }
-
-    protected boolean isRequestOnAllowedPort(HttpServletRequest request) {
-        if (mAllowedPorts != null && mAllowedPorts.length > 0) {
-            int incoming = request.getLocalPort();
-            for (int i = 0; i < mAllowedPorts.length; i++) {
-                if (mAllowedPorts[i] == incoming) {
-                	return true;
-                }
-            }
-            return false;
-        }
-        return true;
-    }
-    /**
-     * Filter the request based on incoming port.  If the allowed.ports
-     * parameter is specified for the servlet, the incoming port must
-     * match one of the listed ports.
-     */
-    @Override
-    protected void service(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException {
-        boolean allowed = isRequestOnAllowedPort(request);
-        if (!allowed) {
-            SoapProtocol soapProto = SoapProtocol.Soap12;
-            ServiceException e = ServiceException.FAILURE("Request not allowed on port " + request.getLocalPort(), null);
-            ZimbraLog.soap.warn(null, e);
-            Element fault = SoapProtocol.Soap12.soapFault(e);
-            Element envelope = SoapProtocol.Soap12.soapEnvelope(fault);
-            byte[] soapBytes = envelope.toUTF8();
-            response.setContentType(soapProto.getContentType());
-            response.setBufferSize(soapBytes.length + 2048);
-            response.setContentLength(soapBytes.length);
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            response.getOutputStream().write(soapBytes);
-            return;
-        }
-        super.service(request, response);
-    }
-
-    public static AuthToken getAuthTokenFromCookie(HttpServletRequest req, HttpServletResponse resp)
-    throws IOException {
-        return getAuthTokenFromHttpReq(req, resp, false, false);
-    }
-
-    public static AuthToken getAuthTokenFromCookie(HttpServletRequest req, HttpServletResponse resp, boolean doNotSendHttpError)
-    throws IOException {
-        return getAuthTokenFromHttpReq(req, resp, false, doNotSendHttpError);
-    }
-
-    public static AuthToken getAdminAuthTokenFromCookie(HttpServletRequest req, HttpServletResponse resp)
-    throws IOException {
-        return getAuthTokenFromHttpReq(req, resp, true, false);
-    }
-
-    public static AuthToken getAdminAuthTokenFromCookie(HttpServletRequest req, HttpServletResponse resp, boolean doNotSendHttpError)
-    throws IOException {
-        return getAuthTokenFromHttpReq(req, resp, true, doNotSendHttpError);
-    }
-
-    public static AuthToken getAdminAuthTokenFromCookie(HttpServletRequest req) {
-        return getAuthTokenFromHttpReq(req, true);
-    }
-
-    public static AuthToken getAuthTokenFromHttpReq(HttpServletRequest req,
-                                                    HttpServletResponse resp,
-                                                    boolean isAdminReq,
-                                                    boolean doNotSendHttpError) throws IOException {
-        AuthToken authToken = null;
-        try {
-            authToken = getAuthToken(req, isAdminReq);
-            if (authToken == null) {
-                if (!doNotSendHttpError)
-                    resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "no authtoken cookie");
-                return null;
-            }
-
-            if (authToken.isExpired() || !authToken.isRegistered()) {
-                if (!doNotSendHttpError)
-                    resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "authtoken expired");
-                return null;
-            }
-            return authToken;
-        } catch (AuthTokenException e) {
-            if (!doNotSendHttpError)
-                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "unable to parse authtoken");
-            return null;
-        }
-    }
-
-    private static AuthToken getAuthToken(HttpServletRequest req, boolean isAdminReq) throws AuthTokenException {
-        AuthToken authToken = AuthProvider.getAuthToken(req, isAdminReq);
-        if (authToken == null) {
-            Map <Object, Object> engineCtxt = new HashMap<Object, Object>();
-            engineCtxt.put(SoapServlet.SERVLET_REQUEST, req);
-            authToken = AuthProvider.getJWToken(null, engineCtxt);
-        }
-        return authToken;
-    }
-
-    public static AuthToken getAuthTokenFromHttpReq(HttpServletRequest req, boolean isAdminReq) {
-        AuthToken authToken = null;
-        try {
-            authToken = getAuthToken(req, isAdminReq);
-            if (authToken == null)
-                return null;
-
-            if (authToken.isExpired())
-                return null;
-
-            if (!authToken.isRegistered())
-                return null;
-
-            return authToken;
-        } catch (AuthTokenException e) {
-            return null;
-        }
-    }
-
-    public static void proxyServletRequest(HttpServletRequest req, HttpServletResponse resp, String accountId)
-    throws IOException, ServiceException, HttpException {
-        Provisioning prov = Provisioning.getInstance();
-        Account acct = prov.get(AccountBy.id, accountId);
-        if (acct == null) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no such user");
-            return;
-        }
-        proxyServletRequest(req, resp, prov.getServer(acct), null);
-    }
-
-    public static void proxyServletRequest(HttpServletRequest req, HttpServletResponse resp, Server server, AuthToken authToken)
-    throws IOException, ServiceException, HttpException {
-        String uri = req.getRequestURI();
-        String qs = req.getQueryString();
-        if (qs != null) {
-            uri += '?' + qs;
-        }
-        proxyServletRequest(req, resp, server, uri, authToken);
-    }
-
-    public static void proxyServletRequest(HttpServletRequest req, HttpServletResponse resp, Server server, String uri, AuthToken authToken)
-    throws IOException, ServiceException, HttpException {
-        if (server == null) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "cannot find remote server");
-            return;
-        }
-        HttpRequestBase method;
-        String url = getProxyUrl(req, server, uri);
-        mLog.debug("Proxy URL = %s", url);
-        if (req.getMethod().equalsIgnoreCase("GET")) {
-            method = new HttpGet(url);
-        } else if (req.getMethod().equalsIgnoreCase("POST") || req.getMethod().equalsIgnoreCase("PUT")) {
-            HttpPost post = new HttpPost(url);
-            post.setEntity(new InputStreamEntity(req.getInputStream()));
-            method = post;
-        } else {
-            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "cannot proxy method: " + req.getMethod());
-            return;
-        }
-        BasicCookieStore state = new BasicCookieStore();
-        String hostname = method.getURI().getHost();
-        if (authToken != null) {
-            authToken.encode(state, false, hostname);
-            if (JWTUtil.isJWT(authToken)) {
-                try {
-                    method.addHeader(Constants.AUTH_HEADER, Constants.BEARER + " " + authToken.getEncoded());
-                } catch (AuthTokenException e) {
-                    mLog.debug("auth header not set during request proxy");
-                }
-            }
-        }
-        try {
-            proxyServletRequest(req, resp, method, state);
-        } finally {
-            method.releaseConnection();
-        }
-    }
-
-    private static boolean hasZimbraAuthCookie(BasicCookieStore state) {
-        List<Cookie> cookies = state.getCookies();
-        if (cookies == null)
-            return false;
-
-        for (Cookie c: cookies) {
-            if (c.getName().equals(ZimbraCookie.COOKIE_ZM_AUTH_TOKEN))
-                return true;
-        }
-        return false;
-    }
-
-    // TO DO HTTP
-    private static boolean hasJWTSaltCookie(BasicCookieStore state) {
-        List<Cookie>  cookies = state == null? null : state.getCookies();
-        if (cookies == null) {
-            return false;
-        }
-
-        for (Cookie c: cookies) {
-            if (c.getName().equals(ZimbraCookie.COOKIE_ZM_JWT)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static void proxyServletRequest(HttpServletRequest req, HttpServletResponse resp, HttpRequestBase method, BasicCookieStore state)
-    throws IOException, ServiceException, HttpException {
-        // create an HTTP client with the same cookies
-        javax.servlet.http.Cookie cookies[] = req.getCookies();
-        String hostname = method.getURI().getHost();
-        boolean hasZMAuth = hasZimbraAuthCookie(state);
-        boolean hasJwtSalt = hasJWTSaltCookie(state);
-        if (cookies != null) {
-            for (int i = 0; i < cookies.length; i++) {
-                if ((cookies[i].getName().equals(ZimbraCookie.COOKIE_ZM_AUTH_TOKEN) && hasZMAuth) ||
-                        (hasJwtSalt && cookies[i].getName().equals(ZimbraCookie.COOKIE_ZM_JWT)))
-                    continue;
-                BasicClientCookie cookie = new BasicClientCookie(cookies[i].getName(), cookies[i].getValue());
-                cookie.setDomain(hostname);
-                cookie.setPath("/");
-                cookie.setSecure(false);
-                state.addCookie(cookie);
-            }
-        }
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient();
-        if (state != null)
-            clientBuilder.setDefaultCookieStore(state);
-
-        int hopcount = 0;
-        for (Enumeration<?> enm = req.getHeaderNames(); enm.hasMoreElements(); ) {
-            String hname = (String) enm.nextElement(), hlc = hname.toLowerCase();
-            if (hlc.equals("x-hopcount"))
-                try { hopcount = Math.max(Integer.parseInt(req.getHeader(hname)), 0); } catch (NumberFormatException e) { }
-            else if (hlc.startsWith("x-") || hlc.startsWith("content-") || hlc.equals("authorization"))
-                method.addHeader(hname, req.getHeader(hname));
-        }
-        if (hopcount >= MAX_PROXY_HOPCOUNT)
-            throw ServiceException.TOO_MANY_HOPS(HttpUtil.getFullRequestURL(req));
-        method.addHeader("X-Zimbra-Hopcount", Integer.toString(hopcount + 1));
-        if (method.getFirstHeader("X-Zimbra-Orig-Url") == null)
-            method.addHeader("X-Zimbra-Orig-Url", req.getRequestURL().toString());
-        String ua = req.getHeader("User-Agent");
-        if (ua != null)
-            method.addHeader("User-Agent", ua);
-
-        // dispatch the request and copy over the results
-        int statusCode = -1;
-        HttpClient client = clientBuilder.build();
-        HttpResponse httpResp = null;
-        for (int retryCount = 3; statusCode == -1 && retryCount > 0; retryCount--) {
-            httpResp = HttpClientUtil.executeMethod(client, method);
-            statusCode = httpResp.getStatusLine().getStatusCode();
-        }
-        if (statusCode == -1) {
-            resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "retry limit reached");
-            return;
-        } else if (statusCode >= 300) {
-            resp.sendError(statusCode, httpResp.getStatusLine().getReasonPhrase());
-            return;
-        }
-
-        Header[] headers = httpResp.getAllHeaders();
-        for (int i = 0; i < headers.length; i++) {
-            String hname = headers[i].getName(), hlc = hname.toLowerCase();
-            if (hlc.startsWith("x-") || hlc.startsWith("content-") || hlc.startsWith("www-"))
-                resp.addHeader(hname, headers[i].getValue());
-        }
-        InputStream responseStream = httpResp.getEntity().getContent();
-        if (responseStream == null || resp.getOutputStream() == null)
-            return;
-        ByteUtil.copy(httpResp.getEntity().getContent(), false, resp.getOutputStream(), false);
-
-    }
-
-    protected boolean isAdminRequest(HttpServletRequest req) throws ServiceException {
-        int adminPort = Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraAdminPort, -1);
-        if (req.getLocalPort() == adminPort) {
-            //can still be in offline server where port=adminPort
-            int mailPort = Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraMailPort, -1);
-            if (mailPort == adminPort) //we are in offline, so check cookie
-                return getAdminAuthTokenFromCookie(req) != null;
-            else
-                return true;
-        }
-        return false;
-    }
-
-    public AuthToken cookieAuthRequest(HttpServletRequest req, HttpServletResponse resp)
-    throws IOException, ServiceException {
-        AuthToken at = isAdminRequest(req) ? getAdminAuthTokenFromCookie(req, resp, true) : getAuthTokenFromCookie(req, resp, true);
-        return at;
-    }
-
-    /**
-     * Note that if this method returns null, it isn't clear whether resp.sendError has been called or not.
-     * For that reason, it has been deprecated.  Believe there is no Zimbra code which still calls it but
-     * left in case customization code uses it.
-     */
-    @Deprecated
-    public Account basicAuthRequest(HttpServletRequest req, HttpServletResponse resp, boolean sendChallenge)
-    throws IOException, ServiceException {
-        return AuthUtil.basicAuthRequest(req, resp, this, sendChallenge);
-    }
-
-    public static String getAccountPath(Account acct) {
-        return "/" + acct.getName();
-    }
-
-    public static String getServiceUrl(Account acct, String path) throws ServiceException {
-        Provisioning prov = Provisioning.getInstance();
-        Server server = prov.getServer(acct);
-
-        if (server == null) {
-            throw ServiceException.FAILURE("unable to retrieve server for account" + acct.getName(), null);
-        }
-
-        return getServiceUrl(server, prov.getDomain(acct), path + getAccountPath(acct));
-    }
-
-
-    public static String getServiceUrl(Server server, Domain domain, String path) throws ServiceException {
-        return URLUtil.getPublicURLForDomain(server, domain, path, true);
-    }
-
-    protected static String getProxyUrl(HttpServletRequest req, Server server, String path) throws ServiceException {
-        int servicePort = (req == null) ? -1 : req.getLocalPort();
-        Provisioning prov = Provisioning.getInstance();
-        Server localServer = prov.getLocalServer();
-        if (!prov.isOfflineProxyServer(server) && servicePort == localServer.getIntAttr(Provisioning.A_zimbraAdminPort, 0))
-            return URLUtil.getAdminURL(server, path);
-        else
-            return URLUtil.getServiceURL(server, path, servicePort == localServer.getIntAttr(Provisioning.A_zimbraMailSSLPort, 0));
-    }
-
-    protected void returnError(HttpServletResponse resp, ServiceException e) {
-        resp.setHeader(ZIMBRA_FAULT_CODE_HEADER, e.getCode());
-        resp.setHeader(ZIMBRA_FAULT_MESSAGE_HEADER, e.getMessage());
-        resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
-
-    public static String getOrigIp(HttpServletRequest req) {
-        RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
-        return remoteIp.getOrigIP();
-    }
-
-    public static String getClientIp(HttpServletRequest req) {
-        RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
-        return remoteIp.getClientIP();
-    }
-
-    public static void addRemoteIpToLoggingContext(HttpServletRequest req) {
-        RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
-        remoteIp.addToLoggingContext();
-    }
-
-    public static RemoteIP.TrustedIPs getTrustedIPs() {
-        try {
-            Server server = Provisioning.getInstance().getLocalServer();
-            return new RemoteIP.TrustedIPs(server.getMultiAttr(Provisioning.A_zimbraMailTrustedIP));
+          domain =
+              Provisioning.getInstance()
+                  .getDomain(Key.DomainBy.virtualHostname, host.toLowerCase(), true);
         } catch (ServiceException e) {
-            ZimbraLog.misc.warn("failed to get trusted IPs, only localhost will be trusted", e);
+          mLog.warn("caught exception while getting domain by virtual host: " + host, e);
         }
-        return new RemoteIP.TrustedIPs(null);
+      }
     }
 
-    public static void addUAToLoggingContext(HttpServletRequest req) {
-        ZimbraLog.addUserAgentToContext(req.getHeader("User-Agent"));
+    if (domain != null) realm = domain.getBasicAuthRealm();
+
+    return getRealmHeader(realm);
+  }
+
+  public static final String ZIMBRA_FAULT_CODE_HEADER = "X-Zimbra-Fault-Code";
+  public static final String ZIMBRA_FAULT_MESSAGE_HEADER = "X-Zimbra-Fault-Message";
+
+  private static final int MAX_PROXY_HOPCOUNT = 3;
+
+  private static Map<String, ZimbraServlet> sServlets = new HashMap<String, ZimbraServlet>();
+
+  private int[] mAllowedPorts;
+
+  @Override
+  public void init() throws ServletException {
+    try {
+      String portsCSV = getInitParameter(PARAM_ALLOWED_PORTS);
+      if (portsCSV != null) {
+        // Split on zero-or-more spaces followed by comma followed by
+        // zero-or-more spaces.
+        String[] vals = portsCSV.split("\\s*,\\s*");
+        if (vals == null || vals.length == 0)
+          throw new ServletException(
+              "Must specify comma-separated list of port numbers for "
+                  + PARAM_ALLOWED_PORTS
+                  + " parameter");
+        List<Integer> allowedPorts = new ArrayList<Integer>();
+        int port;
+        for (int i = 0; i < vals.length; i++) {
+          try {
+            port = Integer.parseInt(vals[i]);
+          } catch (NumberFormatException e) {
+            throw new ServletException(
+                "Invalid port number \"" + vals[i] + "\" in " + PARAM_ALLOWED_PORTS + " parameter");
+          }
+          if (port < 0)
+            throw new ServletException(
+                "Invalid port number "
+                    + vals[i]
+                    + " in "
+                    + PARAM_ALLOWED_PORTS
+                    + " parameter; port number must be greater than zero");
+          else if (port != 0) // 0 is a legit value for those ports that are disabled
+          allowedPorts.add(port);
+        }
+
+        mAllowedPorts = new int[allowedPorts.size()];
+        for (int i = 0; i < allowedPorts.size(); i++) mAllowedPorts[i] = allowedPorts.get(i);
+      }
+
+      // Store reference to this servlet for accessor
+      synchronized (sServlets) {
+        String name = getServletName();
+        if (sServlets.containsKey(name)) {
+          Zimbra.halt("Attempted to instantiate a second instance of " + name);
+        }
+        sServlets.put(getServletName(), this);
+        mLog.debug("Added " + getServletName() + " to the servlet list");
+      }
+    } catch (Throwable t) {
+      Zimbra.halt("Unable to initialize servlet " + getServletName() + "; halting", t);
     }
+  }
+
+  public static ZimbraServlet getServlet(String name) {
+    synchronized (sServlets) {
+      return sServlets.get(name);
+    }
+  }
+
+  protected boolean isRequestOnAllowedPort(HttpServletRequest request) {
+    if (mAllowedPorts != null && mAllowedPorts.length > 0) {
+      int incoming = request.getLocalPort();
+      for (int i = 0; i < mAllowedPorts.length; i++) {
+        if (mAllowedPorts[i] == incoming) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+  /**
+   * Filter the request based on incoming port. If the allowed.ports parameter is specified for the
+   * servlet, the incoming port must match one of the listed ports.
+   */
+  @Override
+  protected void service(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    boolean allowed = isRequestOnAllowedPort(request);
+    if (!allowed) {
+      SoapProtocol soapProto = SoapProtocol.Soap12;
+      ServiceException e =
+          ServiceException.FAILURE("Request not allowed on port " + request.getLocalPort(), null);
+      ZimbraLog.soap.warn(null, e);
+      Element fault = SoapProtocol.Soap12.soapFault(e);
+      Element envelope = SoapProtocol.Soap12.soapEnvelope(fault);
+      byte[] soapBytes = envelope.toUTF8();
+      response.setContentType(soapProto.getContentType());
+      response.setBufferSize(soapBytes.length + 2048);
+      response.setContentLength(soapBytes.length);
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.getOutputStream().write(soapBytes);
+      return;
+    }
+    super.service(request, response);
+  }
+
+  public static AuthToken getAuthTokenFromCookie(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
+    return getAuthTokenFromHttpReq(req, resp, false, false);
+  }
+
+  public static AuthToken getAuthTokenFromCookie(
+      HttpServletRequest req, HttpServletResponse resp, boolean doNotSendHttpError)
+      throws IOException {
+    return getAuthTokenFromHttpReq(req, resp, false, doNotSendHttpError);
+  }
+
+  public static AuthToken getAdminAuthTokenFromCookie(
+      HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    return getAuthTokenFromHttpReq(req, resp, true, false);
+  }
+
+  public static AuthToken getAdminAuthTokenFromCookie(
+      HttpServletRequest req, HttpServletResponse resp, boolean doNotSendHttpError)
+      throws IOException {
+    return getAuthTokenFromHttpReq(req, resp, true, doNotSendHttpError);
+  }
+
+  public static AuthToken getAdminAuthTokenFromCookie(HttpServletRequest req) {
+    return getAuthTokenFromHttpReq(req, true);
+  }
+
+  public static AuthToken getAuthTokenFromHttpReq(
+      HttpServletRequest req,
+      HttpServletResponse resp,
+      boolean isAdminReq,
+      boolean doNotSendHttpError)
+      throws IOException {
+    AuthToken authToken = null;
+    try {
+      authToken = getAuthToken(req, isAdminReq);
+      if (authToken == null) {
+        if (!doNotSendHttpError)
+          resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "no authtoken cookie");
+        return null;
+      }
+
+      if (authToken.isExpired() || !authToken.isRegistered()) {
+        if (!doNotSendHttpError)
+          resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "authtoken expired");
+        return null;
+      }
+      return authToken;
+    } catch (AuthTokenException e) {
+      if (!doNotSendHttpError)
+        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "unable to parse authtoken");
+      return null;
+    }
+  }
+
+  private static AuthToken getAuthToken(HttpServletRequest req, boolean isAdminReq)
+      throws AuthTokenException {
+    AuthToken authToken = AuthProvider.getAuthToken(req, isAdminReq);
+    if (authToken == null) {
+      Map<Object, Object> engineCtxt = new HashMap<Object, Object>();
+      engineCtxt.put(SoapServlet.SERVLET_REQUEST, req);
+      authToken = AuthProvider.getJWToken(null, engineCtxt);
+    }
+    return authToken;
+  }
+
+  public static AuthToken getAuthTokenFromHttpReq(HttpServletRequest req, boolean isAdminReq) {
+    AuthToken authToken = null;
+    try {
+      authToken = getAuthToken(req, isAdminReq);
+      if (authToken == null) return null;
+
+      if (authToken.isExpired()) return null;
+
+      if (!authToken.isRegistered()) return null;
+
+      return authToken;
+    } catch (AuthTokenException e) {
+      return null;
+    }
+  }
+
+  public static void proxyServletRequest(
+      HttpServletRequest req, HttpServletResponse resp, String accountId)
+      throws IOException, ServiceException, HttpException {
+    Provisioning prov = Provisioning.getInstance();
+    Account acct = prov.get(AccountBy.id, accountId);
+    if (acct == null) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no such user");
+      return;
+    }
+    proxyServletRequest(req, resp, prov.getServer(acct), null);
+  }
+
+  public static void proxyServletRequest(
+      HttpServletRequest req, HttpServletResponse resp, Server server, AuthToken authToken)
+      throws IOException, ServiceException, HttpException {
+    String uri = req.getRequestURI();
+    String qs = req.getQueryString();
+    if (qs != null) {
+      uri += '?' + qs;
+    }
+    proxyServletRequest(req, resp, server, uri, authToken);
+  }
+
+  public static void proxyServletRequest(
+      HttpServletRequest req,
+      HttpServletResponse resp,
+      Server server,
+      String uri,
+      AuthToken authToken)
+      throws IOException, ServiceException, HttpException {
+    if (server == null) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "cannot find remote server");
+      return;
+    }
+    HttpRequestBase method;
+    String url = getProxyUrl(req, server, uri);
+    mLog.debug("Proxy URL = %s", url);
+    if (req.getMethod().equalsIgnoreCase("GET")) {
+      method = new HttpGet(url);
+    } else if (req.getMethod().equalsIgnoreCase("POST")
+        || req.getMethod().equalsIgnoreCase("PUT")) {
+      HttpPost post = new HttpPost(url);
+      post.setEntity(new InputStreamEntity(req.getInputStream()));
+      method = post;
+    } else {
+      resp.sendError(
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "cannot proxy method: " + req.getMethod());
+      return;
+    }
+    BasicCookieStore state = new BasicCookieStore();
+    String hostname = method.getURI().getHost();
+    if (authToken != null) {
+      authToken.encode(state, false, hostname);
+      if (JWTUtil.isJWT(authToken)) {
+        try {
+          method.addHeader(Constants.AUTH_HEADER, Constants.BEARER + " " + authToken.getEncoded());
+        } catch (AuthTokenException e) {
+          mLog.debug("auth header not set during request proxy");
+        }
+      }
+    }
+    try {
+      proxyServletRequest(req, resp, method, state);
+    } finally {
+      method.releaseConnection();
+    }
+  }
+
+  private static boolean hasZimbraAuthCookie(BasicCookieStore state) {
+    List<Cookie> cookies = state.getCookies();
+    if (cookies == null) return false;
+
+    for (Cookie c : cookies) {
+      if (c.getName().equals(ZimbraCookie.COOKIE_ZM_AUTH_TOKEN)) return true;
+    }
+    return false;
+  }
+
+  // TO DO HTTP
+  private static boolean hasJWTSaltCookie(BasicCookieStore state) {
+    List<Cookie> cookies = state == null ? null : state.getCookies();
+    if (cookies == null) {
+      return false;
+    }
+
+    for (Cookie c : cookies) {
+      if (c.getName().equals(ZimbraCookie.COOKIE_ZM_JWT)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static void proxyServletRequest(
+      HttpServletRequest req,
+      HttpServletResponse resp,
+      HttpRequestBase method,
+      BasicCookieStore state)
+      throws IOException, ServiceException, HttpException {
+    // create an HTTP client with the same cookies
+    javax.servlet.http.Cookie cookies[] = req.getCookies();
+    String hostname = method.getURI().getHost();
+    boolean hasZMAuth = hasZimbraAuthCookie(state);
+    boolean hasJwtSalt = hasJWTSaltCookie(state);
+    if (cookies != null) {
+      for (int i = 0; i < cookies.length; i++) {
+        if ((cookies[i].getName().equals(ZimbraCookie.COOKIE_ZM_AUTH_TOKEN) && hasZMAuth)
+            || (hasJwtSalt && cookies[i].getName().equals(ZimbraCookie.COOKIE_ZM_JWT))) continue;
+        BasicClientCookie cookie =
+            new BasicClientCookie(cookies[i].getName(), cookies[i].getValue());
+        cookie.setDomain(hostname);
+        cookie.setPath("/");
+        cookie.setSecure(false);
+        state.addCookie(cookie);
+      }
+    }
+    HttpClientBuilder clientBuilder =
+        ZimbraHttpConnectionManager.getInternalHttpConnMgr().newHttpClient();
+    if (state != null) clientBuilder.setDefaultCookieStore(state);
+
+    int hopcount = 0;
+    for (Enumeration<?> enm = req.getHeaderNames(); enm.hasMoreElements(); ) {
+      String hname = (String) enm.nextElement(), hlc = hname.toLowerCase();
+      if (hlc.equals("x-hopcount"))
+        try {
+          hopcount = Math.max(Integer.parseInt(req.getHeader(hname)), 0);
+        } catch (NumberFormatException e) {
+        }
+      else if (hlc.startsWith("x-") || hlc.startsWith("content-") || hlc.equals("authorization"))
+        method.addHeader(hname, req.getHeader(hname));
+    }
+    if (hopcount >= MAX_PROXY_HOPCOUNT)
+      throw ServiceException.TOO_MANY_HOPS(HttpUtil.getFullRequestURL(req));
+    method.addHeader("X-Zimbra-Hopcount", Integer.toString(hopcount + 1));
+    if (method.getFirstHeader("X-Zimbra-Orig-Url") == null)
+      method.addHeader("X-Zimbra-Orig-Url", req.getRequestURL().toString());
+    String ua = req.getHeader("User-Agent");
+    if (ua != null) method.addHeader("User-Agent", ua);
+
+    // dispatch the request and copy over the results
+    int statusCode = -1;
+    HttpClient client = clientBuilder.build();
+    HttpResponse httpResp = null;
+    for (int retryCount = 3; statusCode == -1 && retryCount > 0; retryCount--) {
+      httpResp = HttpClientUtil.executeMethod(client, method);
+      statusCode = httpResp.getStatusLine().getStatusCode();
+    }
+    if (statusCode == -1) {
+      resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "retry limit reached");
+      return;
+    } else if (statusCode >= 300) {
+      resp.sendError(statusCode, httpResp.getStatusLine().getReasonPhrase());
+      return;
+    }
+
+    Header[] headers = httpResp.getAllHeaders();
+    for (int i = 0; i < headers.length; i++) {
+      String hname = headers[i].getName(), hlc = hname.toLowerCase();
+      if (hlc.startsWith("x-") || hlc.startsWith("content-") || hlc.startsWith("www-"))
+        resp.addHeader(hname, headers[i].getValue());
+    }
+    InputStream responseStream = httpResp.getEntity().getContent();
+    if (responseStream == null || resp.getOutputStream() == null) return;
+    ByteUtil.copy(httpResp.getEntity().getContent(), false, resp.getOutputStream(), false);
+  }
+
+  protected boolean isAdminRequest(HttpServletRequest req) throws ServiceException {
+    int adminPort =
+        Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraAdminPort, -1);
+    if (req.getLocalPort() == adminPort) {
+      // can still be in offline server where port=adminPort
+      int mailPort =
+          Provisioning.getInstance().getLocalServer().getIntAttr(Provisioning.A_zimbraMailPort, -1);
+      if (mailPort == adminPort) // we are in offline, so check cookie
+      return getAdminAuthTokenFromCookie(req) != null;
+      else return true;
+    }
+    return false;
+  }
+
+  public AuthToken cookieAuthRequest(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServiceException {
+    AuthToken at =
+        isAdminRequest(req)
+            ? getAdminAuthTokenFromCookie(req, resp, true)
+            : getAuthTokenFromCookie(req, resp, true);
+    return at;
+  }
+
+  /**
+   * Note that if this method returns null, it isn't clear whether resp.sendError has been called or
+   * not. For that reason, it has been deprecated. Believe there is no Zimbra code which still calls
+   * it but left in case customization code uses it.
+   */
+  @Deprecated
+  public Account basicAuthRequest(
+      HttpServletRequest req, HttpServletResponse resp, boolean sendChallenge)
+      throws IOException, ServiceException {
+    return AuthUtil.basicAuthRequest(req, resp, this, sendChallenge);
+  }
+
+  public static String getAccountPath(Account acct) {
+    return "/" + acct.getName();
+  }
+
+  public static String getServiceUrl(Account acct, String path) throws ServiceException {
+    Provisioning prov = Provisioning.getInstance();
+    Server server = prov.getServer(acct);
+
+    if (server == null) {
+      throw ServiceException.FAILURE(
+          "unable to retrieve server for account" + acct.getName(), null);
+    }
+
+    return getServiceUrl(server, prov.getDomain(acct), path + getAccountPath(acct));
+  }
+
+  public static String getServiceUrl(Server server, Domain domain, String path)
+      throws ServiceException {
+    return URLUtil.getPublicURLForDomain(server, domain, path, true);
+  }
+
+  protected static String getProxyUrl(HttpServletRequest req, Server server, String path)
+      throws ServiceException {
+    int servicePort = (req == null) ? -1 : req.getLocalPort();
+    Provisioning prov = Provisioning.getInstance();
+    Server localServer = prov.getLocalServer();
+    if (!prov.isOfflineProxyServer(server)
+        && servicePort == localServer.getIntAttr(Provisioning.A_zimbraAdminPort, 0))
+      return URLUtil.getAdminURL(server, path);
+    else
+      return URLUtil.getServiceURL(
+          server, path, servicePort == localServer.getIntAttr(Provisioning.A_zimbraMailSSLPort, 0));
+  }
+
+  protected void returnError(HttpServletResponse resp, ServiceException e) {
+    resp.setHeader(ZIMBRA_FAULT_CODE_HEADER, e.getCode());
+    resp.setHeader(ZIMBRA_FAULT_MESSAGE_HEADER, e.getMessage());
+    resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  public static String getOrigIp(HttpServletRequest req) {
+    RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
+    return remoteIp.getOrigIP();
+  }
+
+  public static String getClientIp(HttpServletRequest req) {
+    RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
+    return remoteIp.getClientIP();
+  }
+
+  public static void addRemoteIpToLoggingContext(HttpServletRequest req) {
+    RemoteIP remoteIp = new RemoteIP(req, getTrustedIPs());
+    remoteIp.addToLoggingContext();
+  }
+
+  public static RemoteIP.TrustedIPs getTrustedIPs() {
+    try {
+      final Provisioning prov = Provisioning.getInstance();
+      final Server server = prov.getLocalServer();
+      List<String> trustedIps =
+          new ArrayList<>(Arrays.asList(server.getMultiAttr(Provisioning.A_zimbraMailTrustedIP)));
+
+      prov.getAllServers(Provisioning.SERVICE_PROXY)
+          .forEach(
+              proxyServer -> {
+                try {
+                  final String serverIp = proxyServer.getIPAddress();
+                  if (!Objects.equals(serverIp, "")) {
+                    trustedIps.add(serverIp);
+                  }
+                } catch (UnknownHostException ex) {
+                  ZimbraLog.misc.warn("failed to get proxy IPs, skipping.", ex);
+                  ex.printStackTrace();
+                }
+              });
+      return new RemoteIP.TrustedIPs(trustedIps.toArray(new String[trustedIps.size()]));
+    } catch (ServiceException e) {
+      ZimbraLog.misc.warn("failed to get trusted IPs, only localhost will be trusted", e);
+    }
+    return new RemoteIP.TrustedIPs(null);
+  }
+
+  public static void addUAToLoggingContext(HttpServletRequest req) {
+    ZimbraLog.addUserAgentToContext(req.getHeader("User-Agent"));
+  }
 }

--- a/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
+++ b/store/src/java/com/zimbra/cs/servlet/ZimbraServlet.java
@@ -558,7 +558,7 @@ public class ZimbraServlet extends HttpServlet {
                   Try.of(proxyServer::getIPAddress)
                       .andThen(
                           serverIp -> {
-                            if (!Objects.equals(serverIp, "")) {
+                            if (!Objects.isNull(serverIp) && !Objects.equals(serverIp, "")) {
                               trustedIps.add(serverIp);
                             }
                           })


### PR DESCRIPTION
### Goal

When an http call is received through the proxy, the original client Ip is stored in X-Forwarded-For header (see: https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/).
**In order to propagate the original client ip to the context, the proxy ip address mus be trusted** by adding it to zimbraTrustedIp attribute (see: https://wiki.zimbra.com/wiki/Zimbra_Proxy_Manual:Miscellaneous_Topics).
**We want to automatically trust the proxy ip.**

### What's changed
I have modified the Server class to return the server hostname and its ip address by lazy-loading it, since a DNS resolution is required.
The static method ZimbraServlet#getTrustedIps now returns also the proxy ip address.