### PR TITLE
feat: [CO-377] hostname validation

### DIFF
--- a/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -121,21 +121,17 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldUpdateVirtualHostnamesAndPublicServiceHostnameIfDomainNameChanges()
-      throws ServiceException {
+  public void shouldThrowDomainNameImmutableWhenModifyingDomainName() throws ServiceException {
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage(ZAttrProvisioning.A_zimbraDomainName + " cannot be changed.");
     final String domainName = "demo3.zextras.io";
     final String newDomainName = "newDemo3.zextras.io";
-    final String pubServiceHostname = "public." + domainName;
-    final String[] virtualHostnames =
-        new String[] {"virtual1." + domainName, "virtual2." + domainName};
     final Domain domain =
         provisioning.createDomain(
             domainName,
             new HashMap<>() {
               {
                 put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-                put(ZAttrProvisioning.A_zimbraPublicServiceHostname, pubServiceHostname);
-                put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostnames);
               }
             });
     final Account adminAccount = createDelegatedAdminForDomain(domain);
@@ -149,12 +145,5 @@ public class ModifyDomainIT {
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertNull(provisioning.getDomainByName(domainName));
-    final Domain updatedDomain = provisioning.getDomainByName(newDomainName);
-    assertEquals("public." + newDomainName, updatedDomain.getPublicServiceHostname());
-    assertEquals(newDomainName, updatedDomain.getDomainName());
-    final String[] expectedVirtualHostnames =
-        new String[] {"virtual1." + newDomainName, "virtual2." + newDomainName};
-    assertEquals(expectedVirtualHostnames, updatedDomain.getVirtualHostname());
   }
 }

