### PR TITLE
feat: [CO-495] add carbonioLogoUrl attribute

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2757,6 +2757,14 @@ public class ZAttrProvisioning {
     public static final String A_carbonioFeatureMailsAppEnabled = "carbonioFeatureMailsAppEnabled";
 
     /**
+     * Logo URL for domain
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public static final String A_carbonioLogoUrl = "carbonioLogoUrl";
+
+    /**
      * Carbonio mesh service credentials as base64 string
      *
      * @since ZCS 22.11.0

--- a/store-conf/conf/rights/rights-domainadmin.xml
+++ b/store-conf/conf/rights/rights-domainadmin.xml
@@ -496,6 +496,7 @@
     <a n="carbonioAdminUiLoginLogo"/>
     <a n="carbonioAdminUiTitle"/>
     <a n="carbonioAdminWebUiBannerText"/>
+    <a n="carbonioLogoUrl"/>
     <a n="carbonioWebUiAppLogo"/>
     <a n="carbonioWebUiBannerText"/>
     <a n="carbonioWebUiDarkAppLogo"/>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9982,4 +9982,9 @@ TODO: delete them permanently from here
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Chats feature enabled for account or COS</desc>
 </attr>
+
+<attr id="3126" name="carbonioLogoUrl" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="23.2.0">
+  <desc>Logo URL for domain</desc>
+  <globalConfigValue>https://www.zextras.com</globalConfigValue>
+</attr>
 </attrs>

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -1077,6 +1077,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Logo URL for domain
+     *
+     * @return carbonioLogoUrl, or "https://www.zextras.com" if unset
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public String getCarbonioLogoUrl() {
+        return getAttr(Provisioning.A_carbonioLogoUrl, "https://www.zextras.com", true);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param carbonioLogoUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public void setCarbonioLogoUrl(String carbonioLogoUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, carbonioLogoUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param carbonioLogoUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public Map<String,Object> setCarbonioLogoUrl(String carbonioLogoUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, carbonioLogoUrl);
+        return attrs;
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public void unsetCarbonioLogoUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public Map<String,Object> unsetCarbonioLogoUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, "");
+        return attrs;
+    }
+
+    /**
      * Carbonio mesh service credentials as base64 string
      *
      * @return carbonioMeshCredentials, or null if unset

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -756,6 +756,78 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Logo URL for domain
+     *
+     * @return carbonioLogoUrl, or "https://www.zextras.com" if unset
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public String getCarbonioLogoUrl() {
+        return getAttr(Provisioning.A_carbonioLogoUrl, "https://www.zextras.com", true);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param carbonioLogoUrl new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public void setCarbonioLogoUrl(String carbonioLogoUrl) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, carbonioLogoUrl);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param carbonioLogoUrl new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public Map<String,Object> setCarbonioLogoUrl(String carbonioLogoUrl, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, carbonioLogoUrl);
+        return attrs;
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public void unsetCarbonioLogoUrl() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Logo URL for domain
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.2.0
+     */
+    @ZAttr(id=3126)
+    public Map<String,Object> unsetCarbonioLogoUrl(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioLogoUrl, "");
+        return attrs;
+    }
+
+    /**
      * Enable video server recording for Carbonio
      *
      * @return carbonioVideoServerRecordingEnabled, or false if unset


### PR DESCRIPTION
**What has changed:**
- new LDAP attribute carbonioLogoUrl added to globalConfig and domain entries
- default value is `https://www.zextras.com`
- attribute is domainInherited,domainInfo and domainAdminModifiable

**LDAP Utils PR**: https://github.com/Zextras/carbonio-ldap-utilities/pull/22