### PR TITLE
chore: [CO-535] Address Book proxyconfgen

### DIFF
--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2400,6 +2400,9 @@ public class ProxyConfGen {
           new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps")),
           new File(mConfIncludesDir, getConfFileName("messaging.xmpps")));
       expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("addressBook.default")),
+          new File(mConfIncludesDir, getConfFileName("addressBook.default")));
+      expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("addressBook")),
           new File(mConfIncludesDir, getConfFileName("addressBook")));
     } catch (ProxyConfException | SecurityException pe) {

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2399,27 +2399,23 @@ public class ProxyConfGen {
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps")),
           new File(mConfIncludesDir, getConfFileName("messaging.xmpps")));
+      // Stream templates
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("stream")),
           new File(mConfIncludesDir, getConfFileName("stream")));
-      // map of vhn crt, key
       expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("stream.map.crt")),
-          new File(mConfIncludesDir, getConfFileName("stream.map.crt")));
+          new File(mTemplateDir, getConfTemplateFileName("stream.addressBook")),
+          new File(mConfIncludesDir, getConfFileName("stream.addressBook")));
+      // Templates for ssl mapping
       expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("stream.map.key")),
-          new File(mConfIncludesDir, getConfFileName("stream.map.key")));
-      // put crt, key in maps
+          new File(mTemplateDir, getConfTemplateFileName("map.crt")),
+          new File(mConfIncludesDir, getConfFileName("map.crt")));
       expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("stream.ssl")),
-          new File(mConfIncludesDir, getConfFileName("stream.ssl")));
-      // map vhn to address book upstream
+          new File(mTemplateDir, getConfTemplateFileName("map.key")),
+          new File(mConfIncludesDir, getConfFileName("map.key")));
       expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("stream.map.addressBook")),
-          new File(mConfIncludesDir, getConfFileName("stream.map.addressBook")));
-      expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("addressBook")),
-          new File(mConfIncludesDir, getConfFileName("addressBook")));
+          new File(mTemplateDir, getConfTemplateFileName("map.ssl")),
+          new File(mConfIncludesDir, getConfFileName("map.ssl")));
     } catch (ProxyConfException | SecurityException pe) {
       handleException(pe);
       exitCode = 1;

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2399,6 +2399,9 @@ public class ProxyConfGen {
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps")),
           new File(mConfIncludesDir, getConfFileName("messaging.xmpps")));
+      expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("addressBook")),
+          new File(mConfIncludesDir, getConfFileName("addressBook")));
     } catch (ProxyConfException | SecurityException pe) {
       handleException(pe);
       exitCode = 1;

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2400,6 +2400,9 @@ public class ProxyConfGen {
           new File(mTemplateDir, getConfTemplateFileName("messaging.xmpps")),
           new File(mConfIncludesDir, getConfFileName("messaging.xmpps")));
       expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("stream")),
+          new File(mConfIncludesDir, getConfFileName("stream")));
+      expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("addressBook.default")),
           new File(mConfIncludesDir, getConfFileName("addressBook.default")));
       expandTemplate(

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2402,9 +2402,21 @@ public class ProxyConfGen {
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("stream")),
           new File(mConfIncludesDir, getConfFileName("stream")));
+      // map of vhn crt, key
       expandTemplate(
-          new File(mTemplateDir, getConfTemplateFileName("addressBook.default")),
-          new File(mConfIncludesDir, getConfFileName("addressBook.default")));
+          new File(mTemplateDir, getConfTemplateFileName("stream.map.crt")),
+          new File(mConfIncludesDir, getConfFileName("stream.map.crt")));
+      expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("stream.map.key")),
+          new File(mConfIncludesDir, getConfFileName("stream.map.key")));
+      // put crt, key in maps
+      expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("stream.ssl")),
+          new File(mConfIncludesDir, getConfFileName("stream.ssl")));
+      // map vhn to address book upstream
+      expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("stream.map.addressBook")),
+          new File(mConfIncludesDir, getConfFileName("stream.map.addressBook")));
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("addressBook")),
           new File(mConfIncludesDir, getConfFileName("addressBook")));


### PR DESCRIPTION
Handle Address Book Nginx template files (expand).
 - Expand "stream" conf file that will hold stream configurations (example: https://docs.nginx.com/nginx/admin-guide/load-balancer/tcp-udp-load-balancer/)
 - Expand addressBook template
 - Expand ssl and certificates map templates
 
TODO:
- [x] test standard configurations (addressBook.default)
- [x] test virtual hosts configurations (addressBook)