### PR TITLE
feat: [CO-513] Set sane defaults for postfix smtp server

### DIFF
--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -7726,7 +7726,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1535" name="zimbraMtaSmtpdRejectUnlistedSender" type="enum" value="yes,no" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">
-  <globalConfigValue>no</globalConfigValue>
+  <globalConfigValue>yes</globalConfigValue>
   <desc>Value for postconf smtpd_reject_unlisted_sender</desc>
 </attr>
 

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -8034,6 +8034,7 @@ TODO: delete them permanently from here
 
 <attr id="1591" name="zimbraMtaSmtpdSenderLoginMaps" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">
   <desc>Value for postconf smtpd_sender_login_maps</desc>
+  <globalConfigValue>proxy:ldap:/opt/zextras/conf/ldap-slm.cf</globalConfigValue>
 </attr>
 
 <attr id="1592" name="zimbraPrevFoldersToTrackMax" type="integer" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">
@@ -8078,7 +8079,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1600" name="zimbraServerVersionMinor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
-  <desc>Current minor version of ZCS installed on this server</desc>zimbraMtaSmtpdRejectUnlistedRecipient
+  <desc>Current minor version of ZCS installed on this server</desc>
 </attr>
 
 <attr id="1601" name="zimbraServerVersionMicro" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -7721,7 +7721,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1534" name="zimbraMtaSmtpdRejectUnlistedRecipient" type="enum" value="yes,no" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">
-  <globalConfigValue>no</globalConfigValue>
+  <globalConfigValue>yes</globalConfigValue>
   <desc>Value for postconf smtpd_reject_unlisted_recipient</desc>
 </attr>
 
@@ -8077,7 +8077,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="1600" name="zimbraServerVersionMinor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
-  <desc>Current minor version of ZCS installed on this server</desc>
+  <desc>Current minor version of ZCS installed on this server</desc>zimbraMtaSmtpdRejectUnlistedRecipient
 </attr>
 
 <attr id="1601" name="zimbraServerVersionMicro" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -8029,6 +8029,7 @@ TODO: delete them permanently from here
 
 <attr id="1590" name="zimbraMtaSmtpdSenderRestrictions" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">
   <desc>Value for postconf smtpd_sender_restrictions</desc>
+  <globalConfigValue>reject_sender_login_mismatch</globalConfigValue>
 </attr>
 
 <attr id="1591" name="zimbraMtaSmtpdSenderLoginMaps" type="string" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" since="8.5.0">


### PR DESCRIPTION
**Goal:**
To increase the security and reject false mail from addresses

**What has changed:**
- set default value to yes for zimbraMtaSmtpdRejectUnlistedRecipient
    - postfix SMTP server will reject emails sent to unlisted/unknown addresses(smtpd_reject_unlisted_recipient: yes)
- set default value to yes for zimbraMtaSmtpdRejectUnlistedSender
    - postfix SMTP server will reject emails sent by unlisted/unknown addresses (smtpd_reject_unlisted_sender: yes)
- set default value for zimbraMtaSmtpdSenderRestrictions
    - set reject_sender_login_mismatch as default value (smtpd_sender_restrictions: +reject_sender_login_mismatch) 
- set default value for zimbraMtaSmtpdSenderLoginMaps
    - set default to ldap sender_login_mismatch lookup table (smtpd_sender_login_maps: + proxy:ldap:/opt/zextras/conf/ldap-slm.cf )

_for detailed information see CO-513 on Jira._

**Other PRs:** 
- https://github.com/Zextras/carbonio-mta/pull/2
- https://github.com/Zextras/carbonio-ldap-utilities/pull/25