### PR TITLE
feat: [CO-659] add attribute to disable the amavis antivirus scan

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2703,6 +2703,14 @@ public class ZAttrProvisioning {
     public static final String A_carbonioAllowFeedback = "carbonioAllowFeedback";
 
     /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public static final String A_carbonioAmavisDisableVirusCheck = "carbonioAmavisDisableVirusCheck";
+
+    /**
      * Database Custom Urls for freshclam configuration file.
      *
      * @since ZCS 23.1.0

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9999,4 +9999,9 @@ TODO: delete them permanently from here
 <attr id="3128" name="carbonioNotificationRecipients" type="email" max="256" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="23.4.0">
   <desc>email address of recipients who will receive emails about important infrastructure notifications</desc>
 </attr>
+
+<attr id="3129" name="carbonioAmavisDisableVirusCheck" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mta" since="23.5.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>Whether or not Amavis should skip virus-checking</desc>
+</attr>
 </attrs>

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -943,6 +943,78 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @return carbonioAmavisDisableVirusCheck, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public boolean isCarbonioAmavisDisableVirusCheck() {
+        return getBooleanAttr(Provisioning.A_carbonioAmavisDisableVirusCheck, false, true);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param carbonioAmavisDisableVirusCheck new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public void setCarbonioAmavisDisableVirusCheck(boolean carbonioAmavisDisableVirusCheck) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, carbonioAmavisDisableVirusCheck ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param carbonioAmavisDisableVirusCheck new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public Map<String,Object> setCarbonioAmavisDisableVirusCheck(boolean carbonioAmavisDisableVirusCheck, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, carbonioAmavisDisableVirusCheck ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public void unsetCarbonioAmavisDisableVirusCheck() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public Map<String,Object> unsetCarbonioAmavisDisableVirusCheck(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, "");
+        return attrs;
+    }
+
+    /**
      * Database Custom Urls for freshclam configuration file.
      *
      * @return carbonioClamAVDatabaseCustomURL, or empty array if unset

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -155,6 +155,78 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @return carbonioAmavisDisableVirusCheck, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public boolean isCarbonioAmavisDisableVirusCheck() {
+        return getBooleanAttr(Provisioning.A_carbonioAmavisDisableVirusCheck, false, true);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param carbonioAmavisDisableVirusCheck new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public void setCarbonioAmavisDisableVirusCheck(boolean carbonioAmavisDisableVirusCheck) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, carbonioAmavisDisableVirusCheck ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param carbonioAmavisDisableVirusCheck new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public Map<String,Object> setCarbonioAmavisDisableVirusCheck(boolean carbonioAmavisDisableVirusCheck, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, carbonioAmavisDisableVirusCheck ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public void unsetCarbonioAmavisDisableVirusCheck() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether or not Amavis should skip virus-checking
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3129)
+    public Map<String,Object> unsetCarbonioAmavisDisableVirusCheck(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioAmavisDisableVirusCheck, "");
+        return attrs;
+    }
+
+    /**
      * RFC2256: common name(s) for which the entity is known by
      *
      * @return cn, or null if unset


### PR DESCRIPTION
**What has changed:**
- added new attribute **carbonioAmavisDisableVirusCheck** which will let us enable/disable antivirus scanning in amavis 

**Related PRs:**
- https://github.com/Zextras/carbonio-amavis/pull/4