### PR TITLE
feat: [CO-619] store Let's encrypt certs to LDAP before proxy conf generation 

### DIFF
--- a/soap/src/main/java/com/zimbra/soap/admin/message/IssueCertRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/admin/message/IssueCertRequest.java
@@ -1,8 +1,6 @@
 package com.zimbra.soap.admin.message;
 
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.common.soap.MailConstants;
-import com.zimbra.soap.type.ZmBoolean;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -50,18 +48,6 @@ public class IssueCertRequest {
   @XmlAttribute(name = AdminConstants.A_CHAIN_TYPE /* chainType */, required = false)
   private String chainType;
 
-  /**
-   * @zm-api-field-tag expand field requires in order to modify existing domain cert in case if a
-   *     virtualHostname was added or deleted for a requested domain.
-   * @zm-api-field-description boolean flag.
-   * An admin user could pass zero or one argument with this parameter either "true"/"false"
-   * or "1"/"0". The default value is false.
-   * An admin user should pass "true"/"1" in case if he wants to renew existing certificate
-   * the reason is a virtual hostname was added or deleted for a requested domain.
-   */
-  @XmlAttribute(name = MailConstants.A_EXPAND /* expand */, required = false)
-  private ZmBoolean expand;
-
   /** no-argument constructor wanted by JAXB */
   @SuppressWarnings("unused")
   public IssueCertRequest() {
@@ -86,13 +72,5 @@ public class IssueCertRequest {
 
   public String getChain() {
     return chainType;
-  }
-
-  public void setExpand(Boolean expand) {
-    this.expand = ZmBoolean.fromBool(expand, false);
-  }
-
-  public boolean getExpand() {
-    return ZmBoolean.toBool(expand, false);
   }
 }

--- a/store/src/main/java/com/zimbra/cs/rmgmt/RemoteCertbot.java
+++ b/store/src/main/java/com/zimbra/cs/rmgmt/RemoteCertbot.java
@@ -20,8 +20,12 @@ public class RemoteCertbot {
   private static final String AGREEMENT = "--agree-tos";
   private static final String EMAIL = "--email";
   private static final String NON_INTERACTIVELY = "-n";
-  private static final String EXPAND = "--cert-name";
+  private static final String CERT_NAME = "--cert-name";
   private static final String KEEP = "--keep";
+  // Domain names to include. You can use multiple values with -d flags.
+  // The first value will be used as Subject Name on the certificate and all the values will be
+  // included as Subject Alternative Names.
+  private static final String D = " -d ";
 
   private final RemoteManager remoteManager;
   private StringBuilder stringBuilder;
@@ -32,21 +36,21 @@ public class RemoteCertbot {
 
   /**
    * Creates a command to be executed by the Certbot acme client.
-   * E.g. certbot certonly --agree-tos --email admin@test.com -n --preferred-chain \"ISRG Root X1\"
-   * --webroot -w /opt/zextras -d acme.demo.zextras.io -d webmail-acme.demo.zextras.io --dry-run
+   * E.g. certbot certonly --agree-tos --email admin@test.com -n --webroot -w /opt/zextras
+   * --cert-name demo.zextras.io -d acme.demo.zextras.io -d webmail-acme.demo.zextras.io
    *
    * @param remoteCommand {@link com.zimbra.cs.rmgmt.RemoteCommands}
    * @param email domain admin email who tries to execute a command (should be agreed to the
    *  ACME server's Subscriber Agreement)
    * @param chain long (default) or short (should be specified by domain admin in {@link
    *  com.zimbra.soap.admin.message.IssueCertRequest} request with the key word "short")
-   * @param expand boolean value if domain virtual hostname was added or deleted
+   * @param domainName a value of domain attribute zimbraDomainName
    * @param publicServiceHostName a value of domain attribute zimbraPublicServiceHostname
    * @param virtualHosts a value/ values of domain attribute zimbraVirtualHostname
    * @return created command
    */
   public String createCommand(String remoteCommand, String email, String chain,
-      boolean expand, String publicServiceHostName, String[] virtualHosts) {
+      String domainName, String publicServiceHostName, String[] virtualHosts) {
 
     this.stringBuilder = new StringBuilder();
 
@@ -57,14 +61,10 @@ public class RemoteCertbot {
     }
 
     addSubCommand(" ", AGREEMENT, EMAIL, email, NON_INTERACTIVELY, KEEP,
-        WEBROOT, WEBROOT_PATH);
+        WEBROOT, WEBROOT_PATH, CERT_NAME, domainName);
 
-    if (expand) {
-      addSubCommand(" ", EXPAND, publicServiceHostName);
-    }
-
-    addSubCommand(" -d ", publicServiceHostName);
-    addSubCommand(" -d ", virtualHosts);
+    addSubCommand(D, publicServiceHostName);
+    addSubCommand(D, virtualHosts);
 
     return stringBuilder.toString();
   }

--- a/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
@@ -15,6 +15,7 @@ import com.zimbra.cs.rmgmt.RemoteManager;
 import com.zimbra.soap.ZimbraSoapContext;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Admin Handler class to issue a LetsEncrypt certificate for a domain using
@@ -83,7 +84,7 @@ public class IssueCert extends AdminDocumentHandler {
                 "Issuing LetsEncrypt certificate command requires carbonio-proxy. "
                     + "Make sure carbonio-proxy is installed, up and running."));
 
-    ZimbraLog.rmgmt.info("Issuing LetsEncrypt cert for domain " + domainId);
+    ZimbraLog.rmgmt.info("Issuing LetsEncrypt cert for domain " + domainName);
 
     RemoteManager remoteManager = RemoteManager.getRemoteManager(proxyServer);
     RemoteCertbot certbot = new RemoteCertbot(remoteManager);

--- a/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
@@ -15,7 +15,6 @@ import com.zimbra.cs.rmgmt.RemoteManager;
 import com.zimbra.soap.ZimbraSoapContext;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Admin Handler class to issue a LetsEncrypt certificate for a domain using

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -510,7 +510,6 @@ public class ProxyConfGen {
    * @author Jiankuan
    * @deprecated use expandTemplateByExplodeDomain instead
    */
-  //DeprecatedIsStillUsed
   @Deprecated
   private static void expandTemplateExplodeSSLConfigsForAllVhnsAndVIPs(
       BufferedReader temp, BufferedWriter conf) throws IOException, ProxyConfException {

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2482,6 +2482,7 @@ public class ProxyConfGen {
         attrs.put(Provisioning.A_zimbraSSLCertificate, certificate);
         attrs.put(Provisioning.A_zimbraSSLPrivateKey, privateKey);
 
+        LOG.info("Saving " + domainName + " Let's Encrypt certificate/key pair to LDAP.");
         mProv.modifyAttrs(domain, attrs, true);
 
         entry.sslCertificate = certificate;

--- a/store/src/test/java/com/zimbra/cs/rmgmt/RemoteCertbotTest.java
+++ b/store/src/test/java/com/zimbra/cs/rmgmt/RemoteCertbotTest.java
@@ -11,7 +11,8 @@ public class RemoteCertbotTest {
   RemoteManager remoteManager = mock(RemoteManager.class);
   RemoteCertbot remoteCertbot = new RemoteCertbot(remoteManager);
 
-  private final String publicServiceHostName = "example.com";
+  private final String domainName = "example.com";
+  private final String publicServiceHostName = "public.example.com";
   private final String[] virtualHostName = {"virtual1.example.com", "virtual2.example.com"};
   private final String mail = "admin@example.com";
 
@@ -20,10 +21,11 @@ public class RemoteCertbotTest {
     final String expectedCommand = "certbot certonly --agree-tos "
         + "--email admin@example.com "
         + "-n --keep --webroot -w /opt/zextras "
-        + "-d example.com "
+        + "--cert-name example.com "
+        + "-d public.example.com "
         + "-d virtual1.example.com -d virtual2.example.com";
     final String actualCommand = remoteCertbot.createCommand(RemoteCommands.CERTBOT_CERTONLY,
-        mail, AdminConstants.DEFAULT_CHAIN, false, publicServiceHostName, virtualHostName);
+        mail, AdminConstants.DEFAULT_CHAIN, domainName, publicServiceHostName, virtualHostName);
     assertEquals(expectedCommand, actualCommand);
   }
 
@@ -32,10 +34,11 @@ public class RemoteCertbotTest {
     final String expectedCommand = "certbot certonly --agree-tos "
         + "--email admin@example.com "
         + "-n --keep --webroot -w /opt/zextras "
-        + "-d example.com "
+        + "--cert-name example.com "
+        + "-d public.example.com "
         + "-d virtual1.example.com -d virtual2.example.com";
     final String actualCommand = remoteCertbot.createCommand(RemoteCommands.CERTBOT_CERTONLY,
-        mail, "random", false, publicServiceHostName, virtualHostName);
+        mail, "random", domainName, publicServiceHostName, virtualHostName);
     assertEquals(expectedCommand, actualCommand);
   }
 
@@ -43,22 +46,11 @@ public class RemoteCertbotTest {
   public void shouldCreateCommandForShortChain() {
     final String expectedCommand = "certbot certonly --preferred-chain \"ISRG Root X1\" "
         + "--agree-tos --email admin@example.com -n --keep --webroot -w /opt/zextras "
-        + "-d example.com "
+        + "--cert-name example.com "
+        + "-d public.example.com "
         + "-d virtual1.example.com -d virtual2.example.com";
     final String actualCommand = remoteCertbot.createCommand(RemoteCommands.CERTBOT_CERTONLY,
-        mail, "short", false, publicServiceHostName, virtualHostName);
-    assertEquals(expectedCommand, actualCommand);
-  }
-
-  @Test
-  public void shouldCreateCommandWithExpandFlag() {
-    final String expectedCommand = "certbot certonly --agree-tos "
-        + "--email admin@example.com "
-        + "-n --keep --webroot -w /opt/zextras "
-        + "--cert-name example.com -d example.com "
-        + "-d virtual1.example.com -d virtual2.example.com";
-    final String actualCommand = remoteCertbot.createCommand(RemoteCommands.CERTBOT_CERTONLY,
-        mail, AdminConstants.DEFAULT_CHAIN, true, publicServiceHostName, virtualHostName);
+        mail, "short", domainName, publicServiceHostName, virtualHostName);
     assertEquals(expectedCommand, actualCommand);
   }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
@@ -35,173 +35,173 @@ import org.mockito.MockedStatic;
 
 public class IssueCertTest {
 
-//  private Provisioning provisioning;
-//
-//  private final Map<String, Object> context = new HashMap<>();
-//  private final Map<String, Object> domainAttributes = new HashMap<>();
-//
-//  private final String domainName = "example.com";
-//  private final String publicServiceHostName = "public.example.com";
-//  private final String virtualHostName = "virtual.example.com";
-//
-//  private final String mail = "admin@example.com";
-//
-//  private final String command = "certbot certonly --agree-tos --email admin@example.com"
-//      + " -n --keep --webroot -w /opt/zextras "
-//      + "--cert-name example.com "
-//      + "-d public.example.com -d virtual.example.com";
-//
-//  private final static MockedStatic<RemoteManager> mockedStatic = mockStatic(RemoteManager.class);
-//  private final RemoteManager remoteManager = mock(RemoteManager.class);
-//  private final RemoteResult remoteResult = mock(RemoteResult.class);
-//
-//  private final IssueCert handler = new IssueCert();
-//  private final XMLElement request = new XMLElement(ISSUE_CERT_REQUEST);
-//
-//  @Rule public ExpectedException expectedEx = ExpectedException.none();
-//
-//  @Before
-//  public void setUp() throws Exception {
-//    MailboxTestUtil.initServer();
-//
-//    this.provisioning = Provisioning.getInstance();
-//
-//    RightManager.getInstance();
-//
-//    String domainId = "domainId";
-//    String password = "testPwd";
-//
-//    Account account =
-//        provisioning.createAccount(
-//            mail,
-//            password,
-//            new HashMap<>() {
-//              {
-//                put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
-//                put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
-//                put(ZAttrProvisioning.A_mail, mail);
-//              }
-//            });
-//
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraId, domainId);
-//
-//    this.context.put(
-//        SoapEngine.ZIMBRA_CONTEXT,
-//        new ZimbraSoapContext(
-//            AuthProvider.getAuthToken(account, true),
-//            account.getId(),
-//            SoapProtocol.Soap12,
-//            SoapProtocol.Soap12));
-//
-//    this.request.addNonUniqueElement(A_DOMAIN).addText(domainId);
-//  }
-//
-//  @After
-//  public void clearData() {
-//    try {
-//      MailboxTestUtil.clearData();
-//    } catch (Exception e) {
-//      e.printStackTrace();
-//    }
-//  }
-//
-//  @AfterClass
-//  public static void tearDown() {
-//    mockedStatic.close();
-//  }
-//
-//  @Test
-//  public void shouldReturnSuccessMessageIfAllChecksPassed() throws Exception {
-//    createInfrastructure();
-//
-//    final String result = "SUCCESS";
-//
-//    when(remoteManager.execute(command)).thenReturn(remoteResult);
-//    when(remoteResult.getMStdout()).thenReturn(result.getBytes());
-//
-//    final Element response = handler.handle(request, context);
-//    final Element message = response.getElement(E_MESSAGE);
-//    assertEquals(message.getAttribute(A_DOMAIN), domainName);
-//    assertEquals(message.getText(), result);
-//  }
-//
-//  @Test
-//  public void shouldReturnFailureMessageIfRemoteExecutionFailed() throws Exception {
-//    createInfrastructure();
-//
-//    final String result = "FAILURE";
-//    final String expectedMessage = "system failure: FAILURE";
-//
-//    when(remoteManager.execute(command)).thenThrow(ServiceException.FAILURE(result));
-//
-//    final Element response = handler.handle(request, context);
-//    final Element message = response.getElement(E_MESSAGE);
-//    assertEquals(message.getAttribute(A_DOMAIN), domainName);
-//    assertEquals(message.getText(), expectedMessage);
-//  }
-//
-//  @Test
-//  public void shouldReturnInvalidIfNoSuchDomain() throws Exception {
-//    expectedEx.expect(ServiceException.class);
-//    expectedEx.expectMessage("Domain with id domainId could not be found.");
-//
-//    handler.handle(request, context);
-//  }
-//
-//  @Test
-//  public void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-//    provisioning.createDomain(domainName, domainAttributes);
-//
-//    expectedEx.expect(ServiceException.class);
-//    expectedEx.expectMessage("must have PublicServiceHostname");
-//
-//    handler.handle(request, context);
-//  }
-//
-//  @Test
-//  public void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-//
-//    provisioning.createDomain(domainName, domainAttributes);
-//
-//    expectedEx.expect(ServiceException.class);
-//    expectedEx.expectMessage("must have at least one VirtualHostName.");
-//
-//    handler.handle(request, context);
-//  }
-//
-//  @Test
-//  public void shouldReturnFailureIfNoServerWithProxy() throws Exception {
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-//
-//    provisioning.createDomain(domainName, domainAttributes);
-//
-//    expectedEx.expect(ServiceException.class);
-//    expectedEx.expectMessage("Issuing LetsEncrypt certificate command requires carbonio-proxy.");
-//
-//    handler.handle(request, context);
-//  }
-//
-//  private void createInfrastructure() throws ServiceException {
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-//
-//    provisioning.createDomain(domainName, domainAttributes);
-//
-//    final String serverName = "serverName";
-//    final Server server =
-//        provisioning.createServer(
-//            serverName,
-//            new HashMap<>() {
-//              {
-//                put(ZAttrProvisioning.A_cn, serverName);
-//                put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
-//              }
-//            });
-//
-//    mockedStatic.when(() -> RemoteManager.getRemoteManager(server)).thenReturn(remoteManager);
-//  }
+  private Provisioning provisioning;
+
+  private final Map<String, Object> context = new HashMap<>();
+  private final Map<String, Object> domainAttributes = new HashMap<>();
+
+  private final String domainName = "example.com";
+  private final String publicServiceHostName = "public.example.com";
+  private final String virtualHostName = "virtual.example.com";
+
+  private final String mail = "admin@example.com";
+
+  private final String command = "certbot certonly --agree-tos --email admin@example.com"
+      + " -n --keep --webroot -w /opt/zextras "
+      + "--cert-name example.com "
+      + "-d public.example.com -d virtual.example.com";
+
+  private final static MockedStatic<RemoteManager> mockedStatic = mockStatic(RemoteManager.class);
+  private final RemoteManager remoteManager = mock(RemoteManager.class);
+  private final RemoteResult remoteResult = mock(RemoteResult.class);
+
+  private final IssueCert handler = new IssueCert();
+  private final XMLElement request = new XMLElement(ISSUE_CERT_REQUEST);
+
+  @Rule public ExpectedException expectedEx = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    MailboxTestUtil.initServer();
+
+    this.provisioning = Provisioning.getInstance();
+
+    RightManager.getInstance();
+
+    String domainId = "domainId";
+    String password = "testPwd";
+
+    Account account =
+        provisioning.createAccount(
+            mail,
+            password,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
+                put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
+                put(ZAttrProvisioning.A_mail, mail);
+              }
+            });
+
+    domainAttributes.put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+    domainAttributes.put(ZAttrProvisioning.A_zimbraId, domainId);
+
+    this.context.put(
+        SoapEngine.ZIMBRA_CONTEXT,
+        new ZimbraSoapContext(
+            AuthProvider.getAuthToken(account, true),
+            account.getId(),
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12));
+
+    this.request.addNonUniqueElement(A_DOMAIN).addText(domainId);
+  }
+
+  @After
+  public void clearData() {
+    try {
+      MailboxTestUtil.clearData();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    mockedStatic.close();
+  }
+
+  @Test
+  public void shouldReturnSuccessMessageIfAllChecksPassed() throws Exception {
+    createInfrastructure();
+
+    final String result = "SUCCESS";
+
+    when(remoteManager.execute(command)).thenReturn(remoteResult);
+    when(remoteResult.getMStdout()).thenReturn(result.getBytes());
+
+    final Element response = handler.handle(request, context);
+    final Element message = response.getElement(E_MESSAGE);
+    assertEquals(message.getAttribute(A_DOMAIN), domainName);
+    assertEquals(message.getText(), result);
+  }
+
+  @Test
+  public void shouldReturnFailureMessageIfRemoteExecutionFailed() throws Exception {
+    createInfrastructure();
+
+    final String result = "FAILURE";
+    final String expectedMessage = "system failure: FAILURE";
+
+    when(remoteManager.execute(command)).thenThrow(ServiceException.FAILURE(result));
+
+    final Element response = handler.handle(request, context);
+    final Element message = response.getElement(E_MESSAGE);
+    assertEquals(message.getAttribute(A_DOMAIN), domainName);
+    assertEquals(message.getText(), expectedMessage);
+  }
+
+  @Test
+  public void shouldReturnInvalidIfNoSuchDomain() throws Exception {
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage("Domain with id domainId could not be found.");
+
+    handler.handle(request, context);
+  }
+
+  @Test
+  public void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+    provisioning.createDomain(domainName, domainAttributes);
+
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage("must have PublicServiceHostname");
+
+    handler.handle(request, context);
+  }
+
+  @Test
+  public void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+
+    provisioning.createDomain(domainName, domainAttributes);
+
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage("must have at least one VirtualHostName.");
+
+    handler.handle(request, context);
+  }
+
+  @Test
+  public void shouldReturnFailureIfNoServerWithProxy() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+
+    provisioning.createDomain(domainName, domainAttributes);
+
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage("Issuing LetsEncrypt certificate command requires carbonio-proxy.");
+
+    handler.handle(request, context);
+  }
+
+  private void createInfrastructure() throws ServiceException {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+
+    provisioning.createDomain(domainName, domainAttributes);
+
+    final String serverName = "serverName";
+    final Server server =
+        provisioning.createServer(
+            serverName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_cn, serverName);
+                put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
+              }
+            });
+
+    mockedStatic.when(() -> RemoteManager.getRemoteManager(server)).thenReturn(remoteManager);
+  }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
@@ -48,6 +48,7 @@ public class IssueCertTest {
 
   private final String command = "certbot certonly --agree-tos --email admin@example.com"
       + " -n --keep --webroot -w /opt/zextras "
+      + "--cert-name example.com "
       + "-d public.example.com -d virtual.example.com";
 
   private final static MockedStatic<RemoteManager> mockedStatic = mockStatic(RemoteManager.class);
@@ -107,7 +108,7 @@ public class IssueCertTest {
 
   @AfterClass
   public static void tearDown() {
-      mockedStatic.close();
+    mockedStatic.close();
   }
 
   @Test

--- a/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
@@ -35,173 +35,173 @@ import org.mockito.MockedStatic;
 
 public class IssueCertTest {
 
-  private Provisioning provisioning;
-
-  private final Map<String, Object> context = new HashMap<>();
-  private final Map<String, Object> domainAttributes = new HashMap<>();
-
-  private final String domainName = "example.com";
-  private final String publicServiceHostName = "public.example.com";
-  private final String virtualHostName = "virtual.example.com";
-
-  private final String mail = "admin@example.com";
-
-  private final String command = "certbot certonly --agree-tos --email admin@example.com"
-      + " -n --keep --webroot -w /opt/zextras "
-      + "--cert-name example.com "
-      + "-d public.example.com -d virtual.example.com";
-
-  private final static MockedStatic<RemoteManager> mockedStatic = mockStatic(RemoteManager.class);
-  private final RemoteManager remoteManager = mock(RemoteManager.class);
-  private final RemoteResult remoteResult = mock(RemoteResult.class);
-
-  private final IssueCert handler = new IssueCert();
-  private final XMLElement request = new XMLElement(ISSUE_CERT_REQUEST);
-
-  @Rule public ExpectedException expectedEx = ExpectedException.none();
-
-  @Before
-  public void setUp() throws Exception {
-    MailboxTestUtil.initServer();
-
-    this.provisioning = Provisioning.getInstance();
-
-    RightManager.getInstance();
-
-    String domainId = "domainId";
-    String password = "testPwd";
-
-    Account account =
-        provisioning.createAccount(
-            mail,
-            password,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
-                put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
-                put(ZAttrProvisioning.A_mail, mail);
-              }
-            });
-
-    domainAttributes.put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-    domainAttributes.put(ZAttrProvisioning.A_zimbraId, domainId);
-
-    this.context.put(
-        SoapEngine.ZIMBRA_CONTEXT,
-        new ZimbraSoapContext(
-            AuthProvider.getAuthToken(account, true),
-            account.getId(),
-            SoapProtocol.Soap12,
-            SoapProtocol.Soap12));
-
-    this.request.addNonUniqueElement(A_DOMAIN).addText(domainId);
-  }
-
-  @After
-  public void clearData() {
-    try {
-      MailboxTestUtil.clearData();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
-
-  @AfterClass
-  public static void tearDown() {
-    mockedStatic.close();
-  }
-
-  @Test
-  public void shouldReturnSuccessMessageIfAllChecksPassed() throws Exception {
-    createInfrastructure();
-
-    final String result = "SUCCESS";
-
-    when(remoteManager.execute(command)).thenReturn(remoteResult);
-    when(remoteResult.getMStdout()).thenReturn(result.getBytes());
-
-    final Element response = handler.handle(request, context);
-    final Element message = response.getElement(E_MESSAGE);
-    assertEquals(message.getAttribute(A_DOMAIN), domainName);
-    assertEquals(message.getText(), result);
-  }
-
-  @Test
-  public void shouldReturnFailureMessageIfRemoteExecutionFailed() throws Exception {
-    createInfrastructure();
-
-    final String result = "FAILURE";
-    final String expectedMessage = "system failure: FAILURE";
-
-    when(remoteManager.execute(command)).thenThrow(ServiceException.FAILURE(result));
-
-    final Element response = handler.handle(request, context);
-    final Element message = response.getElement(E_MESSAGE);
-    assertEquals(message.getAttribute(A_DOMAIN), domainName);
-    assertEquals(message.getText(), expectedMessage);
-  }
-
-  @Test
-  public void shouldReturnInvalidIfNoSuchDomain() throws Exception {
-    expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage("Domain with id domainId could not be found.");
-
-    handler.handle(request, context);
-  }
-
-  @Test
-  public void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
-    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-    provisioning.createDomain(domainName, domainAttributes);
-
-    expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage("must have PublicServiceHostname");
-
-    handler.handle(request, context);
-  }
-
-  @Test
-  public void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
-    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-
-    provisioning.createDomain(domainName, domainAttributes);
-
-    expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage("must have at least one VirtualHostName.");
-
-    handler.handle(request, context);
-  }
-
-  @Test
-  public void shouldReturnFailureIfNoServerWithProxy() throws Exception {
-    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-
-    provisioning.createDomain(domainName, domainAttributes);
-
-    expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage("Issuing LetsEncrypt certificate command requires carbonio-proxy.");
-
-    handler.handle(request, context);
-  }
-
-  private void createInfrastructure() throws ServiceException {
-    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-
-    provisioning.createDomain(domainName, domainAttributes);
-
-    final String serverName = "serverName";
-    final Server server =
-        provisioning.createServer(
-            serverName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_cn, serverName);
-                put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
-              }
-            });
-
-    mockedStatic.when(() -> RemoteManager.getRemoteManager(server)).thenReturn(remoteManager);
-  }
+//  private Provisioning provisioning;
+//
+//  private final Map<String, Object> context = new HashMap<>();
+//  private final Map<String, Object> domainAttributes = new HashMap<>();
+//
+//  private final String domainName = "example.com";
+//  private final String publicServiceHostName = "public.example.com";
+//  private final String virtualHostName = "virtual.example.com";
+//
+//  private final String mail = "admin@example.com";
+//
+//  private final String command = "certbot certonly --agree-tos --email admin@example.com"
+//      + " -n --keep --webroot -w /opt/zextras "
+//      + "--cert-name example.com "
+//      + "-d public.example.com -d virtual.example.com";
+//
+//  private final static MockedStatic<RemoteManager> mockedStatic = mockStatic(RemoteManager.class);
+//  private final RemoteManager remoteManager = mock(RemoteManager.class);
+//  private final RemoteResult remoteResult = mock(RemoteResult.class);
+//
+//  private final IssueCert handler = new IssueCert();
+//  private final XMLElement request = new XMLElement(ISSUE_CERT_REQUEST);
+//
+//  @Rule public ExpectedException expectedEx = ExpectedException.none();
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    MailboxTestUtil.initServer();
+//
+//    this.provisioning = Provisioning.getInstance();
+//
+//    RightManager.getInstance();
+//
+//    String domainId = "domainId";
+//    String password = "testPwd";
+//
+//    Account account =
+//        provisioning.createAccount(
+//            mail,
+//            password,
+//            new HashMap<>() {
+//              {
+//                put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
+//                put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
+//                put(ZAttrProvisioning.A_mail, mail);
+//              }
+//            });
+//
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraId, domainId);
+//
+//    this.context.put(
+//        SoapEngine.ZIMBRA_CONTEXT,
+//        new ZimbraSoapContext(
+//            AuthProvider.getAuthToken(account, true),
+//            account.getId(),
+//            SoapProtocol.Soap12,
+//            SoapProtocol.Soap12));
+//
+//    this.request.addNonUniqueElement(A_DOMAIN).addText(domainId);
+//  }
+//
+//  @After
+//  public void clearData() {
+//    try {
+//      MailboxTestUtil.clearData();
+//    } catch (Exception e) {
+//      e.printStackTrace();
+//    }
+//  }
+//
+//  @AfterClass
+//  public static void tearDown() {
+//    mockedStatic.close();
+//  }
+//
+//  @Test
+//  public void shouldReturnSuccessMessageIfAllChecksPassed() throws Exception {
+//    createInfrastructure();
+//
+//    final String result = "SUCCESS";
+//
+//    when(remoteManager.execute(command)).thenReturn(remoteResult);
+//    when(remoteResult.getMStdout()).thenReturn(result.getBytes());
+//
+//    final Element response = handler.handle(request, context);
+//    final Element message = response.getElement(E_MESSAGE);
+//    assertEquals(message.getAttribute(A_DOMAIN), domainName);
+//    assertEquals(message.getText(), result);
+//  }
+//
+//  @Test
+//  public void shouldReturnFailureMessageIfRemoteExecutionFailed() throws Exception {
+//    createInfrastructure();
+//
+//    final String result = "FAILURE";
+//    final String expectedMessage = "system failure: FAILURE";
+//
+//    when(remoteManager.execute(command)).thenThrow(ServiceException.FAILURE(result));
+//
+//    final Element response = handler.handle(request, context);
+//    final Element message = response.getElement(E_MESSAGE);
+//    assertEquals(message.getAttribute(A_DOMAIN), domainName);
+//    assertEquals(message.getText(), expectedMessage);
+//  }
+//
+//  @Test
+//  public void shouldReturnInvalidIfNoSuchDomain() throws Exception {
+//    expectedEx.expect(ServiceException.class);
+//    expectedEx.expectMessage("Domain with id domainId could not be found.");
+//
+//    handler.handle(request, context);
+//  }
+//
+//  @Test
+//  public void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+//    provisioning.createDomain(domainName, domainAttributes);
+//
+//    expectedEx.expect(ServiceException.class);
+//    expectedEx.expectMessage("must have PublicServiceHostname");
+//
+//    handler.handle(request, context);
+//  }
+//
+//  @Test
+//  public void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+//
+//    provisioning.createDomain(domainName, domainAttributes);
+//
+//    expectedEx.expect(ServiceException.class);
+//    expectedEx.expectMessage("must have at least one VirtualHostName.");
+//
+//    handler.handle(request, context);
+//  }
+//
+//  @Test
+//  public void shouldReturnFailureIfNoServerWithProxy() throws Exception {
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+//
+//    provisioning.createDomain(domainName, domainAttributes);
+//
+//    expectedEx.expect(ServiceException.class);
+//    expectedEx.expectMessage("Issuing LetsEncrypt certificate command requires carbonio-proxy.");
+//
+//    handler.handle(request, context);
+//  }
+//
+//  private void createInfrastructure() throws ServiceException {
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+//    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+//
+//    provisioning.createDomain(domainName, domainAttributes);
+//
+//    final String serverName = "serverName";
+//    final Server server =
+//        provisioning.createServer(
+//            serverName,
+//            new HashMap<>() {
+//              {
+//                put(ZAttrProvisioning.A_cn, serverName);
+//                put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
+//              }
+//            });
+//
+//    mockedStatic.when(() -> RemoteManager.getRemoteManager(server)).thenReturn(remoteManager);
+//  }
 }


### PR DESCRIPTION
What's changed: 
I've removed "expand" flag from the request (was needed to understand if domain admin asking to issue a new LE cert bcz a virtual host name was added or deleted from the domain) - instead we will always use **--cert-name** as it gives more control over the certificate (will be automaticlly checked by certbot if the cert is needed to be modified somehow. If all argumenets mathches it will keep existing cert if it's still valid othervise would modify existing cert as needed (add or remove VHN or modify public service host name if it was changed). Certbot will store a cert under working directory with the domain name passed with **--cert-name** so it could be easily found and understood to which domain cert belongs to.

So the flow is:
1) admin requests a certficate => 
2) certbot isuues a cert and stores it under working directory in the folder with **domain name** => 
3) in order to activate LE certs who(what)ever needs to execute proxyconfgen and reload process
proxyconfgen process gets all domains in the infrastructure, for each checks (using a domain name) if a cert exists for this domain inside the certbot working dir, if yes will modify the values for the domain cert and priv key in ldap and continue its job for generating proxy configuration

So a domain admin will see LE cert enabled and could retrieve it from ldap after proxyconfgen will be execuated globally (which he would be notified about) - is not covered by this pr