### PR TITLE
chore: [CO-644] mailbox service-discover registration

### DIFF
--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -54,7 +54,7 @@ postinst() {
 
   usermod -a -G 'carbonio-mailbox' 'zextras'
 
-  # Copy token old token. This way services using new token can be restarted and use the new one
+  # Copy old token. This way services using new token can be restarted and use the new one
   # without the need of running pending-setups before
   if [ -f /etc/zextras/carbonio-mailbox/token ]; then
     cp /etc/zextras/carbonio-mailbox/token /etc/carbonio/mailbox/service-discover/token

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -25,19 +25,19 @@ priority="optional"
 
 package() {
   cd "${srcdir}"/../../staging
-  install -Dm 755 carbonio-mailbox packages/appserver-service/carbonio-mailbox \
+  install -Dm 755 packages/appserver-service/carbonio-mailbox \
     "${pkgdir}/usr/bin/carbonio-mailbox"
-    install -Dm 644 packages/appserver-service/carbonio-mailbox-setup.sh \
+  install -Dm 644 packages/appserver-service/carbonio-mailbox-setup.sh \
     "${pkgdir}/etc/zextras/pending-setups.d/carbonio-mailbox.sh"
-  install -Dm 644 carbonio-mailbox packages/appserver-service/carbonio-mailbox.hcl \
+  install -Dm 644 packages/appserver-service/carbonio-mailbox.hcl \
     "${pkgdir}/etc/zextras/service-discover/carbonio-mailbox.hcl"
-  install -Dm 644 carbonio-mailbox packages/appserver-service/carbonio-mailbox-sidecar.service \
+  install -Dm 644 packages/appserver-service/carbonio-mailbox-sidecar.service \
     "${pkgdir}/lib/systemd/system/carbonio-mailbox-sidecar.service"
-  install -Dm 644 carbonio-mailbox packages/appserver-service/intentions.json \
+  install -Dm 644 packages/appserver-service/intentions.json \
     "${pkgdir}/etc/carbonio/mailbox/service-discover/intentions.json"
-  install -Dm 644 carbonio-mailbox packages/appserver-service/policies.json \
+  install -Dm 644 packages/appserver-service/policies.json \
     "${pkgdir}/etc/carbonio/mailbox/service-discover/policies.json"
-  install -Dm 644 carbonio-mailbox packages/appserver-service/service-protocol.json \
+  install -Dm 644 packages/appserver-service/service-protocol.json \
     "${pkgdir}/etc/carbonio/mailbox/service-discover/service-protocol.json"
 }
 

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -25,12 +25,20 @@ priority="optional"
 
 package() {
   cd "${srcdir}"/../../staging
-  install -D packages/appserver-service/carbonio-mailbox-sidecar.service \
-    "${pkgdir}/lib/systemd/system/carbonio-mailbox-sidecar.service"
-  install -D packages/appserver-service/carbonio-mailbox.hcl \
-    "${pkgdir}/etc/zextras/service-discover/carbonio-mailbox.hcl"
-  install -D packages/appserver-service/carbonio-mailbox \
+  install -Dm 755 carbonio-mailbox packages/appserver-service/carbonio-mailbox \
     "${pkgdir}/usr/bin/carbonio-mailbox"
+    install -Dm 644 packages/appserver-service/carbonio-mailbox-setup.sh \
+    "${pkgdir}/etc/zextras/pending-setups.d/carbonio-mailbox.sh"
+  install -Dm 644 carbonio-mailbox packages/appserver-service/carbonio-mailbox.hcl \
+    "${pkgdir}/etc/zextras/service-discover/carbonio-mailbox.hcl"
+  install -Dm 644 carbonio-mailbox packages/appserver-service/carbonio-mailbox-sidecar.service \
+    "${pkgdir}/lib/systemd/system/carbonio-mailbox-sidecar.service"
+  install -Dm 644 carbonio-mailbox packages/appserver-service/intentions.json \
+    "${pkgdir}/etc/carbonio/mailbox/service-discover/intentions.json"
+  install -Dm 644 carbonio-mailbox packages/appserver-service/policies.json \
+    "${pkgdir}/etc/carbonio/mailbox/service-discover/policies.json"
+  install -Dm 644 carbonio-mailbox packages/appserver-service/service-protocol.json \
+    "${pkgdir}/etc/carbonio/mailbox/service-discover/service-protocol.json"
 }
 
 postinst() {
@@ -46,9 +54,6 @@ postinst() {
 
   usermod -a -G 'carbonio-mailbox' 'zextras'
 
-  mkdir -p '/etc/zextras/carbonio-mailbox/'
-  chown 'carbonio-mailbox:carbonio-mailbox' '/etc/zextras/carbonio-mailbox/'
-
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl enable carbonio-mailbox-sidecar.service >/dev/null 2>&1 || :
@@ -58,9 +63,18 @@ postinst() {
   echo "Carbonio Mailbox Service installed successfully!"
   echo "You must run pending-setups to configure it correctly."
   echo "======================================================"
+}
 
-  cat > /etc/zextras/pending-setups.d/carbonio-mailbox-setup.sh <<EOF
-#!/usr/bin/env bash
-carbonio-mailbox setup
-EOF
+prerm() {
+  if [ -d /run/systemd/system ]; then
+    systemctl --no-reload disable carbonio-mailbox-sidecar.service >/dev/null 2>&1 || :
+    systemctl stop carbonio-mailbox-sidecar.service >/dev/null 2>&1 || :
+  fi
+}
+
+postrm() {
+  rm -f /etc/carbonio/mailbox/service-discover/token
+  if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+  fi
 }

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -54,6 +54,12 @@ postinst() {
 
   usermod -a -G 'carbonio-mailbox' 'zextras'
 
+  # Copy token old token. This way services using new token can be restarted and use the new one
+  # without the need of running pending-setups before
+  if [ -f /etc/zextras/carbonio-mailbox/token ]; then
+    cp /etc/zextras/carbonio-mailbox/token /etc/carbonio/mailbox/service-discover/token
+  fi
+
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl enable carbonio-mailbox-sidecar.service >/dev/null 2>&1 || :

--- a/packages/appserver-service/carbonio-mailbox
+++ b/packages/appserver-service/carbonio-mailbox
@@ -6,107 +6,48 @@ if [[ $(id -u) -ne 0 ]]; then
 fi
 
 if [[ "$1" != "setup" ]]; then
-  echo "Syntax: carbonio-mailbox <setup> to automatically setup the service"
+  echo "Syntax: carbonio-mailbox setup to automatically setup the service"
   exit 1;
 fi
 
-# decrypt the bootstrap token, asking the password to the sys admin
+# Decrypt the bootstrap token, asking the password to the sys admin
 # --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
-# to avoid re-asking for the password multiple times
-echo -n "insert the cluster credential password: "
+# to avoid re-asking for the password
+echo -n "Insert the cluster credential password: "
 export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
 EXIT_CODE="$?"
 echo ""
 if [[ "${EXIT_CODE}" != "0" ]]; then
-  echo "cannot access to bootstrap token"
+  echo "Cannot access to bootstrap token"
   exit 1;
 fi
-# limit secret visibility as much as possible
+# Limit secret visibility as much as possible
 export -n SETUP_CONSUL_TOKEN
 
 POLICY_NAME='carbonio-mailbox-policy'
-POLICY_DESCRIPTION='Carbonio Mailbox service policy for config generation and for mailbox sidecar proxy'
-POLICY_RULES="$(cat <<EOF
-"key_prefix" = {
-  "carbonio-mailbox/" = {
-    "policy" = "read"
-  }
-  "carbonio-powerstore/"= {
-    "policy"= "read"
-  }
-  "carbonio-abq/"= {
-    "policy"= "read"
-  }
-  "carbonio-activesync/"= {
-    "policy"= "read"
-  }
-  "carbonio-auth/"= {
-    "policy"= "read"
-  }
-  "carbonio-core/"= {
-    "policy"= "read"
-  }
-  "carbonio-ha/"= {
-    "policy"= "read"
-  }
-}
-"node_prefix" = {
-  "" = {
-    "policy" = "read"
-  }
-}
-"service" = {
-  "carbonio-mailbox" = {
-    "policy" = "write"
-  }
-  "carbonio-mailbox-sidecar-proxy" = {
-    "policy" = "write"
-  }
-}
-EOF
-)"
+POLICY_DESCRIPTION='Carbonio Mailbox service policy for service and sidecar proxy'
 
 # create or update policy for the specific service (this will be shared across cluster)
-consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules "${POLICY_RULES}" >/dev/null 2>&1
+consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules  @/etc/carbonio/mailbox/service-discover/policies.json >/dev/null 2>&1
 if [[ "$?" != "0" ]]; then
-    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules "${POLICY_RULES}"
+    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/mailbox/service-discover/policies.json
     if [[ "$?" != "0" ]]; then
       echo "Setup failed: Cannot update policy for ${POLICY_NAME}"
       exit 1
     fi
 fi
 
-# allow user-management service to access mailbox
-cat <<EOF | consul config write -
-{
-  "kind": "service-intentions",
-  "name": "carbonio-mailbox",
-  "sources": [
-    {
-      "name": "carbonio-user-management",
-      "action": "allow"
-    },
-    {
-      "name": "carbonio-files",
-      "action": "allow"
-    }
-  ]
-}
-EOF
+trap 'echo Script for template terminated with error' EXIT
+set -e
 
-# declare the service as http
-cat <<EOF | consul config write -
-{
-  "kind": "service-defaults",
-  "name": "carbonio-mailbox",
-  "protocol": "http"
-}
-EOF
+consul config write /etc/carbonio/mailbox/service-discover/service-protocol.json
+# Allow other services to contact this service
+consul config write /etc/carbonio/mailbox/service-discover/intentions.json
 
-if [[ ! -f "/etc/zextras/carbonio-mailbox/token" ]]; then
+if [[ ! -f "/etc/carbonio/mailbox/service-discover/token" ]]; then
     # create the token
     consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for carbonio-mailbox/$(hostname -A)" |
-      jq -r '.SecretID' > /etc/zextras/carbonio-mailbox/token;
+      jq -r '.SecretID' > /etc/carbonio/mailbox/service-discover/token;
 fi
 
 chown carbonio-mailbox:carbonio-mailbox /etc/zextras/carbonio-mailbox/token
@@ -117,4 +58,7 @@ consul reload
 # limit token visibility as much as possible
 export -n CONSUL_HTTP_TOKEN
 
+# carbonio-mailbox is not managed by systemd
+
 systemctl restart carbonio-mailbox-sidecar.service
+trap - EXIT

--- a/packages/appserver-service/carbonio-mailbox
+++ b/packages/appserver-service/carbonio-mailbox
@@ -37,7 +37,7 @@ if [[ "$?" != "0" ]]; then
     fi
 fi
 
-trap 'echo Script for template terminated with error' EXIT
+trap 'echo Script for mailbox terminated with error' EXIT
 set -e
 
 consul config write /etc/carbonio/mailbox/service-discover/service-protocol.json

--- a/packages/appserver-service/carbonio-mailbox-setup.sh
+++ b/packages/appserver-service/carbonio-mailbox-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+carbonio-mailbox setup

--- a/packages/appserver-service/carbonio-mailbox-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-sidecar.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/consul connect envoy \
-    -token-file /etc/zextras/carbonio-mailbox/token \
+    -token-file /etc/carbonio/mailbox/service-discover/token \
     -admin-bind localhost:0 \
     -sidecar-for carbonio-mailbox
 Restart=on-failure

--- a/packages/appserver-service/intentions.json
+++ b/packages/appserver-service/intentions.json
@@ -1,0 +1,14 @@
+{
+  "kind": "service-intentions",
+  "name": "carbonio-mailbox",
+  "sources": [
+    {
+      "name": "carbonio-user-management",
+      "action": "allow"
+    },
+    {
+      "name": "carbonio-files",
+      "action": "allow"
+    }
+  ]
+}

--- a/packages/appserver-service/policies.json
+++ b/packages/appserver-service/policies.json
@@ -1,0 +1,44 @@
+{
+  "key_prefix": [
+    {
+      "carbonio-mailbox/": {
+        "policy": "read"
+      },
+      "carbonio-powerstore/": {
+        "policy": "read"
+      },
+      "carbonio-abq/": {
+        "policy": "read"
+      },
+      "carbonio-activesync/": {
+        "policy": "read"
+      },
+      "carbonio-auth/": {
+        "policy": "read"
+      },
+      "carbonio-core/": {
+        "policy": "read"
+      },
+      "carbonio-ha/": {
+        "policy": "read"
+      }
+    }
+  ],
+  "node_prefix": [
+    {
+      "": {
+        "policy": "read"
+      }
+    }
+  ],
+  "service": [
+    {
+      "carbonio-mailbox": {
+        "policy": "write"
+      },
+      "carbonio-mailbox-sidecar-proxy": {
+        "policy": "write"
+      }
+    }
+  ]
+}

--- a/packages/appserver-service/service-protocol.json
+++ b/packages/appserver-service/service-protocol.json
@@ -1,0 +1,5 @@
+{
+  "kind": "service-defaults",
+  "name": "carbonio-mailbox",
+  "protocol": "http"
+}


### PR DESCRIPTION
Uniforms mailbox service registration to: https://github.com/Zextras/consul-templates/tree/main/services-package

Tests:
 - installation ok
 - setup ok
 - token is now under /etc/carbonio/mailbox/service-discover/token
 **- copy old token to new in postinst. This in case other services are restarted and need the new token but pending-setups did not run (although that shouldn't happen, the token should be read only by the service itself, I'm a bit confused about this)**
 - old token /etc/zextras/carbonio-mailbox/token still present in the system (any idea how we can remove it? automatically or manually?)