### PR TITLE
feat: [CO-499] Remove both and mixed mode form web proxy config

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2230,10 +2230,7 @@ public class ZAttrProvisioning {
     }
 
     public static enum ReverseProxyMailMode {
-        http("http"),
         https("https"),
-        both("both"),
-        mixed("mixed"),
         redirect("redirect");
         private String mValue;
         private ReverseProxyMailMode(String value) { mValue = value; }
@@ -2244,10 +2241,7 @@ public class ZAttrProvisioning {
              }
              throw ServiceException.INVALID_REQUEST("invalid value: "+s+", valid values: "+ Arrays.asList(values()), null);
         }
-        public boolean isHttp() { return this == http;}
         public boolean isHttps() { return this == https;}
-        public boolean isBoth() { return this == both;}
-        public boolean isMixed() { return this == mixed;}
         public boolean isRedirect() { return this == redirect;}
     }
 
@@ -15327,9 +15321,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraReverseProxyMailImapsEnabled = "zimbraReverseProxyMailImapsEnabled";
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
      * @since ZCS 5.0.7
      */

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -46932,13 +46932,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no if unset and/or has invalid value
+     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes if unset and/or has invalid value
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1534)
     public ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient getMtaSmtpdRejectUnlistedRecipient() {
-        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no : ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no; }
+        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes : ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes; }
     }
 
     /**
@@ -46946,13 +46946,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or "no" if unset
+     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or "yes" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1534)
     public String getMtaSmtpdRejectUnlistedRecipientAsString() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, "no", true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, "yes", true);
     }
 
     /**
@@ -47063,13 +47063,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedSender, or ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no if unset and/or has invalid value
+     * @return zimbraMtaSmtpdRejectUnlistedSender, or ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes if unset and/or has invalid value
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1535)
     public ZAttrProvisioning.MtaSmtpdRejectUnlistedSender getMtaSmtpdRejectUnlistedSender() {
-        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no : ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no; }
+        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes : ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes; }
     }
 
     /**
@@ -47077,13 +47077,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedSender, or "no" if unset
+     * @return zimbraMtaSmtpdRejectUnlistedSender, or "yes" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1535)
     public String getMtaSmtpdRejectUnlistedSenderAsString() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, "no", true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, "yes", true);
     }
 
     /**
@@ -47574,13 +47574,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Value for postconf smtpd_sender_login_maps
      *
-     * @return zimbraMtaSmtpdSenderLoginMaps, or null if unset
+     * @return zimbraMtaSmtpdSenderLoginMaps, or "proxy:ldap:/opt/zextras/conf/ldap-slm.cf" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1591)
     public String getMtaSmtpdSenderLoginMaps() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderLoginMaps, null, true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderLoginMaps, "proxy:ldap:/opt/zextras/conf/ldap-slm.cf", true);
     }
 
     /**
@@ -47646,13 +47646,13 @@ public abstract class ZAttrConfig extends Entry {
     /**
      * Value for postconf smtpd_sender_restrictions
      *
-     * @return zimbraMtaSmtpdSenderRestrictions, or null if unset
+     * @return zimbraMtaSmtpdSenderRestrictions, or "reject_sender_login_mismatch" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1590)
     public String getMtaSmtpdSenderRestrictions() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderRestrictions, null, true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderRestrictions, "reject_sender_login_mismatch", true);
     }
 
     /**
@@ -60098,11 +60098,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @return zimbraReverseProxyMailMode, or null if unset and/or has invalid value
      *
@@ -60114,11 +60113,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @return zimbraReverseProxyMailMode, or null if unset
      *
@@ -60130,11 +60128,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -60149,11 +60146,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @param attrs existing map to populate, or null to create a new map
@@ -60169,11 +60165,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -60188,11 +60183,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @param attrs existing map to populate, or null to create a new map
@@ -60208,11 +60202,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -60226,11 +60219,10 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -32615,13 +32615,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no if unset and/or has invalid value
+     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes if unset and/or has invalid value
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1534)
     public ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient getMtaSmtpdRejectUnlistedRecipient() {
-        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no : ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.no; }
+        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes : ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedRecipient.yes; }
     }
 
     /**
@@ -32629,13 +32629,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or "no" if unset
+     * @return zimbraMtaSmtpdRejectUnlistedRecipient, or "yes" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1534)
     public String getMtaSmtpdRejectUnlistedRecipientAsString() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, "no", true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedRecipient, "yes", true);
     }
 
     /**
@@ -32746,13 +32746,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedSender, or ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no if unset and/or has invalid value
+     * @return zimbraMtaSmtpdRejectUnlistedSender, or ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes if unset and/or has invalid value
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1535)
     public ZAttrProvisioning.MtaSmtpdRejectUnlistedSender getMtaSmtpdRejectUnlistedSender() {
-        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no : ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.no; }
+        try { String v = getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, true, true); return v == null ? ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes : ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.MtaSmtpdRejectUnlistedSender.yes; }
     }
 
     /**
@@ -32760,13 +32760,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [yes, no]
      *
-     * @return zimbraMtaSmtpdRejectUnlistedSender, or "no" if unset
+     * @return zimbraMtaSmtpdRejectUnlistedSender, or "yes" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1535)
     public String getMtaSmtpdRejectUnlistedSenderAsString() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, "no", true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdRejectUnlistedSender, "yes", true);
     }
 
     /**
@@ -33257,13 +33257,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Value for postconf smtpd_sender_login_maps
      *
-     * @return zimbraMtaSmtpdSenderLoginMaps, or null if unset
+     * @return zimbraMtaSmtpdSenderLoginMaps, or "proxy:ldap:/opt/zextras/conf/ldap-slm.cf" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1591)
     public String getMtaSmtpdSenderLoginMaps() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderLoginMaps, null, true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderLoginMaps, "proxy:ldap:/opt/zextras/conf/ldap-slm.cf", true);
     }
 
     /**
@@ -33329,13 +33329,13 @@ public abstract class ZAttrServer extends NamedEntry {
     /**
      * Value for postconf smtpd_sender_restrictions
      *
-     * @return zimbraMtaSmtpdSenderRestrictions, or null if unset
+     * @return zimbraMtaSmtpdSenderRestrictions, or "reject_sender_login_mismatch" if unset
      *
      * @since ZCS 8.5.0
      */
     @ZAttr(id=1590)
     public String getMtaSmtpdSenderRestrictions() {
-        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderRestrictions, null, true);
+        return getAttr(Provisioning.A_zimbraMtaSmtpdSenderRestrictions, "reject_sender_login_mismatch", true);
     }
 
     /**
@@ -42228,11 +42228,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @return zimbraReverseProxyMailMode, or null if unset and/or has invalid value
      *
@@ -42244,11 +42243,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @return zimbraReverseProxyMailMode, or null if unset
      *
@@ -42260,11 +42258,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -42279,11 +42276,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @param attrs existing map to populate, or null to create a new map
@@ -42299,11 +42295,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -42318,11 +42313,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param zimbraReverseProxyMailMode new value
      * @param attrs existing map to populate, or null to create a new map
@@ -42338,11 +42332,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -42356,11 +42349,10 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * whether to run proxy in HTTP, HTTPS, both, mixed, or redirect mode.
-     * See also related attributes zimbraMailProxyPort and
-     * zimbraMailSSLProxyPort
+     * whether to run proxy in HTTPS or redirect mode. See also related
+     * attributes zimbraMailProxyPort and zimbraMailSSLProxyPort
      *
-     * <p>Valid values: [http, https, both, mixed, redirect]
+     * <p>Valid values: [https, redirect]
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2349,14 +2349,8 @@ public class ProxyConfGen {
           new File(mTemplateDir, getWebHttpModeConfTemplate("https")),
           new File(mConfIncludesDir, getWebHttpModeConf("https")));
       expandTemplate(
-          new File(mTemplateDir, getWebHttpModeConfTemplate("both")),
-          new File(mConfIncludesDir, getWebHttpModeConf("both")));
-      expandTemplate(
           new File(mTemplateDir, getWebHttpModeConfTemplate("redirect")),
           new File(mConfIncludesDir, getWebHttpModeConf("redirect")));
-      expandTemplate(
-          new File(mTemplateDir, getWebHttpModeConfTemplate("mixed")),
-          new File(mConfIncludesDir, getWebHttpModeConf("mixed")));
       expandTemplate(
           new File(mTemplateDir, getWebHttpSModeConfTemplate("http")),
           new File(mConfIncludesDir, getWebHttpSModeConf("http")));
@@ -2364,14 +2358,8 @@ public class ProxyConfGen {
           new File(mTemplateDir, getWebHttpSModeConfTemplate("https")),
           new File(mConfIncludesDir, getWebHttpSModeConf("https")));
       expandTemplate(
-          new File(mTemplateDir, getWebHttpSModeConfTemplate("both")),
-          new File(mConfIncludesDir, getWebHttpSModeConf("both")));
-      expandTemplate(
           new File(mTemplateDir, getWebHttpSModeConfTemplate("redirect")),
           new File(mConfIncludesDir, getWebHttpSModeConf("redirect")));
-      expandTemplate(
-          new File(mTemplateDir, getWebHttpSModeConfTemplate("mixed")),
-          new File(mConfIncludesDir, getWebHttpSModeConf("mixed")));
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("web.carbonio.admin.default")),
           new File(mConfIncludesDir, getConfFileName("web.carbonio.admin.default")));

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -1485,10 +1485,10 @@ public class ProxyConfGen {
         new ProxyConfVar(
             "web.mailmode",
             ZAttrProvisioning.A_zimbraReverseProxyMailMode,
-            "both",
+            "https",
             ProxyConfValueType.STRING,
             ProxyConfOverride.SERVER,
-            "Reverse Proxy Mail Mode - can be http|https|both|redirect|mixed"));
+            "Reverse Proxy Mail Mode - can be https|redirect"));
     mConfVars.put(
         "web.server_name.default",
         new ProxyConfVar(


### PR DESCRIPTION
**What has changed:**
- Remove both and mixed mode template expansion
    - mixed and both mode templates are no longer required
- update default value of zimbraReverseProxyMailMode to https from both mode
- source code generation (this also includes updates we missed in #151 & #152)

**Realted PRs:**
- https://github.com/Zextras/carbonio-nginx-conf/pull/46