### PR TITLE
feat: [CO-643] Make Carbonio NotificationRecipients/From domainInherited

### DIFF
--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9992,11 +9992,11 @@ TODO: delete them permanently from here
   <globalConfigValue>https://www.zextras.com</globalConfigValue>
 </attr>
 
-<attr id="3127" name="carbonioNotificationFrom" type="email" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainAdminModifiable" since="23.4.0">
+<attr id="3127" name="carbonioNotificationFrom" type="email" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="23.4.0">
   <desc>email address of sender used to send emails about important infrastructure notifications</desc>
 </attr>
 
-<attr id="3128" name="carbonioNotificationRecipients" type="email" max="256" cardinality="multi" optionalIn="globalConfig,domain" flags="domainAdminModifiable" since="23.4.0">
+<attr id="3128" name="carbonioNotificationRecipients" type="email" max="256" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="23.4.0">
   <desc>email address of recipients who will receive emails about important infrastructure notifications</desc>
 </attr>
 </attrs>


### PR DESCRIPTION
**What has changed:**
- make carbonioNotificationRecipients and carbonioNotificationFrom inherit from global config

We missed this in the [CO-539], as it was not asked in the requirements, but it makes sense to have the domain entries inherit value from global config if they don't have these two attributes set.

This change requires no migration as 23.4.0 is not yet released.