### PR TITLE
feat: [CO-536] Add/update CSP headers in ReverseProxyResponseHeaders  

### DIFF
--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -8882,10 +8882,12 @@ TODO: delete them permanently from here
   <globalConfigValue>Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"</globalConfigValue>
   <globalConfigValue>Permissions-Policy: "geolocation=(self), microphone=(self)"</globalConfigValue>
   <globalConfigValue>Referrer-Policy: "same-origin"</globalConfigValue>
-  <globalConfigValue>X-Content-Type-Options: nosniff"</globalConfigValue>
-  <globalConfigValue>X-Robots-Tag: noindex"</globalConfigValue>
+  <globalConfigValue>X-Content-Type-Options: "nosniff"</globalConfigValue>
+  <globalConfigValue>X-Robots-Tag: "noindex, nofollow"</globalConfigValue>
   <globalConfigValue>X-XSS-Protection: "1; mode=block"</globalConfigValue>
+  <globalConfigValue>X-Frame-Options: "sameorigin"</globalConfigValue>
   <globalConfigValue>Expect-CT: max-age=86400</globalConfigValue>
+  <globalConfigValue>Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src 'self' data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src 'self'; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self'"</globalConfigValue>
   <desc>
      Custom response headers to be added by the proxy. For example, can be used to add a HSTS header
      that will enforce SSL usage on the client side. Note: the value

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -61434,7 +61434,7 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=1973)
     public String[] getReverseProxyResponseHeaders() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: nosniff\"","X-Robots-Tag: noindex\"","X-XSS-Protection: \"1; mode=block\"","Expect-CT: max-age=86400"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400","Content-Security-Policy: \"default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src 'self' data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src 'self'; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self'\""};
     }
 
     /**

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -20510,7 +20510,7 @@ public abstract class ZAttrDomain extends NamedEntry {
      */
     @ZAttr(id=1973)
     public String[] getReverseProxyResponseHeaders() {
-        String[] value = getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: nosniff\"","X-Robots-Tag: noindex\"","X-XSS-Protection: \"1; mode=block\"","Expect-CT: max-age=86400"};
+        String[] value = getMultiAttr(Provisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400","Content-Security-Policy: \"default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src 'self' data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src 'self'; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self'\""};
     }
 
     /**


### PR DESCRIPTION
**What has changed:**
- fix existing headers
- add X-Frame-Options for backward compatibility
- add rules to enforce CSP 

**Other PRs:**
- https://github.com/Zextras/carbonio-ldap-utilities/pull/30
- https://github.com/Zextras/carbonio-nginx-conf/pull/50