### PR TITLE
feat: [CO-378] add proxy ip to log

### DIFF
--- a/common/ivy.xml
+++ b/common/ivy.xml
@@ -5,6 +5,13 @@
     <include file="../ivy-configuration.xml"/>
   </configurations>
   <dependencies>
+    <!-- Testing -->
+    <dependency org="junit" name="junit" rev="4.8.2" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-core" rev="4.4.0" conf="test->default"/>
+    <dependency org="net.bytebuddy" name="byte-buddy" rev="1.12.8" conf="test->default"/>
+    <dependency org="net.bytebuddy" name="byte-buddy-agent" rev="1.12.8" conf="test->default"/>
+    <dependency org="org.objenesis" name="objenesis" rev="1.2"/>
+    <!-- Production -->
     <dependency org="commons-codec" name="commons-codec" rev="1.7" />
     <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
     <dependency org="commons-lang" name="commons-lang" rev="2.6" />
@@ -15,7 +22,6 @@
     <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="${httpclient.httpcore.version}" />
     <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
     <dependency org="ical4j" name="ical4j" rev="0.9.16-patched" />
-    <dependency org="junit" name="junit" rev="4.8.2" conf="test->default"/>
     <dependency org="log4j" name="log4j" rev="1.2.16" />
     <dependency org="javax.mail" name="mail" rev="1.4.5" />
     <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.22" />

--- a/common/src/java-test/com/zimbra/common/util/RemoteIPIT.java
+++ b/common/src/java-test/com/zimbra/common/util/RemoteIPIT.java
@@ -1,0 +1,67 @@
+package com.zimbra.common.util;
+
+import static com.zimbra.common.util.RemoteIP.X_ORIGINATING_IP_HEADER;
+import static com.zimbra.common.util.RemoteIP.X_ORIGINATING_PORT_HEADER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.zimbra.common.util.RemoteIP.TrustedIPs;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RemoteIPIT {
+
+  @Before
+  public void clearLogContext() {
+    ZimbraLog.clearContext();
+  }
+
+  @Test
+  public void shouldAddClientIpAndPortToLogWhenNotLocalhost() {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final String remoteAddr = "192.168.10.7";
+    final int remotePort = 8080;
+    when(httpServletRequest.getRemoteAddr()).thenReturn(remoteAddr);
+    when(httpServletRequest.getRemotePort()).thenReturn(remotePort);
+    new RemoteIP(httpServletRequest, new TrustedIPs(new String[] {})).addToLoggingContext();
+    final String contextString = ZimbraLog.getContextString();
+    Assert.assertEquals("ip=" + remoteAddr + ";port=" + remotePort + ";", contextString);
+  }
+
+  @Test
+  public void shouldNotAddClientIpAndClientPortWhenRemoteAddressLocalhost() {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final String remoteAddr = "127.0.0.1";
+    final int remotePort = 8080;
+    when(httpServletRequest.getRemoteAddr()).thenReturn(remoteAddr);
+    when(httpServletRequest.getRemotePort()).thenReturn(remotePort);
+    new RemoteIP(httpServletRequest, new TrustedIPs(new String[] {})).addToLoggingContext();
+    final String contextString = ZimbraLog.getContextString();
+    Assert.assertNull(contextString);
+  }
+
+  @Test
+  public void shouldAddOrigIpAndOrigPortWhenRemoteAddressTrusted() {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final String remoteAddr = "172.18.18.20";
+    final int remotePort = 8080;
+    final String origIp = "192.168.10.7";
+    final int origPort = 9090;
+
+    when(httpServletRequest.getRemoteAddr()).thenReturn(remoteAddr);
+    when(httpServletRequest.getRemotePort()).thenReturn(remotePort);
+    when(httpServletRequest.getHeader(X_ORIGINATING_IP_HEADER)).thenReturn(origIp);
+    when(httpServletRequest.getHeader(X_ORIGINATING_PORT_HEADER))
+        .thenReturn(Integer.toString(origPort));
+    new RemoteIP(httpServletRequest, new TrustedIPs(new String[] {remoteAddr}))
+        .addToLoggingContext();
+    final String contextString = ZimbraLog.getContextString();
+    // Logging context is unordered, so no way to assert equals
+    Assert.assertTrue(contextString.contains("ip=" + remoteAddr));
+    Assert.assertTrue(contextString.contains("port=" + remotePort));
+    Assert.assertTrue(contextString.contains("oport=" + origPort));
+    Assert.assertTrue(contextString.contains("oip=" + origIp));
+  }
+}

