### PR TITLE
fix: [CO-544] modify domain remove vhost names

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -74,6 +74,7 @@ public class ModifyDomain extends AdminDocumentHandler {
     }
     final String[] gotVirtualHostNames = getVirtualHostnamesFromAttributes(attrs);
     if (!(Objects.isNull(gotVirtualHostNames))
+        && !(Arrays.equals(gotVirtualHostNames, new String[] {""}))
         && !(areVirtualHostnamesCompliant(
             domain, Arrays.stream(gotVirtualHostNames).collect(Collectors.toList())))) {
       throw ServiceException.FAILURE(

--- a/store/src/test/java/com/zimbra/cs/account/MockProvisioning.java
+++ b/store/src/test/java/com/zimbra/cs/account/MockProvisioning.java
@@ -256,6 +256,8 @@ public final class MockProvisioning extends Provisioning {
               map.remove(realKey);
             }
           }
+        } else if (Objects.equals("", value)) {
+          map.remove(attr.getKey());
         } else {
           map.put(attr.getKey(), value);
         }
@@ -442,9 +444,9 @@ public final class MockProvisioning extends Provisioning {
     }
 
     if (domainType.equalsIgnoreCase(DomainType.alias.name())) {
-      attrs.put(A_zimbraMailCatchAllAddress,  "@" + name);
-      final Domain targetDomain = getDomainById(
-          (String) attrs.getOrDefault(A_zimbraDomainAliasTargetId, name));
+      attrs.put(A_zimbraMailCatchAllAddress, "@" + name);
+      final Domain targetDomain =
+          getDomainById((String) attrs.getOrDefault(A_zimbraDomainAliasTargetId, name));
       attrs.put(A_zimbraMailCatchAllForwardingAddress, "@" + targetDomain.getName());
     }
 


### PR DESCRIPTION
## Goal

When using zmprov we want to remove all virtual hostnames on a domain by executing:
> zmprov md <domain_name> zimbraVirtualHostname ""
> 

and not having to remove them all by specifying each one.

## What's changed
This PR adds the fix by matching the expected behavior.
If zimbraVirtualHostname are not passed then existing values will not be overridden, **the condition for removal is met when you pass exactly a zimbraVirtualHostname array containing only the empty string.**

### About MockProvisioning
I found MockProvisioning has many limitations as it does not reflect the real underlying behavior of the production system in some cases.
For example removing an attribute by setting it to empty value did not work (it should AFAIK), so I changed the class to match real-scenario.

## Tests
Code aside, **tested on a VM using zmprov.**
