### PR TITLE
fix(appserver-service): depends service-discover + pending-setups

### DIFF
--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -15,6 +15,10 @@ url="https://zextras.com"
 optdepends=(
   "carbonio-common-appserver-docs"
 )
+depends=(
+  "service-discover"
+  "pending-setups"
+)
 
 section="mail"
 priority="optional"


### PR DESCRIPTION
Since the package uses pending-setups and service-discover it should depend on them.

In some cases this can lead to errors (was not able to replicate them, but was reported), for example if pending-setups was not installed the package will try to install some files on directories defined by pending-setups.