--- a/common/src/java/com/zimbra/common/util/RemoteIP.java
+++ b/common/src/java/com/zimbra/common/util/RemoteIP.java
@@ -3,178 +3,160 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-package
-com.zimbra.common.util;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
+package com.zimbra.common.util;
 
 import com.zimbra.common.localconfig.LC;
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
 
 public class RemoteIP {
 
-    public static final String X_ORIGINATING_IP_HEADER = LC.zimbra_http_originating_ip_header.value();
-    public static final String X_ORIGINATING_PORT_HEADER = "X-Forwarded-Port";
-    public static final String X_ORIGINATING_PROTOCOL_HEADER = "X-Forwarded-Proto";
+  public static final String X_ORIGINATING_IP_HEADER = LC.zimbra_http_originating_ip_header.value();
+  public static final String X_ORIGINATING_PORT_HEADER = "X-Forwarded-Port";
+  public static final String X_ORIGINATING_PROTOCOL_HEADER = "X-Forwarded-Proto";
 
-    /**
-     * IP of the http client, Should be always present.
-     */
-    private String mClientIP;
+  /** IP of the http client, Should be always present. */
+  private String mClientIP;
 
-    /**
-     * port of the http client, Should be always present.
-     */
-    private int mClientPort;
+  /** port of the http client, Should be always present. */
+  private int mClientPort;
 
-    /**
-     * IP of the originating client. It can be null.
-     */
-    private String mOrigIP;
+  /** IP of the originating client. It can be null. */
+  private String mOrigIP;
 
-    /**
-     * Port of the originating client. Can be null.
-     */
-    private Integer mOrigPort;
+  /** Port of the originating client. Can be null. */
+  private Integer mOrigPort;
 
-    /**
-     * It can be the IP of the http client, or in the presence of a real origin IP address http header(header specified
-     * in the LC key zimbra_http_originating_ip_header) the IP of the real origin client if the http client is in a
-     * trusted network.
-     *
-     * Should be always present.
-     */
-    private String mRequestIP;
+  /**
+   * It can be the IP of the http client, or in the presence of a real origin IP address http
+   * header(header specified in the LC key zimbra_http_originating_ip_header) the IP of the real
+   * origin client if the http client is in a trusted network.
+   *
+   * <p>Should be always present.
+   */
+  private String mRequestIP;
 
-    /**
-     * Port number of the http client.
-     */
-    private Integer mRequestPort;
+  /** Port number of the http client. */
+  private Integer mRequestPort;
 
-    /**
-     * Original protocol of the request.
-     */
-    private String mOrigProto;
+  /** Original protocol of the request. */
+  private String mOrigProto;
 
-    public RemoteIP(HttpServletRequest req, TrustedIPs trustedIPs) {
-        mClientIP = req.getRemoteAddr();
-        mClientPort = req.getRemotePort();
+  public RemoteIP(HttpServletRequest req, TrustedIPs trustedIPs) {
+    mClientIP = req.getRemoteAddr();
+    mClientPort = req.getRemotePort();
 
-        if (trustedIPs.isIpTrusted(mClientIP)) {
-            mOrigIP = req.getHeader(X_ORIGINATING_IP_HEADER);
-            String origPort = req.getHeader(X_ORIGINATING_PORT_HEADER);
-            if (origPort != null) {
-                try {
-                    mOrigPort = Integer.parseInt(origPort);
-                } catch (NumberFormatException e) {
-                    // ignore bad header
-                }
-            }
-
-            mOrigProto = req.getHeader(X_ORIGINATING_PROTOCOL_HEADER);
+    if (trustedIPs.isIpTrusted(mClientIP)) {
+      mOrigIP = req.getHeader(X_ORIGINATING_IP_HEADER);
+      String origPort = req.getHeader(X_ORIGINATING_PORT_HEADER);
+      if (origPort != null) {
+        try {
+          mOrigPort = Integer.parseInt(origPort);
+        } catch (NumberFormatException e) {
+          // ignore bad header
         }
+      }
 
-        if (mOrigPort != null) {
-            mRequestPort = mOrigPort;
-        } else {
-            mRequestPort = mClientPort;
+      mOrigProto = req.getHeader(X_ORIGINATING_PROTOCOL_HEADER);
+    }
+
+    if (mOrigPort != null) {
+      mRequestPort = mOrigPort;
+    } else {
+      mRequestPort = mClientPort;
+    }
+
+    if (mOrigIP != null) {
+      mRequestIP = mOrigIP;
+    } else {
+      mRequestIP = mClientIP;
+    }
+  }
+
+  public String getClientIP() {
+    return mClientIP;
+  }
+
+  public String getOrigIP() {
+    return mOrigIP;
+  }
+
+  public String getRequestIP() {
+    return mRequestIP;
+  }
+
+  public Integer getOrigPort() {
+    return mOrigPort;
+  }
+
+  public Integer getRequestPort() {
+    return mRequestPort;
+  }
+
+  public Integer getClientPort() {
+    return mClientPort;
+  }
+
+  public String getOrigProto() {
+    return mOrigProto;
+  }
+
+  public void addToLoggingContext() {
+    if (mOrigIP != null) {
+      ZimbraLog.addOrigIpToContext(mOrigIP);
+    }
+
+    if (mOrigPort != null) {
+      ZimbraLog.addOrigPortToContext(mOrigPort);
+    }
+
+    if (mOrigProto != null) {
+      ZimbraLog.addOrigProtoToContext(mOrigProto);
+    }
+    // don't log client's IP or client's port if client's IP is localhost
+    if (!TrustedIPs.isLocalhost(mClientIP)) {
+      if (mClientIP != null) {
+        ZimbraLog.addIpToContext(mClientIP);
+      }
+      if (mClientPort != 0) {
+        ZimbraLog.addPortToContext(mClientPort);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "RemoteIP [mClientIP=%s, mOrigIP=%s, mRequestIP=%s] : RemotePort [mClientPort=%d,"
+            + " mOrigPort=%d, mRequestPort=%d] mOrigProto=%s",
+        mClientIP, mOrigIP, mRequestIP, mClientPort, mOrigPort, mRequestPort, mOrigProto);
+  }
+
+  public static class TrustedIPs {
+    private static final String IP_LOCALHOST = "127.0.0.1";
+
+    private Set<String> mTrustedIPs = new HashSet<String>();
+
+    public TrustedIPs(String[] ips) {
+      if (ips != null) {
+        for (String ip : ips) {
+          if (!StringUtil.isNullOrEmpty(ip)) mTrustedIPs.add(ip);
         }
-
-        if (mOrigIP != null) {
-            mRequestIP = mOrigIP;
-        } else {
-            mRequestIP = mClientIP;
-        }
+      }
     }
 
-    public String getClientIP() {
-        return mClientIP;
+    public boolean isIpTrusted(String ip) {
+      return isLocalhost(ip) || mTrustedIPs.contains(ip);
     }
 
-    public String getOrigIP() {
-        return mOrigIP;
-    }
-
-    public String getRequestIP() {
-        return mRequestIP;
-    }
-
-    public Integer getOrigPort() {
-        return mOrigPort;
-    }
-
-    public Integer getRequestPort() {
-        return mRequestPort;
-    }
-
-    public Integer getClientPort() {
-        return mClientPort;
-    }
-
-    public String getOrigProto() {
-        return mOrigProto;
-    }
-
-    public void addToLoggingContext() {
-        if (mOrigIP != null) {
-            ZimbraLog.addOrigIpToContext(mOrigIP);
-        }
-
-        if (mOrigPort != null) {
-            ZimbraLog.addOrigPortToContext(mOrigPort);
-        }
-
-        if (mOrigProto != null) {
-            ZimbraLog.addOrigProtoToContext(mOrigProto);
-        }
-
-        // don't log client's IP or client's port if original IP/port are present or if client's IP is localhost
-        if (!TrustedIPs.isLocalhost(mClientIP)) {
-            if (mOrigIP == null) {
-                ZimbraLog.addIpToContext(mClientIP);
-            }
-            if (mOrigPort == null) {
-                ZimbraLog.addPortToContext(mClientPort);
-            }
-        }
+    private static boolean isLocalhost(String ip) {
+      return IP_LOCALHOST.equals(ip);
     }
 
     @Override
     public String toString() {
-        return String
-                .format("RemoteIP [mClientIP=%s, mOrigIP=%s, mRequestIP=%s] : RemotePort [mClientPort=%d, mOrigPort=%d, mRequestPort=%d] mOrigProto=%s",
-                        mClientIP, mOrigIP, mRequestIP, mClientPort, mOrigPort, mRequestPort, mOrigProto);
+      return "TrustedIPs [mTrustedIPs=" + mTrustedIPs + "]";
     }
-
-    public static class TrustedIPs {
-        private static final String IP_LOCALHOST = "127.0.0.1";
-
-        private Set<String> mTrustedIPs = new HashSet<String>();
-
-        public TrustedIPs(String[] ips) {
-            if (ips != null) {
-                for (String ip : ips) {
-                    if (!StringUtil.isNullOrEmpty(ip))
-                        mTrustedIPs.add(ip);
-                }
-            }
-        }
-
-        public boolean isIpTrusted(String ip) {
-            return isLocalhost(ip) || mTrustedIPs.contains(ip);
-        }
-
-        private static boolean isLocalhost(String ip) {
-            return IP_LOCALHOST.equals(ip);
-        }
-
-        @Override
-        public String toString() {
-            return "TrustedIPs [mTrustedIPs=" + mTrustedIPs + "]";
-        }
-
-    }
-
+  }
 }


### PR DESCRIPTION
When OrigIp and OrigPort are not null or the remote address is localhost, remote address and port do not get logged.
In case of requests coming from of a trusted proxy the result is only the client ip and port get logged, but not the proxy server ip and port.

This PRs is to always add remote address and port, except when the remote address is localhost.