--- a/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -70,11 +70,8 @@ public class ModifyDomainIT {
     final String newPubServiceHostname = "this.domain.iz.fake";
     expectedEx.expect(ServiceException.class);
     expectedEx.expectMessage(
-        "Public service hostname "
-            + newPubServiceHostname
-            + " must be complaint with domain "
-            + domainName
-            + ".");
+        "Public service hostname must be a valid FQDN and compatible with current domain (or its"
+            + " aliases).");
     final Domain domain =
         provisioning.createDomain(
             domainName,
@@ -195,12 +192,14 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldThrowExceptionIfVirtualHostnameNotCompliantWithDomain()
+  public void shouldThrowServiceExceptionIfVirtualHostnameNotCompliantWithDomain()
       throws ServiceException {
     final String domainName = UUID.randomUUID() + ".zextras.io";
     final String virtualHostname = "virtual.whatever.not.compliant";
     expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage("Virtual hostnames must be complaint with domain " + domainName + ".");
+    expectedEx.expectMessage(
+        "Virtual hostnames must be valid FQDNs and compatible with current domain (or its"
+            + " aliases).");
     final Domain domain =
         provisioning.createDomain(
             domainName,

--- a/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/java-test/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -1,0 +1,160 @@
+package com.zimbra.cs.service.admin;
+
+import static org.junit.Assert.*;
+
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.ModifyDomainRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ModifyDomainIT {
+
+  private static Provisioning provisioning;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    MailboxTestUtil.initServer();
+    provisioning = Provisioning.getInstance();
+  }
+
+  @Rule public ExpectedException expectedEx = ExpectedException.none();
+
+  private Account createDelegatedAdminForDomain(Domain domain) throws ServiceException {
+    return provisioning.createAccount(
+        "admin@" + domain.getDomainName(),
+        "testPwd",
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
+            put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
+          }
+        });
+  }
+
+  private HashMap<String, Object> getSoapContextFromAccount(Account account)
+      throws ServiceException {
+    return new HashMap<String, Object>() {
+      {
+        put(
+            SoapEngine.ZIMBRA_CONTEXT,
+            new ZimbraSoapContext(
+                AuthProvider.getAuthToken(account, true),
+                account.getId(),
+                SoapProtocol.Soap12,
+                SoapProtocol.Soap12));
+      }
+    };
+  }
+
+  @Test
+  public void shouldThrowServiceExceptionIfPublicServiceHostnameNotSubdomainOfDomainName()
+      throws ServiceException {
+    final String domainName = "demo.zextras.io";
+    final String newPubServiceHostname = "this.domain.iz.fake";
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage(
+        "Public service hostname "
+            + newPubServiceHostname
+            + " must be subdomain of "
+            + domainName
+            + ".");
+    final Domain domain =
+        provisioning.createDomain(
+            domainName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+              }
+            });
+    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, newPubServiceHostname);
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+  }
+
+  @Test
+  public void shouldUpdatePublicServiceHostnameIfSubdomainOfDomainName() throws ServiceException {
+    final String domainName = "demo2.zextras.io";
+    final String newPubServiceHostname = "this.domain.is.legit.demo2.zextras.io";
+    final Domain domain =
+        provisioning.createDomain(
+            domainName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+              }
+            });
+    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, newPubServiceHostname);
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(
+        newPubServiceHostname, provisioning.getDomainByName(domainName).getPublicServiceHostname());
+  }
+
+  @Test
+  public void shouldUpdateVirtualHostnamesAndPublicServiceHostnameIfDomainNameChanges()
+      throws ServiceException {
+    final String domainName = "demo3.zextras.io";
+    final String newDomainName = "newDemo3.zextras.io";
+    final String pubServiceHostname = "public." + domainName;
+    final String[] virtualHostnames =
+        new String[] {"virtual1." + domainName, "virtual2." + domainName};
+    final Domain domain =
+        provisioning.createDomain(
+            domainName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+                put(ZAttrProvisioning.A_zimbraPublicServiceHostname, pubServiceHostname);
+                put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostnames);
+              }
+            });
+    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraDomainName, newDomainName);
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertNull(provisioning.getDomainByName(domainName));
+    final Domain updatedDomain = provisioning.getDomainByName(newDomainName);
+    assertEquals("public." + newDomainName, updatedDomain.getPublicServiceHostname());
+    assertEquals(newDomainName, updatedDomain.getDomainName());
+    final String[] expectedVirtualHostnames =
+        new String[] {"virtual1." + newDomainName, "virtual2." + newDomainName};
+    assertEquals(expectedVirtualHostnames, updatedDomain.getVirtualHostname());
+  }
+}

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -69,18 +69,16 @@ public class ModifyDomain extends AdminDocumentHandler {
     if (!Objects.isNull(gotPublicServiceHostname)
         && !(isPublicServiceHostnameCompliant(domain, gotPublicServiceHostname))) {
       throw ServiceException.FAILURE(
-          "Public service hostname "
-              + gotPublicServiceHostname
-              + " must be complaint with domain "
-              + domain.getDomainName()
-              + ".");
+          "Public service hostname must be a valid FQDN and compatible with current domain (or its"
+              + " aliases).");
     }
     final String[] gotVirtualHostNames = getVirtualHostnamesFromAttributes(attrs);
     if (!(Objects.isNull(gotVirtualHostNames))
         && !(areVirtualHostnamesCompliant(
             domain, Arrays.stream(gotVirtualHostNames).collect(Collectors.toList())))) {
       throw ServiceException.FAILURE(
-          "Virtual hostnames must be complaint with domain " + domain.getDomainName() + ".");
+          "Virtual hostnames must be valid FQDNs and compatible with current domain (or its"
+              + " aliases).");
     }
 
     // pass in true to checkImmutable

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -9,6 +9,7 @@
 package com.zimbra.cs.service.admin;
 
 import com.zimbra.common.account.Key;
