### PR TITLE
fix: generate rights localconfig

### DIFF
--- a/store/build.xml
+++ b/store/build.xml
@@ -435,6 +435,7 @@
   <target name="generate-domainadmin-rights-xml" depends="compile">
     <java classname="com.zimbra.cs.account.accesscontrol.RightManager" fork="true" classpathref="run.class.path" failonerror="true">
       <sysproperty key="zimbra.version" value="${carbonio.buildinfo.all}"/>
+      <sysproperty key="zimbra.config" value="conf/localconfig-autogen.xml"/>
       <arg line="-a genDomainAdminSetAttrsRights -r ${conf.dir}/rights/rights-domainadmin.xml -t ${conf.dir}/rights/rights-domainadmin.xml-template"/>
     </java>
   </target>
@@ -442,14 +443,17 @@
   <target name="generate-rights-java" depends="compile">
     <java classname="com.zimbra.cs.account.accesscontrol.RightManager" fork="true" classpathref="run.class.path" failonerror="true">
       <sysproperty key="zimbra.version" value="${carbonio.buildinfo.all}"/>
+      <sysproperty key="zimbra.config" value="conf/localconfig-autogen.xml"/>
       <arg line="-a genRightConsts -i ${conf.dir}/rights -r ${src.java.dir}/com/zimbra/cs/account/accesscontrol/generated/RightConsts.java"/>
     </java>
     <java classname="com.zimbra.cs.account.accesscontrol.RightManager" fork="true" classpathref="run.class.path" failonerror="true">
       <sysproperty key="zimbra.version" value="${carbonio.buildinfo.all}"/>
+      <sysproperty key="zimbra.config" value="conf/localconfig-autogen.xml"/>
       <arg line="-a genAdminRights -i ${conf.dir}/rights -r ${src.java.dir}/com/zimbra/cs/account/accesscontrol/generated/AdminRights.java"/>
     </java>
     <java classname="com.zimbra.cs.account.accesscontrol.RightManager" fork="true" classpathref="run.class.path" failonerror="true">
       <sysproperty key="zimbra.version" value="${carbonio.buildinfo.all}"/>
+      <sysproperty key="zimbra.config" value="conf/localconfig-autogen.xml"/>
       <arg line="-a genUserRights -i ${conf.dir}/rights -r ${src.java.dir}/com/zimbra/cs/account/accesscontrol/generated/UserRights.java"/>
     </java>
   </target>
@@ -457,6 +461,7 @@
   <target name="generate-rights-message-properties" depends="compile">
     <java classname="com.zimbra.cs.account.accesscontrol.RightManager" fork="true" classpathref="run.class.path" failonerror="true">
       <sysproperty key="zimbra.version" value="${carbonio.buildinfo.all}"/>
+      <sysproperty key="zimbra.config" value="conf/localconfig-autogen.xml"/>
       <arg line="-a genMessageProperties -i ${conf.dir}/rights -r ${conf.dir}/msgs/ZsMsgRights.properties"/>
     </java>
   </target>

--- a/store/conf/localconfig-autogen.xml
+++ b/store/conf/localconfig-autogen.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!-- Used only for code autogen -->
+<localconfig>
+  <key name="zimbra_home">
+    <value>.</value>
+  </key>
+</localconfig>


### PR DESCRIPTION
### Issue
When calling generate-rights target from withing **store** module, the task tries to read localconfig under /opt/zextras.

### Proposed solution
By setting zimbra.config we can tell the class to **load the configuration from a specific file.**
This file contains minimal information: the zimbra_home path (as current directory). The reason is it will load attrs.xml definition defined in it.

These changes were already made in maven migration: https://github.com/Zextras/carbonio-mailbox/commit/6f6ec69f90ab2104bb9f7ae0498f010a21c14317