### PR TITLE
chore(CI): jdk11-headless is already included in the agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,6 @@ pipeline {
             stage('Build') {
             steps {
 
-                sh 'sudo apt-get update && sudo apt-get install -yqq openjdk-11-jdk-headless'
-
                 mvnCmd("$BUILD_PROPERTIES_PARAMS -DskipTests=true clean package")
 
                 sh 'mkdir staging'


### PR DESCRIPTION
This will reduce CI time of a minute or less.
Instead of updating at build time, an agent update would be recommended
My 2 cents to the maven effort