### PR TITLE
fix: remove old token copy logic

### DIFF
--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -54,10 +54,9 @@ postinst() {
 
   usermod -a -G 'carbonio-mailbox' 'zextras'
 
-  # Copy old token. This way services using new token can be restarted and use the new one
-  # without the need of running pending-setups before
-  if [ -f /etc/zextras/carbonio-mailbox/token ]; then
-    cp /etc/zextras/carbonio-mailbox/token /etc/carbonio/mailbox/service-discover/token
+  # Move old token if new does not exist. Migration purposes
+  if [ -f /etc/zextras/carbonio-mailbox/token ] && [! -f  /etc/carbonio/mailbox/service-discover/token]; then
+    mv /etc/zextras/carbonio-mailbox/token /etc/carbonio/mailbox/service-discover/token
   fi
 
   if [ -d /run/systemd/system ]; then

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -54,11 +54,6 @@ postinst() {
 
   usermod -a -G 'carbonio-mailbox' 'zextras'
 
-  # Move old token if new does not exist. Migration purposes
-  if [ -f /etc/zextras/carbonio-mailbox/token ] && [! -f  /etc/carbonio/mailbox/service-discover/token]; then
-    mv /etc/zextras/carbonio-mailbox/token /etc/carbonio/mailbox/service-discover/token
-  fi
-
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl enable carbonio-mailbox-sidecar.service >/dev/null 2>&1 || :


### PR DESCRIPTION
Reasons:
- Copying token could result in overwriting new one
- After package installation old token is still there for running processes
- Updated services will use new token only after restart
- Service restart should be done after pending-setups in all cases