### PR TITLE
feat: [CO-526] prevent delegated admins creating DDLs

### DIFF
--- a/soap/src/main/java/com/zimbra/soap/admin/message/CreateDistributionListRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/admin/message/CreateDistributionListRequest.java
@@ -24,7 +24,7 @@ import com.zimbra.soap.type.ZmBoolean;
  * <br />
  * Notes:
  * <ul>
- * <li> dynamic - create a dynamic distribution list
+ * <li> dynamic - create a dynamic distribution list (global admins only)
  * <li> Extra attrs: <b>description</b>, <b>zimbraNotes</b>
  * </ul>
  * <b>Access</b>: domain admin sufficient

--- a/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
@@ -60,6 +60,11 @@ public class CreateDistributionList extends AdminDocumentHandler {
         boolean dynamic = Boolean.TRUE.equals(req.getDynamic());
 
         if (dynamic) {
+            // see issue CO-526
+            if (zsc.getAuthToken().isDelegatedAdmin()) {
+                throw ServiceException.INVALID_REQUEST(
+                    "Delegated Admins are not allowed to create Dynamic Distribution Lists", null);
+            }
             checkDomainRightByEmail(zsc, name, Admin.R_createGroup);
             checkSetAttrsOnCreate(zsc, TargetType.group, name, attrs);
         } else {

--- a/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
@@ -5,11 +5,6 @@
 
 package com.zimbra.cs.service.admin;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
@@ -17,90 +12,89 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Group;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.AdminRight;
-import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.account.accesscontrol.TargetType;
-import com.zimbra.soap.JaxbUtil;
+import com.zimbra.cs.account.accesscontrol.generated.AdminRights;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.CreateDistributionListRequest;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 public class CreateDistributionList extends AdminDocumentHandler {
 
-    /**
-     * must be careful and only allow access to domain if domain admin
-     */
-    @Override
-    public boolean domainAuthSufficient(Map context) {
-        return true;
+  /**
+   * must be careful and only allow access to domain if domain admin
+   */
+  @Override
+  public boolean domainAuthSufficient(Map<String, Object> context) {
+    return true;
+  }
+
+  /**
+   * @return true - which means accept responsibility for measures to prevent account harvesting by
+   * delegate admins
+   */
+  @Override
+  public boolean defendsAgainstDelegateAdminAccountHarvesting() {
+    return true;
+  }
+
+  @Override
+  public Element handle(Element request, Map<String, Object> context)
+      throws ServiceException {
+
+    ZimbraSoapContext zsc = getZimbraSoapContext(context);
+    Provisioning prov = Provisioning.getInstance();
+    CreateDistributionListRequest req = zsc.elementToJaxb(request);
+
+    if (StringUtils.isEmpty(req.getName())) {
+      throw ServiceException.INVALID_REQUEST(String.format("missing %s", AdminConstants.E_NAME),
+          null);
     }
 
-    /**
-     * @return true - which means accept responsibility for measures to prevent account harvesting by delegate admins
-     */
-    @Override
-    public boolean defendsAgainstDelegateAdminAccountHarvesting() {
-        return true;
+    String name = req.getName().toLowerCase();
+
+    Map<String, Object> attrs = req.getAttrsAsOldMultimap(true);
+
+    boolean dynamic = Boolean.TRUE.equals(req.getDynamic());
+
+    if (dynamic) {
+      // see issue CO-526
+      if (zsc.getAuthToken().isDelegatedAdmin()) {
+        throw ServiceException.INVALID_REQUEST(
+            "Delegated Admins are not allowed to create Dynamic Distribution Lists", null);
+      }
+      checkDomainRightByEmail(zsc, name, AdminRights.R_createGroup);
+      checkSetAttrsOnCreate(zsc, TargetType.group, name, attrs);
+    } else {
+      checkDomainRightByEmail(zsc, name, AdminRights.R_createDistributionList);
+      checkSetAttrsOnCreate(zsc, TargetType.dl, name, attrs);
     }
 
-    @Override
-    public Element handle(Element request, Map<String, Object> context)
-    throws ServiceException {
+    Group group = prov.createGroup(name, attrs, dynamic);
 
-        ZimbraSoapContext zsc = getZimbraSoapContext(context);
-        Provisioning prov = Provisioning.getInstance();
-        CreateDistributionListRequest req = zsc.elementToJaxb(request);
+    ZimbraLog.security.info(ZimbraLog.encodeAttrs(
+        new String[]{"cmd", "CreateDistributionList", "name", name}, attrs));
 
-        if (StringUtils.isEmpty(req.getName())) {
-            throw ServiceException.INVALID_REQUEST(String.format("missing %s", AdminConstants.E_NAME), null);
-        }
+    Element response = getResponseElement(zsc);
 
-        String name = req.getName().toLowerCase();
+    GetDistributionList.encodeDistributionList(response, group);
 
-        Map<String, Object> attrs = req.getAttrsAsOldMultimap(true);
+    return response;
+  }
 
-        boolean dynamic = Boolean.TRUE.equals(req.getDynamic());
+  @Override
+  public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+    relatedRights.add(AdminRights.R_createDistributionList);
+    relatedRights.add(AdminRights.R_createGroup);
+    notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
+        AdminRights.R_modifyDistributionList.getName(), "distribution list"));
+    notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
+        AdminRights.R_modifyGroup.getName(), "group"));
+  }
 
-        if (dynamic) {
-            // see issue CO-526
-            if (zsc.getAuthToken().isDelegatedAdmin()) {
-                throw ServiceException.INVALID_REQUEST(
-                    "Delegated Admins are not allowed to create Dynamic Distribution Lists", null);
-            }
-            checkDomainRightByEmail(zsc, name, Admin.R_createGroup);
-            checkSetAttrsOnCreate(zsc, TargetType.group, name, attrs);
-        } else {
-            checkDomainRightByEmail(zsc, name, Admin.R_createDistributionList);
-            checkSetAttrsOnCreate(zsc, TargetType.dl, name, attrs);
-        }
-
-        preGroupCreation(request, zsc, attrs);
-        Group group = prov.createGroup(name, attrs, dynamic);
-
-        ZimbraLog.security.info(ZimbraLog.encodeAttrs(
-                new String[] {"cmd", "CreateDistributionList","name", name}, attrs));
-
-        Element response = getResponseElement(zsc);
-
-        GetDistributionList.encodeDistributionList(response, group);
-
-        return response;
-    }
-
-    @Override
-    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
-        relatedRights.add(Admin.R_createDistributionList);
-        relatedRights.add(Admin.R_createGroup);
-        notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
-                Admin.R_modifyDistributionList.getName(), "distribution list"));
-        notes.add(String.format(AdminRightCheckPoint.Notes.MODIFY_ENTRY,
-                Admin.R_modifyGroup.getName(), "group"));
-    }
-
-    protected void preGroupCreation(Element request, ZimbraSoapContext zsc, Map<String, Object> attrs)
-            throws ServiceException {
-        // do nothing
-    }
-
-    protected Element getResponseElement(ZimbraSoapContext zsc) {
-        return zsc.createElement(AdminConstants.CREATE_DISTRIBUTION_LIST_RESPONSE);
-    }
+  @Override
+  protected Element getResponseElement(ZimbraSoapContext zsc) {
+    return zsc.createElement(AdminConstants.CREATE_DISTRIBUTION_LIST_RESPONSE);
+  }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/CreateDistributionListTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/CreateDistributionListTest.java
@@ -1,0 +1,112 @@
+package com.zimbra.cs.service.admin;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.zimbra.common.account.ProvisioningConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.DynamicGroup;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.CreateDistributionListRequest;
+import com.zimbra.soap.admin.type.Attr;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class CreateDistributionListTest {
+
+  private final static String DOMAIN_NAME = "test.com";
+  private final static String ADMIN_USER_NAME = "admin";
+  private final static String DOMAIN_ADMIN_EMAIL = ADMIN_USER_NAME + "@" + DOMAIN_NAME;
+  private final static  String DISTRIBUTION_LIST_NAME = "developers" + "@" + DOMAIN_NAME;
+  private final static String DOMAIN_ADMIN_PASSWORD = "assext";
+
+  private static Provisioning provisioningSpy;
+
+  @Rule
+  public final ExpectedException exceptionRule = ExpectedException.none();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    provisioningSpy = spy(Provisioning.getInstance());
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  /**
+   * Delegated Admins are not allowed to create Dynamic Distribution Lists see issue CO-526
+   *
+   * @throws ServiceException if any
+   */
+  @Test
+  public void shouldThrowServiceExceptionWhenDelegatedAdminRequestToCreateDynamicDistributionList()
+      throws ServiceException {
+
+    final HashMap<String, Object> attrs = new HashMap<>();
+
+    //create domain
+    provisioningSpy.createDomain(DOMAIN_NAME, attrs);
+
+    //create domain admin user
+    attrs.put(Provisioning.A_zimbraIsDelegatedAdminAccount,
+        ProvisioningConstants.TRUE);
+    final Account domainAdminAccount = provisioningSpy.createAccount(DOMAIN_ADMIN_EMAIL,
+        DOMAIN_ADMIN_PASSWORD,
+        attrs);
+
+    //AuthToken mock, set auth account as delegatedAdmin
+    final AuthToken authTokenMock = mock(AuthToken.class);
+    when(authTokenMock.isDelegatedAdmin()).thenReturn(true);
+
+    //create soap context with delegated admin auth
+    final Map<String, Object> context = new HashMap<>();
+    final ZimbraSoapContext zsc = new ZimbraSoapContext(authTokenMock, domainAdminAccount.getId(),
+        SoapProtocol.Soap12, SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+
+    //create CreateDistributionListRequest
+    List<Attr> attributes = new ArrayList<>();
+    attributes.add(new Attr(Provisioning.A_memberURL,
+        "ldap:///??sub?(&amp;(objectClass=zimbraAccount)(ZimbraAccountStatus=active))"));
+    attributes.add(new Attr(Provisioning.A_zimbraIsACLGroup, ProvisioningConstants.TRUE));
+    final CreateDistributionListRequest createDistributionListRequest = new CreateDistributionListRequest(
+        DISTRIBUTION_LIST_NAME, attributes, true);
+
+    //create CreateDistributionList spy
+    final CreateDistributionList createDistributions = spy(CreateDistributionList.class);
+
+    //stub createGroup method of provisioning since it is not supported without real provisioning backend
+    final DynamicGroup mockDGroup = mock(DynamicGroup.class);
+    doReturn(mockDGroup).when(provisioningSpy).createGroup(anyString(), anyMap(), anyBoolean());
+
+    //setup tests cases
+    exceptionRule.expect(ServiceException.class);
+    exceptionRule.expectMessage(
+        "Delegated Admins are not allowed to create Dynamic Distribution Lists");
+
+    //execute request
+    createDistributions.handle(JaxbUtil.jaxbToElement(createDistributionListRequest), context);
+  }
+}

--- a/store/src/test/java/com/zimbra/cs/service/admin/CreateDistributionListTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/CreateDistributionListTest.java
@@ -94,8 +94,8 @@ public class CreateDistributionListTest {
     final CreateDistributionListRequest createDistributionListRequest = new CreateDistributionListRequest(
         DISTRIBUTION_LIST_NAME, attributes, true);
 
-    //create CreateDistributionList spy
-    final CreateDistributionList createDistributions = spy(CreateDistributionList.class);
+    //create CreateDistributionList
+    final CreateDistributionList createDistributions = new CreateDistributionList();
 
     //stub createGroup method of provisioning since it is not supported without real provisioning backend
     final DynamicGroup mockDGroup = mock(DynamicGroup.class);


### PR DESCRIPTION
**What has changed:**
- prohibit delegatedAdmins from creating dynamic distribution list using CreateDistributionList SOAP command
    - Now throws ServiceException when a delegatedAdmin requests to create dynamic distribution list
