### PR TITLE
feat: [CO-620] Enable gzip and brotli compression with ProxyConfGen

### DIFF
--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVar.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVar.java
@@ -1,0 +1,93 @@
+package com.zimbra.cs.util.proxyconfgen;
+
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.common.service.ServiceException;
+
+/**
+ * Class representing a {@link ProxyConfGen} variable, Instance of this class overrides update
+ * method and provide value based on the {@link ProxyConfVar#serverSource} attribute
+ * <p>
+ * The {@link ProxyConfVar#mValue} of this variable defines definition of proxy http compression
+ * directives namely: GZip {@link ProxyCompressionServerVar#G_ZIP_COMPRESSION_DIRECTIVE} and Brotli
+ * {@link ProxyCompressionServerVar#BROTLI_COMPRESSION_DIRECTIVE}.
+ * <p>
+ * Definition are some sane defaults hence hardcoded for simplicity.
+ * <p>
+ * The expansion of this variable depends on {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled}
+ * server and global config variable
+ *
+ * @author Keshav Bhatt
+ * @since 23.4.0
+ */
+@SuppressWarnings("StringBufferReplaceableByString")
+public class ProxyCompressionServerVar extends ProxyConfVar {
+
+  static final String DIRECTIVE_SEPARATOR = "    ";
+  static final String TYPE_DIRECTIVE_SEPARATOR = DIRECTIVE_SEPARATOR + DIRECTIVE_SEPARATOR;
+
+  private static final String TYPES = new StringBuilder()
+      .append(String.format("%sapplication/atom+xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/geo+json%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/javascript%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/x-javascript%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/json%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/ld+json%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/manifest+json%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/rdf+xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/rss+xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/xhtml+xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sapplication/xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sfont/eot%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sfont/otf%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sfont/ttf%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%sfont/woff2%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%simage/svg+xml%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%stext/css%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%stext/javascript%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%stext/plain%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%stext/xml;%n", TYPE_DIRECTIVE_SEPARATOR))
+      .append(String.format("%n"))
+      .toString();
+
+  private static final String G_ZIP_COMPRESSION_DIRECTIVE = new StringBuilder()
+      .append(String.format("%n"))
+      .append(String.format("%sgzip on;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_disable \"msie6\";%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_vary on;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_proxied any;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_comp_level 6;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_buffers 16 8k;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_http_version 1.1;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_min_length 256;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sgzip_types%n", DIRECTIVE_SEPARATOR))
+      .append(TYPES)
+      .toString();
+
+  private static final String BROTLI_COMPRESSION_DIRECTIVE = new StringBuilder()
+      .append(String.format("%n"))
+      .append(String.format("%sbrotli on;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sbrotli_static on;%n", DIRECTIVE_SEPARATOR))
+      .append(String.format("%sbrotli_types%n", DIRECTIVE_SEPARATOR))
+      .append(TYPES)
+      .toString();
+
+  protected ProxyCompressionServerVar() {
+    super(
+        "proxy.http.compression",
+        null,
+        "",
+        ProxyConfValueType.STRING,
+        ProxyConfOverride.SERVER,
+        "Proxy HTTP compression directives definition");
+  }
+
+  @Override
+  public void update() throws ServiceException {
+
+    final boolean httpCompressionEnabled = serverSource.getBooleanAttr(
+        ZAttrProvisioning.A_zimbraHttpCompressionEnabled, true);
+
+    mValue =
+        httpCompressionEnabled ? G_ZIP_COMPRESSION_DIRECTIVE + BROTLI_COMPRESSION_DIRECTIVE : "";
+  }
+}

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -855,6 +855,7 @@ public class ProxyConfGen {
     mConfVars.put("core.ipv4only.enabled", new IPv4OnlyEnablerVar());
     mConfVars.put("core.ipv6only.enabled", new IPv6OnlyEnablerVar());
     mConfVars.put("core.ipboth.enabled", new IPBothEnablerVar());
+    mConfVars.put("proxy.http.compression", new ProxyCompressionServerVar());
     mConfVars.put(
         "ssl.crt.default",
         new ProxyConfVar(

--- a/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
+++ b/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
@@ -1,0 +1,114 @@
+package com.zimbra.cs.util.proxyconfgen;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.cs.account.Entry;
+import com.zimbra.cs.account.MockServer;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ProxyCompressionServerVarTest {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      MailboxTestUtil.clearData();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void shouldUpdateProxyConfGenVarValueWhenCalledUpdate() throws Exception {
+
+    // setup
+    Entry mockServerSource = new MockServer("server", "0");
+
+    Map<String, Object> attrs = new HashMap<>();
+    attrs.put(ZAttrProvisioning.A_zimbraHttpCompressionEnabled, true);
+    mockServerSource.setAttrs(attrs);
+
+    ProxyCompressionServerVar proxyCompressionServerVar = new ProxyCompressionServerVar();
+
+    // set the mockServerSource on the ProxyCompressionServerVar instance
+    ProxyConfVar.serverSource = mockServerSource;
+
+    // execute: call the update method
+    proxyCompressionServerVar.update();
+
+    // expected value
+    final String expectedVal = "\n"
+        + "    gzip on;\n"
+        + "    gzip_disable \"msie6\";\n"
+        + "    gzip_vary on;\n"
+        + "    gzip_proxied any;\n"
+        + "    gzip_comp_level 6;\n"
+        + "    gzip_buffers 16 8k;\n"
+        + "    gzip_http_version 1.1;\n"
+        + "    gzip_min_length 256;\n"
+        + "    gzip_types\n"
+        + "        application/atom+xml\n"
+        + "        application/geo+json\n"
+        + "        application/javascript\n"
+        + "        application/x-javascript\n"
+        + "        application/json\n"
+        + "        application/ld+json\n"
+        + "        application/manifest+json\n"
+        + "        application/rdf+xml\n"
+        + "        application/rss+xml\n"
+        + "        application/xhtml+xml\n"
+        + "        application/xml\n"
+        + "        font/eot\n"
+        + "        font/otf\n"
+        + "        font/ttf\n"
+        + "        font/woff2\n"
+        + "        image/svg+xml\n"
+        + "        text/css\n"
+        + "        text/javascript\n"
+        + "        text/plain\n"
+        + "        text/xml;\n"
+        + "\n"
+        + "\n"
+        + "    brotli on;\n"
+        + "    brotli_static on;\n"
+        + "    brotli_types\n"
+        + "        application/atom+xml\n"
+        + "        application/geo+json\n"
+        + "        application/javascript\n"
+        + "        application/x-javascript\n"
+        + "        application/json\n"
+        + "        application/ld+json\n"
+        + "        application/manifest+json\n"
+        + "        application/rdf+xml\n"
+        + "        application/rss+xml\n"
+        + "        application/xhtml+xml\n"
+        + "        application/xml\n"
+        + "        font/eot\n"
+        + "        font/otf\n"
+        + "        font/ttf\n"
+        + "        font/woff2\n"
+        + "        image/svg+xml\n"
+        + "        text/css\n"
+        + "        text/javascript\n"
+        + "        text/plain\n"
+        + "        text/xml;\n"
+        + "\n";
+
+    // verify: that the value is not null or empty
+    assertNotNull(proxyCompressionServerVar.mValue);
+
+    // verify: if the value is as expected
+    assertEquals(expectedVal, proxyCompressionServerVar.mValue);
+  }
+}

--- a/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
+++ b/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
@@ -7,15 +7,11 @@ import static org.mockito.Mockito.when;
 
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.cs.account.Entry;
-import com.zimbra.cs.account.MockServer;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mock;
 
 public class ProxyCompressionServerVarTest {
 
@@ -34,19 +30,22 @@ public class ProxyCompressionServerVarTest {
   }
 
   /**
-   * test default behavior when {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled} is set to true (default)
-   * returned value must contain defined directive definition
+   * test default behavior when {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled} is set to
+   * true (default) returned value must contain defined directive definition
+   *
    * @throws Exception if any
    */
   @Test
   public void shouldUpdateProxyConfGenVarValueWhenCalledUpdate() throws Exception {
 
     // setup
-    Entry mockServerSource = new MockServer("server", "0");
+    Entry mockServerSource = mock(Server.class);
 
-    Map<String, Object> attrs = new HashMap<>();
-    attrs.put(ZAttrProvisioning.A_zimbraHttpCompressionEnabled, true);
-    mockServerSource.setAttrs(attrs);
+    // set up mock behavior to make A_zimbraHttpCompressionEnabled return true
+    // we won't use mockito ArgumentMatcher.any* and use concrete possible values
+    // to ensure method contract
+    when(mockServerSource.getBooleanAttr(ZAttrProvisioning.A_zimbraHttpCompressionEnabled,
+        true)).thenReturn(true);
 
     ProxyCompressionServerVar proxyCompressionServerVar = new ProxyCompressionServerVar();
 
@@ -124,6 +123,7 @@ public class ProxyCompressionServerVarTest {
   /**
    * test behavior when {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled} is set to false,
    * returned value must be empty
+   *
    * @throws Exception if any
    */
   @Test
@@ -131,9 +131,11 @@ public class ProxyCompressionServerVarTest {
       throws Exception {
 
     // setup
-    Entry mockServerSource = mock(Server.class); // create a mock object using Mockito
+    Entry mockServerSource = mock(Server.class);
 
     // set up mock behavior to make A_zimbraHttpCompressionEnabled return false
+    // we won't use mockito ArgumentMatcher.any* and use concrete possible values
+    // to ensure method contract
     when(mockServerSource.getBooleanAttr(ZAttrProvisioning.A_zimbraHttpCompressionEnabled,
         true)).thenReturn(false);
 
@@ -147,8 +149,6 @@ public class ProxyCompressionServerVarTest {
 
     // verify: that the value is not null or empty
     assertNotNull(proxyCompressionServerVar.mValue);
-
-    System.out.println(proxyCompressionServerVar.mValue);
 
     // verify: if the value is as expected
     assertEquals("", proxyCompressionServerVar.mValue);

--- a/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
+++ b/store/src/test/java/com/zimbra/cs/util/proxyconfgen/ProxyCompressionServerVarTest.java
@@ -2,16 +2,20 @@ package com.zimbra.cs.util.proxyconfgen;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.account.MockServer;
+import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mock;
 
 public class ProxyCompressionServerVarTest {
 
@@ -29,6 +33,11 @@ public class ProxyCompressionServerVarTest {
     }
   }
 
+  /**
+   * test default behavior when {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled} is set to true (default)
+   * returned value must contain defined directive definition
+   * @throws Exception if any
+   */
   @Test
   public void shouldUpdateProxyConfGenVarValueWhenCalledUpdate() throws Exception {
 
@@ -110,5 +119,38 @@ public class ProxyCompressionServerVarTest {
 
     // verify: if the value is as expected
     assertEquals(expectedVal, proxyCompressionServerVar.mValue);
+  }
+
+  /**
+   * test behavior when {@code ZAttrProvisioning.A_zimbraHttpCompressionEnabled} is set to false,
+   * returned value must be empty
+   * @throws Exception if any
+   */
+  @Test
+  public void shouldReturnEmptyProxyConfGenVarValueWhenCompressionDisabledAndCalledUpdate()
+      throws Exception {
+
+    // setup
+    Entry mockServerSource = mock(Server.class); // create a mock object using Mockito
+
+    // set up mock behavior to make A_zimbraHttpCompressionEnabled return false
+    when(mockServerSource.getBooleanAttr(ZAttrProvisioning.A_zimbraHttpCompressionEnabled,
+        true)).thenReturn(false);
+
+    ProxyCompressionServerVar proxyCompressionServerVar = new ProxyCompressionServerVar();
+
+    // set the mockServerSource on the ProxyCompressionServerVar instance
+    ProxyConfVar.serverSource = mockServerSource;
+
+    // execute: call the update method
+    proxyCompressionServerVar.update();
+
+    // verify: that the value is not null or empty
+    assertNotNull(proxyCompressionServerVar.mValue);
+
+    System.out.println(proxyCompressionServerVar.mValue);
+
+    // verify: if the value is as expected
+    assertEquals("", proxyCompressionServerVar.mValue);
   }
 }


### PR DESCRIPTION
**What has changed:**

- provide ProxyConfGen variable that can be expanded using templates based on HttpCompressionEnabled server and global config attribute
    - proxy.http.compression can be exploded using carbonio-proxy-templates to enable compression

**Related PRs:**

- https://github.com/Zextras/carbonio-nginx-conf/pull/51
- https://github.com/Zextras/carbonio-jetty-conf/pull/6