### PR TITLE
feat: [CO-477] Set default for 'catch-all messages' address in alias domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build.properties
 build
 **/**/out/
 .flattened-pom.xml
+
+target/
+**/common-passwords.txt

--- a/store/src/main/java/com/zimbra/cs/account/Domain.java
+++ b/store/src/main/java/com/zimbra/cs/account/Domain.java
@@ -10,17 +10,13 @@
  */
 package com.zimbra.cs.account;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.zimbra.common.account.ZAttrProvisioning.DomainStatus;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.Provisioning.GalMode;
-import com.zimbra.cs.account.Provisioning.SearchGalResult;
-import com.zimbra.soap.type.GalSearchType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author schemers
@@ -28,8 +24,8 @@ import com.zimbra.soap.type.GalSearchType;
  * Window - Preferences - Java - Code Style - Code Templates
  */
 public class Domain extends ZAttrDomain {
-    private String mUnicodeName;
-    private Map<String, Object> mAccountDefaults = new HashMap<String, Object>();
+    private final String mUnicodeName;
+    private final Map<String, Object> mAccountDefaults = new HashMap<>();
     
     public Domain(String name, String id, Map<String, Object> attrs, Map<String, Object> defaults, Provisioning prov) {
         super(name, id, attrs, defaults, prov);

--- a/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
@@ -2566,8 +2566,8 @@ public class ProvUtil implements HttpDebugListener {
   }
 
   private Domain doCreateAliasDomain(
-      String aliasDomain, String localDoamin, Map<String, Object> attrs) throws ServiceException {
-    Domain local = lookupDomain(localDoamin);
+      String aliasDomain, String localDomain, Map<String, Object> attrs) throws ServiceException {
+    Domain local = lookupDomain(localDomain);
     if (!local.isLocal()) {
       throw ServiceException.INVALID_REQUEST("target domain must be a local domain", null);
     }
@@ -2582,8 +2582,8 @@ public class ProvUtil implements HttpDebugListener {
 
     if (args[1].equals("-e")) {
       if (args.length > 1) {
-        applyDefault = false;
-        acctPos = 2;
+      applyDefault = false;
+      acctPos = 2;
       } else {
         usage();
         return;

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -2843,6 +2843,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
       if (domainType.equalsIgnoreCase(DomainType.alias.name())) {
         entry.setAttr(A_zimbraMailCatchAllAddress, "@" + name);
+        final Domain targetDomain = getDomainById(
+            (String) domainAttrs.getOrDefault(A_zimbraDomainAliasTargetId, name));
+        entry.setAttr(A_zimbraMailCatchAllForwardingAddress, "@" + targetDomain.getDomainName());
       }
 
       entry.setAttr(A_o, name + " domain");
@@ -2886,9 +2889,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     } catch (LdapEntryAlreadyExistException nabe) {
       throw AccountServiceException.DOMAIN_EXISTS(name);
-    } catch (LdapException e) {
-      throw e;
-    } catch (AccountServiceException e) {
+    } catch (LdapException | AccountServiceException e) {
       throw e;
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create domain: " + name, e);

--- a/store/src/test/java/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/test/java/com/zimbra/cs/account/MockProvisioning.java
@@ -436,6 +436,18 @@ public final class MockProvisioning extends Provisioning {
       attrs.put(A_zimbraSmtpHostname, "localhost");
     }
 
+    String domainType = (String) attrs.get(A_zimbraDomainType);
+    if (domainType == null) {
+      domainType = DomainType.local.name();
+    }
+
+    if (domainType.equalsIgnoreCase(DomainType.alias.name())) {
+      attrs.put(A_zimbraMailCatchAllAddress,  "@" + name);
+      final Domain targetDomain = getDomainById(
+          (String) attrs.getOrDefault(A_zimbraDomainAliasTargetId, name));
+      attrs.put(A_zimbraMailCatchAllForwardingAddress, "@" + targetDomain.getName());
+    }
+
     Domain domain = new Domain(name, id, attrs, null, this);
     id2domain.put(id, domain);
     return domain;

--- a/store/src/test/java/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -1,8 +1,11 @@
 package com.zimbra.cs.account.ldap;
 
+import static org.junit.Assert.assertEquals;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.auth.AuthContext.Protocol;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
@@ -15,7 +18,9 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-/** Unit test for {@link LdapProvisioning}. */
+/**
+ * Unit test for {@link LdapProvisioning}.
+ */
 public class LdapProvisioningTest {
 
   @BeforeClass
@@ -57,8 +62,7 @@ public class LdapProvisioningTest {
   }
 
   /**
-   * This test is to validate functionality of ({@link
-   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
    * Account)}) for personal data
    *
    * @throws ServiceException
@@ -70,7 +74,7 @@ public class LdapProvisioningTest {
 
     // fake passwords for test against created user account
     String[] testPasswords = {
-      "natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"
+        "natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"
     };
     for (String testPassword : testPasswords) {
       String passwordLower = testPassword.toLowerCase();
@@ -79,8 +83,7 @@ public class LdapProvisioningTest {
   }
 
   /**
-   * This test is to validate functionality of ({@link
-   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
    * Account)}) for specific case in which user might be <b>using a dotless domain</b>
    *
    * @throws ServiceException
@@ -92,13 +95,13 @@ public class LdapProvisioningTest {
 
     // fake passwords for test against created user account
     String[] testPasswords = {
-      "milano",
-      "Lamborghini123",
-      "Milano34",
-      "lamborghini01",
-      "Milano.Lamborghini",
-      "lAmbOrgHini",
-      "2022cars"
+        "milano",
+        "Lamborghini123",
+        "Milano34",
+        "lamborghini01",
+        "Milano.Lamborghini",
+        "lAmbOrgHini",
+        "2022cars"
     };
 
     for (String testPassword : testPasswords) {
@@ -108,8 +111,7 @@ public class LdapProvisioningTest {
   }
 
   /**
-   * This test is to validate functionality of ({@link
-   * com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+   * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
    * Account)}) for specific case in which user's <b>domain name contains special chars</b>
    *
    * @throws ServiceException
@@ -183,5 +185,24 @@ public class LdapProvisioningTest {
     exampleAccountAttrs3.put(Provisioning.A_mail, email);
     final Account testAdminAccount = prov.createAccount(email, password, exampleAccountAttrs3);
     prov.authAccount(testAdminAccount, password, Protocol.soap);
+  }
+
+  @Test
+  public void aliasDomainShouldHaveZimbraMailCatchAllForwardingAddressSetByDefault() throws ServiceException {
+    Provisioning prov = Provisioning.getInstance();
+
+    // create target domain
+    final String domainName = "co477.com";
+    final String aliasDomainName = "aka.co477.com";
+    final Domain targetDomain = prov.createDomain(domainName, new HashMap<String, Object>());
+
+    // create alias domain
+    final HashMap<String, Object> attrs = new HashMap<>();
+    attrs.put(Provisioning.A_zimbraDomainType, Provisioning.DomainType.alias.name());
+    attrs.put(Provisioning.A_zimbraDomainAliasTargetId, targetDomain.getId());
+    final Domain aliasDomain = prov.createDomain(aliasDomainName, attrs);
+
+    assertEquals(aliasDomain.getAttr(Provisioning.A_zimbraMailCatchAllForwardingAddress),
+        "@" + domainName);
   }
 }


### PR DESCRIPTION
**What has changed:**
- Provisioning now sets mailCatchAllForwardingAddress domain attribute to default value during alias domain creation.