### PR TITLE
fix:[CO-457] delete orphaned cert-key pair from domain SSL dir

### DIFF
--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2436,7 +2436,14 @@ public class ProxyConfGen {
                   "Will delete obsoleted domain %s file %s",
                   (fileName.endsWith(SSL_KEY_EXT) ? "key" : "cert"), fileName));
     } else {
-      filesInDirectory.forEach(Utils::deleteFileIfExists);
+      filesInDirectory.forEach(
+          filePath -> {
+            try {
+              Utils.deleteFileIfExists(filePath);
+            } catch (ProxyConfException e) {
+              LOG.info(e.getMessage());
+            }
+          });
     }
   }
 

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -327,11 +327,6 @@ public class ProxyConfGen {
    */
   public static void updateDomainCertificate(
       String domainName, String certificate, String privateKey) throws ProxyConfException {
-
-    if (certificate == null || privateKey == null) {
-      return;
-    }
-
     final File certificateFile =
         new File(Path.of(DOMAIN_SSL_DIR, domainName + SSL_CRT_EXT).toUri());
     final File privateKeyFile = new File(Path.of(DOMAIN_SSL_DIR, domainName + SSL_KEY_EXT).toUri());

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -36,6 +36,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 public class ProxyConfGen {
+
   static final String ZIMBRA_USER = "zextras";
   static final String ZIMBRA_UPSTREAM_NAME = "zimbra";
   static final String ZIMBRA_UPSTREAM_WEBCLIENT_NAME = "zimbra_webclient";
@@ -177,9 +178,10 @@ public class ProxyConfGen {
    * @author Davide Baldo
    */
   private static List<ServerAttrItem> loadServerAttrs() throws ServiceException {
-    if (!(mProv instanceof LdapProv))
+    if (!(mProv instanceof LdapProv)) {
       throw ServiceException.INVALID_REQUEST(
           "The method can work only when LDAP is available", null);
+    }
 
     final List<ServerAttrItem> serverAttrItems = new ArrayList<>();
     for (Server server : mProv.getAllServers()) {
@@ -206,9 +208,10 @@ public class ProxyConfGen {
     if (!mGenConfPerVhn) {
       return Collections.emptyList();
     }
-    if (!(mProv instanceof LdapProv))
+    if (!(mProv instanceof LdapProv)) {
       throw ServiceException.INVALID_REQUEST(
           "The method can work only when LDAP is available", null);
+    }
 
     final Set<String> attrsNeeded = new HashSet<>();
     attrsNeeded.add(ZAttrProvisioning.A_zimbraVirtualHostname);
@@ -324,6 +327,11 @@ public class ProxyConfGen {
    */
   public static void updateDomainCertificate(
       String domainName, String certificate, String privateKey) throws ProxyConfException {
+
+    if (certificate == null || privateKey == null) {
+      return;
+    }
+
     final File certificateFile =
         new File(Path.of(DOMAIN_SSL_DIR, domainName + SSL_CRT_EXT).toUri());
     final File privateKeyFile = new File(Path.of(DOMAIN_SSL_DIR, domainName + SSL_KEY_EXT).toUri());
@@ -375,7 +383,9 @@ public class ProxyConfGen {
 
   /* Guess how to find a server object -- taken from ProvUtil::guessServerBy */
   public static Key.ServerBy guessServerBy(String value) {
-    if (Provisioning.isUUID(value)) return Key.ServerBy.id;
+    if (Provisioning.isUUID(value)) {
+      return Key.ServerBy.id;
+    }
     return Key.ServerBy.name;
   }
 
@@ -657,7 +667,9 @@ public class ProxyConfGen {
       ArrayList<String> cache = new ArrayList<>(50);
       String line;
       while ((line = temp.readLine()) != null) {
-        if (!line.startsWith("#")) cache.add(line); // cache only non-comment lines
+        if (!line.startsWith("#")) {
+          cache.add(line); // cache only non-comment lines
+        }
       }
 
       for (ServerAttrItem server : filteredServers) {
@@ -810,7 +822,9 @@ public class ProxyConfGen {
     String line;
     ArrayList<String> cache = new ArrayList<>(50);
     while ((line = temp.readLine()) != null) {
-      if (!line.startsWith("#")) cache.add(line); // cache only non-comment lines
+      if (!line.startsWith("#")) {
+        cache.add(line); // cache only non-comment lines
+      }
       line = StringUtil.fillTemplate(line, mVars);
       conf.write(line);
       conf.newLine();
@@ -854,8 +868,9 @@ public class ProxyConfGen {
     SortedSet<String> sk = new TreeSet<>(mVars.keySet());
     for (String k : sk) {
       ProxyConfVar proxyConfVar = mConfVars.get(k);
-      if (proxyConfVar instanceof TimeInSecVarWrapper)
+      if (proxyConfVar instanceof TimeInSecVarWrapper) {
         proxyConfVar = ((TimeInSecVarWrapper) proxyConfVar).mVar;
+      }
       proxyConfVar.write(System.out);
     }
   }
@@ -2221,6 +2236,9 @@ public class ProxyConfGen {
 
       String clientCA = loadAllClientCertCA();
       writeClientCAtoFile(clientCA);
+
+      // cleanup DOMAIN_SSL_DIR
+      deleteObsoleteCertificateKeyPair(mDomainReverseProxyAttrs, mDryRun);
     } catch (ProxyConfException | ServiceException pe) {
       handleException(pe);
       exitCode = 1;
@@ -2399,6 +2417,32 @@ public class ProxyConfGen {
       }
     }
     return (exitCode);
+  }
+
+  /**
+   * Cleanup of Obsolete certificate-key file pair from {@link ProxyConfGen#DOMAIN_SSL_DIR}
+   *
+   * @param mDomainReverseProxyAttrs List<{@link DomainAttrItem}> domain attribute items collected
+   *     from domains
+   * @param dryRun if it's a dry run
+   * @author Keshav Bhatt
+   * @since 22.12.0
+   */
+  private static void deleteObsoleteCertificateKeyPair(
+      final List<DomainAttrItem> mDomainReverseProxyAttrs, final boolean dryRun) {
+    List<String> filesInDirectory = Utils.getFilesPathInDirectory(DOMAIN_SSL_DIR);
+    for (DomainAttrItem entry : mDomainReverseProxyAttrs) {
+      filesInDirectory.removeIf(filePath -> (filePath.contains(entry.domainName)));
+    }
+    if (dryRun) {
+      filesInDirectory.forEach(
+          fileName ->
+              LOG.info(
+                  "Will delete obsoleted domain %s file %s",
+                  (fileName.endsWith(SSL_KEY_EXT) ? "key" : "cert"), fileName));
+    } else {
+      filesInDirectory.forEach(Utils::deleteFileIfExists);
+    }
   }
 
   /**

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
@@ -3,11 +3,16 @@ package com.zimbra.cs.util.proxyconfgen;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.cs.account.Server;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class Utils {
 
@@ -48,5 +53,40 @@ public final class Utils {
     if (!directory.exists() && !directory.mkdirs()) {
       throw new ProxyConfException("Unable to create folder in " + folderPath);
     }
+  }
+
+  /**
+   * Delete a file specified by the given path
+   *
+   * @param filePath path of file to delete
+   * @author Keshav Bhatt
+   * @since 22.12.0
+   */
+  public static void deleteFileIfExists(final String filePath) {
+    File file = new File(filePath);
+    if (file.exists()) {
+      try {
+        Files.delete(file.toPath());
+      } catch (final IOException ignored) {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * get file paths from the given directory path
+   *
+   * @param directoryPath path to get directory
+   * @return String List of file paths
+   * @author Keshav Bhatt
+   * @since 22.12.0
+   */
+  public static List<String> getFilesPathInDirectory(final String directoryPath) {
+    try (Stream<Path> paths = Files.walk(Paths.get(directoryPath), 1)) {
+      return paths.filter(Files::isRegularFile).map(Path::toString).collect(Collectors.toList());
+    } catch (IOException ignored) {
+      // ignore
+    }
+    return List.of();
   }
 }

--- a/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
+++ b/store/src/java/com/zimbra/cs/util/proxyconfgen/Utils.java
@@ -62,19 +62,20 @@ public final class Utils {
    * @author Keshav Bhatt
    * @since 22.12.0
    */
-  public static void deleteFileIfExists(final String filePath) {
+  public static void deleteFileIfExists(final String filePath) throws ProxyConfException {
     File file = new File(filePath);
     if (file.exists()) {
       try {
         Files.delete(file.toPath());
-      } catch (final IOException ignored) {
-        // ignore
+      } catch (final IOException ie) {
+        throw new ProxyConfException("Unable to delete file " + filePath);
       }
     }
   }
 
   /**
-   * get file paths from the given directory path
+   * Get file paths from the given directory path Note: This will only return path of regular
+   * 'files' in the given directory path limiting the scan to depth -> 1
    *
    * @param directoryPath path to get directory
    * @return String List of file paths


### PR DESCRIPTION
**What has changed:**
- The domain SSL directory is cleaned to remove orphaned certificate key pair.

**Test:** Changes are manually tested, its really hard to write unit test for this class as
methods and members are static everywhere. 