### PR TITLE
chore: [CO-644] chown + chmod new service-discover token

### DIFF
--- a/packages/appserver-service/carbonio-mailbox
+++ b/packages/appserver-service/carbonio-mailbox
@@ -50,8 +50,8 @@ if [[ ! -f "/etc/carbonio/mailbox/service-discover/token" ]]; then
       jq -r '.SecretID' > /etc/carbonio/mailbox/service-discover/token;
 fi
 
-chown carbonio-mailbox:carbonio-mailbox /etc/zextras/carbonio-mailbox/token
-chmod 0640 /etc/zextras/carbonio-mailbox/token
+chown carbonio-mailbox:carbonio-mailbox /etc/carbonio/mailbox/service-discover/token
+chmod 0640 /etc/carbonio/mailbox/service-discover/token
 
 consul reload
 


### PR DESCRIPTION
While running pending-setups without old token I found it failed because of chmod and chown pointing to wrong path.
Sorry :pray: 