+import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
@@ -20,81 +21,150 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.soap.ZimbraSoapContext;
-
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author schemers
  */
 public class ModifyDomain extends AdminDocumentHandler {
 
-    public boolean domainAuthSufficient(Map context) {
-        return true;
+  public boolean domainAuthSufficient(Map context) {
+    return true;
+  }
+
+  public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+
+    ZimbraSoapContext zsc = getZimbraSoapContext(context);
+    Provisioning prov = Provisioning.getInstance();
+
+    String id = request.getAttribute(AdminConstants.E_ID);
+    Map<String, Object> attrs = AdminService.getAttrs(request);
+
+    Domain domain = prov.get(Key.DomainBy.id, id);
+    if (domain == null) throw AccountServiceException.NO_SUCH_DOMAIN(id);
+
+    if (domain.isShutdown())
+      throw ServiceException.PERM_DENIED(
+          "can not access domain, domain is in " + domain.getDomainStatusAsString() + " status");
+
+    checkDomainRight(zsc, domain, attrs);
+
+    // check to see if domain default cos is being changed, need right on new cos
+    checkCos(zsc, attrs, Provisioning.A_zimbraDomainDefaultCOSId);
+    checkCos(zsc, attrs, Provisioning.A_zimbraDomainDefaultExternalUserCOSId);
+
+    final String gotPubServiceHostname =
+        (String) attrs.get(Provisioning.A_zimbraPublicServiceHostname);
+    final String gotDomainName = (String) attrs.get(Provisioning.A_zimbraDomainName);
+    if (!Objects.isNull(gotPubServiceHostname)) {
+      checkPublicServiceHostname(domain, gotPubServiceHostname);
     }
-    
-	public Element handle(Element request, Map<String, Object> context) throws ServiceException {
-
-        ZimbraSoapContext zsc = getZimbraSoapContext(context);
-	    Provisioning prov = Provisioning.getInstance();
-
-	    String id = request.getAttribute(AdminConstants.E_ID);
-	    Map<String, Object> attrs = AdminService.getAttrs(request);
-	    
-	    Domain domain = prov.get(Key.DomainBy.id, id);
-        if (domain == null)
-            throw AccountServiceException.NO_SUCH_DOMAIN(id);
-        
-        if (domain.isShutdown())
-            throw ServiceException.PERM_DENIED("can not access domain, domain is in " + domain.getDomainStatusAsString() + " status");
-        
-        checkDomainRight(zsc, domain, attrs);
-        
-        // check to see if domain default cos is being changed, need right on new cos 
-        checkCos(zsc, attrs, Provisioning.A_zimbraDomainDefaultCOSId);
-        checkCos(zsc, attrs, Provisioning.A_zimbraDomainDefaultExternalUserCOSId);
-
-        // pass in true to checkImmutable
-        prov.modifyAttrs(domain, attrs, true);
-
-        ZimbraLog.security.info(ZimbraLog.encodeAttrs(
-                new String[] {"cmd", "ModifyDomain","name", domain.getName()}, attrs));	    
-
-        Element response = zsc.createElement(AdminConstants.MODIFY_DOMAIN_RESPONSE);
-	    GetDomain.encodeDomain(response, domain);
-	    return response;
-	}
-	
-    private void checkCos(ZimbraSoapContext zsc, Map<String, Object> attrs, String defaultCOSIdAttrName)
-            throws ServiceException {
-        String newDomainCosId = ModifyAccount.getStringAttrNewValue(defaultCOSIdAttrName, attrs);
-        if (newDomainCosId == null)
-            return;  // not changing it
-        
-        Provisioning prov = Provisioning.getInstance();
-        if (newDomainCosId.equals("")) {
-            // they are unsetting it, no problem
-            return; 
-        } 
-
-        Cos cos = prov.get(Key.CosBy.id, newDomainCosId);
-        if (cos == null) {
-            throw AccountServiceException.NO_SUCH_COS(newDomainCosId);
-        }
-        
-        // call checkRight instead of checkCosRight, because:
-        // 1. no domain based access manager backward compatibility issue
-        // 2. we only want to check right if we are using pure ACL based access manager. 
-        checkRight(zsc, cos, Admin.R_assignCos);
+    if (!Objects.isNull(gotDomainName)) {
+      attrs.putAll(getAttributesToUpdateFromNewDomain(domain, gotDomainName));
     }
-	
-    @Override
-    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
-        notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY, 
-                Admin.R_modifyDomain.getName(), "domain"));
-        
-        notes.add("Notes on " + Provisioning.A_zimbraDomainDefaultCOSId + ": " +
-                "If setting " + Provisioning.A_zimbraDomainDefaultCOSId + ", needs the " + Admin.R_assignCos.getName() + 
-                " right on the cos.");
+
+    // pass in true to checkImmutable
+    prov.modifyAttrs(domain, attrs, true);
+
+    ZimbraLog.security.info(
+        ZimbraLog.encodeAttrs(
+            new String[] {"cmd", "ModifyDomain", "name", domain.getName()}, attrs));
+
+    Element response = zsc.createElement(AdminConstants.MODIFY_DOMAIN_RESPONSE);
+    GetDomain.encodeDomain(response, domain);
+    return response;
+  }
+
+  /**
+   * Checks that given publicServiceHostname is valid for a domain.
+   *
+   * @param domain domain being updated
+   * @param publicServiceHostname value to check against domain
+   * @throws ServiceException exception if public service hostname not valid
+   */
+  private void checkPublicServiceHostname(Domain domain, String publicServiceHostname)
+      throws ServiceException {
+    final String domainName = domain.getDomainName();
+    if (!publicServiceHostname.endsWith(domainName)) {
+      throw ServiceException.FAILURE(
+          "Public service hostname "
+              + publicServiceHostname
+              + " must be subdomain of "
+              + domainName
+              + ".");
     }
+  }
+
+  /**
+   * Returns a {@link Map} of attributes to be updated based on new given domain name. Returned
+   * attributes include only {@link ZAttrProvisioning#A_zimbraPublicServiceHostname} and {@link
+   * ZAttrProvisioning#A_zimbraVirtualHostname}.
+   *
+   * @param domain domain that is being updated
+   * @param newDomainName new domain name
+   * @return a map of attributes to update from new domain name
+   */
+  private Map<String, Object> getAttributesToUpdateFromNewDomain(
+      Domain domain, String newDomainName) {
+    final HashMap<String, Object> attrsToUpdate = new HashMap<>();
+    final String oldPubServiceHostname = domain.getPublicServiceHostname();
+    final String oldDomainName = domain.getDomainName();
+    final String newPubServiceHostname =
+        oldPubServiceHostname.substring(0, oldPubServiceHostname.lastIndexOf(oldDomainName))
+            + newDomainName;
+    attrsToUpdate.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, newPubServiceHostname);
+    final List<String> newVirtualHostnames = new ArrayList<>();
+    for (String virtualHostname : domain.getVirtualHostname()) {
+      newVirtualHostnames.add(
+          virtualHostname.substring(0, virtualHostname.lastIndexOf(oldDomainName)) + newDomainName);
+    }
+    if (!newVirtualHostnames.isEmpty()) {
+      attrsToUpdate.put(ZAttrProvisioning.A_zimbraVirtualHostname, newVirtualHostnames);
+    }
+    return attrsToUpdate;
+  }
+
+  private void checkCos(
+      ZimbraSoapContext zsc, Map<String, Object> attrs, String defaultCOSIdAttrName)
+      throws ServiceException {
+    String newDomainCosId = ModifyAccount.getStringAttrNewValue(defaultCOSIdAttrName, attrs);
+    if (newDomainCosId == null) return; // not changing it
+
+    Provisioning prov = Provisioning.getInstance();
+    if (newDomainCosId.equals("")) {
+      // they are unsetting it, no problem
+      return;
+    }
+
+    Cos cos = prov.get(Key.CosBy.id, newDomainCosId);
+    if (cos == null) {
+      throw AccountServiceException.NO_SUCH_COS(newDomainCosId);
+    }
+
+    // call checkRight instead of checkCosRight, because:
+    // 1. no domain based access manager backward compatibility issue
+    // 2. we only want to check right if we are using pure ACL based access manager.
+    checkRight(zsc, cos, Admin.R_assignCos);
+  }
+
+  @Override
+  public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+    notes.add(
+        String.format(
+            AdminRightCheckPoint.Notes.MODIFY_ENTRY, Admin.R_modifyDomain.getName(), "domain"));
+
+    notes.add(
+        "Notes on "
+            + Provisioning.A_zimbraDomainDefaultCOSId
+            + ": "
+            + "If setting "
+            + Provisioning.A_zimbraDomainDefaultCOSId
+            + ", needs the "
+            + Admin.R_assignCos.getName()
+            + " right on the cos.");
+  }
 }

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -105,14 +105,15 @@ public class ModifyDomain extends AdminDocumentHandler {
   }
 
   /**
-   * Checks if a given FQDN is compliant for a domain.
+   * Checks if a given FQDN is compliant for a domain. FQDN can be equal to domain or must be in
+   * subdomain-fashion style (e.g.: domain test.com -> fqdn web.test.com)
    *
    * @param domainName name of the domain
    * @param fqdn fqdn to test against domain
    * @return id public service hostname compliant
    */
   private boolean isFQDNCompliant(String domainName, String fqdn) {
-    return fqdn.endsWith(domainName);
+    return Objects.equals(domainName, fqdn) || fqdn.endsWith("." + domainName);
   }
 
   /**

--- a/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -82,7 +82,6 @@ public class ModifyDomain extends AdminDocumentHandler {
       throw ServiceException.FAILURE(
           "Virtual hostnames must be complaint with domain " + domain.getDomainName() + ".");
     }
-    ;
 
     // pass in true to checkImmutable
     prov.modifyAttrs(domain, attrs, true);


### PR DESCRIPTION
### Goal
Domain **VirtualHostnames** and **PublicServiceHostname** must be **compliant with domain name**.
**Same rules must apply also for alias domain.**

### What's changed
This PR introduces some checks on virtualHostnames and publicServiceHostname when updating a domain through ModifyDomain.

- validation on publicServiceHostname when given (valid fqdn)
- validation on virtualHostnames when given (valid fqdn)
- **alias domain is treated just a specific type of domain**, so the same API applies. (**missing tests for alias, request them if you believe they are necessary**)
- Compliance error is as follows: "[Field name] must be a valid FQDN and compatible with current domain (or its aliases)".

**Edit: re-requesting review because I forgot to push the validation code for virtualHostnames.**
