### PR TITLE
chore: [CO-482] copy maven settings file

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -25,6 +25,9 @@ pipeline {
         stage('Checkout') {
             steps {
                 checkout scm
+                withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                    sh "cp ${SETTINGS_PATH} settings-jenkins.xml"
+                }
             }
         }
         stage('Build') {


### PR DESCRIPTION
Add missing copy instruction for maven settings in Nightly builds.