### PR TITLE
feat: [CO-640] chats, meeting, team feature enabled attributes

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2721,7 +2721,7 @@ public class ZAttrProvisioning {
     /**
      * Whether the Chats feature enabled for account or COS
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public static final String A_carbonioFeatureChatsEnabled = "carbonioFeatureChatsEnabled";
@@ -2749,6 +2749,22 @@ public class ZAttrProvisioning {
      */
     @ZAttr(id=3123)
     public static final String A_carbonioFeatureMailsAppEnabled = "carbonioFeatureMailsAppEnabled";
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public static final String A_carbonioFeatureMeetingEnabled = "carbonioFeatureMeetingEnabled";
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public static final String A_carbonioFeatureTeamEnabled = "carbonioFeatureTeamEnabled";
 
     /**
      * Logo URL for domain

--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2723,7 +2723,7 @@ public class ZAttrProvisioning {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public static final String A_carbonioFeatureChatsEnabled = "carbonioFeatureChatsEnabled";
 
     /**

--- a/store-conf/conf/rights/rights-domainadmin.xml
+++ b/store-conf/conf/rights/rights-domainadmin.xml
@@ -31,6 +31,8 @@
     <a n="carbonioFeatureFilesAppEnabled"/>
     <a n="carbonioFeatureFilesEnabled"/>
     <a n="carbonioFeatureMailsAppEnabled"/>
+    <a n="carbonioFeatureMeetingEnabled"/>
+    <a n="carbonioFeatureTeamEnabled"/>
     <a n="carbonioPrefWebUiDarkMode"/>
     <a n="cn"/>
     <a n="co"/>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9999,19 +9999,19 @@ TODO: delete them permanently from here
   <desc>Whether or not Amavis should skip virus-checking</desc>
 </attr>
 
-<attr id="3130" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3130" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Chats feature enabled for account or COS</desc>
 </attr>
 
-<attr id="3131" name="carbonioFeatureMeetingEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3131" name="carbonioFeatureMeetingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Meeting feature enabled for account or COS</desc>
 </attr>
 
-<attr id="3132" name="carbonioFeatureTeamEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3132" name="carbonioFeatureTeamEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Team feature enabled for account or COS</desc>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9981,12 +9981,6 @@ TODO: delete them permanently from here
   <desc>Whether the Files feature enabled for account or COS</desc>
 </attr>
 
-<attr id="3125" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.1.0">
-  <defaultCOSValue>TRUE</defaultCOSValue>
-  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
-  <desc>Whether the Chats feature enabled for account or COS</desc>
-</attr>
-
 <attr id="3126" name="carbonioLogoUrl" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInherited,domainInfo,domainAdminModifiable" since="23.2.0">
   <desc>Logo URL for domain</desc>
   <globalConfigValue>https://www.zextras.com</globalConfigValue>
@@ -9998,5 +9992,11 @@ TODO: delete them permanently from here
 
 <attr id="3128" name="carbonioNotificationRecipients" type="email" max="256" cardinality="multi" optionalIn="globalConfig,domain" flags="domainInherited,domainAdminModifiable" since="23.4.0">
   <desc>email address of recipients who will receive emails about important infrastructure notifications</desc>
+</attr>
+
+<attr id="3129" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.1.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
+  <desc>Whether the Chats feature enabled for account or COS</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9994,9 +9994,21 @@ TODO: delete them permanently from here
   <desc>email address of recipients who will receive emails about important infrastructure notifications</desc>
 </attr>
 
-<attr id="3129" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.1.0">
+<attr id="3129" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Chats feature enabled for account or COS</desc>
+</attr>
+
+<attr id="3130" name="carbonioFeatureMeetingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
+  <desc>Whether the Meeting feature enabled for account or COS</desc>
+</attr>
+
+<attr id="3131" name="carbonioFeatureTeamEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+  <defaultCOSValue>FALSE</defaultCOSValue>
+  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
+  <desc>Whether the Team feature enabled for account or COS</desc>
 </attr>
 </attrs>

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -9999,19 +9999,19 @@ TODO: delete them permanently from here
   <desc>Whether or not Amavis should skip virus-checking</desc>
 </attr>
 
-<attr id="3130" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3130" name="carbonioFeatureChatsEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Chats feature enabled for account or COS</desc>
 </attr>
 
-<attr id="3131" name="carbonioFeatureMeetingEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3131" name="carbonioFeatureMeetingEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Meeting feature enabled for account or COS</desc>
 </attr>
 
-<attr id="3132" name="carbonioFeatureTeamEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
+<attr id="3132" name="carbonioFeatureTeamEnabled" type="boolean" cardinality="single" requiredIn="cos" optionalIn="account" flags="accountInfo,accountInherited,domainAdminModifiable" since="23.5.0">
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Team feature enabled for account or COS</desc>

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -170,7 +170,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @return carbonioFeatureChatsEnabled, or false if unset
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public boolean isCarbonioFeatureChatsEnabled() {
@@ -183,7 +183,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param carbonioFeatureChatsEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public void setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled) throws com.zimbra.common.service.ServiceException {
@@ -199,7 +199,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public Map<String,Object> setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled, Map<String,Object> attrs) {
@@ -213,7 +213,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public void unsetCarbonioFeatureChatsEnabled() throws com.zimbra.common.service.ServiceException {
@@ -228,7 +228,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public Map<String,Object> unsetCarbonioFeatureChatsEnabled(Map<String,Object> attrs) {
@@ -450,6 +450,150 @@ public abstract class ZAttrAccount  extends MailTarget {
     public Map<String,Object> unsetCarbonioFeatureMailsAppEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureMailsAppEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @return carbonioFeatureMeetingEnabled, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public boolean isCarbonioFeatureMeetingEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioFeatureMeetingEnabled, false, true);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param carbonioFeatureMeetingEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public void setCarbonioFeatureMeetingEnabled(boolean carbonioFeatureMeetingEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, carbonioFeatureMeetingEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param carbonioFeatureMeetingEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public Map<String,Object> setCarbonioFeatureMeetingEnabled(boolean carbonioFeatureMeetingEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, carbonioFeatureMeetingEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public void unsetCarbonioFeatureMeetingEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public Map<String,Object> unsetCarbonioFeatureMeetingEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @return carbonioFeatureTeamEnabled, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public boolean isCarbonioFeatureTeamEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioFeatureTeamEnabled, false, true);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param carbonioFeatureTeamEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public void setCarbonioFeatureTeamEnabled(boolean carbonioFeatureTeamEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, carbonioFeatureTeamEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param carbonioFeatureTeamEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public Map<String,Object> setCarbonioFeatureTeamEnabled(boolean carbonioFeatureTeamEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, carbonioFeatureTeamEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public void unsetCarbonioFeatureTeamEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public Map<String,Object> unsetCarbonioFeatureTeamEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, "");
         return attrs;
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -168,13 +168,13 @@ public abstract class ZAttrAccount  extends MailTarget {
     /**
      * Whether the Chats feature enabled for account or COS
      *
-     * @return carbonioFeatureChatsEnabled, or true if unset
+     * @return carbonioFeatureChatsEnabled, or false if unset
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public boolean isCarbonioFeatureChatsEnabled() {
-        return getBooleanAttr(Provisioning.A_carbonioFeatureChatsEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_carbonioFeatureChatsEnabled, false, true);
     }
 
     /**
@@ -185,7 +185,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public void setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, carbonioFeatureChatsEnabled ? TRUE : FALSE);
@@ -201,7 +201,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public Map<String,Object> setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, carbonioFeatureChatsEnabled ? TRUE : FALSE);
@@ -215,7 +215,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public void unsetCarbonioFeatureChatsEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, "");
@@ -230,7 +230,7 @@ public abstract class ZAttrAccount  extends MailTarget {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public Map<String,Object> unsetCarbonioFeatureChatsEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, "");

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
@@ -109,13 +109,13 @@ public abstract class ZAttrCos extends NamedEntry {
     /**
      * Whether the Chats feature enabled for account or COS
      *
-     * @return carbonioFeatureChatsEnabled, or true if unset
+     * @return carbonioFeatureChatsEnabled, or false if unset
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public boolean isCarbonioFeatureChatsEnabled() {
-        return getBooleanAttr(Provisioning.A_carbonioFeatureChatsEnabled, true, true);
+        return getBooleanAttr(Provisioning.A_carbonioFeatureChatsEnabled, false, true);
     }
 
     /**
@@ -126,7 +126,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public void setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled) throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, carbonioFeatureChatsEnabled ? TRUE : FALSE);
@@ -142,7 +142,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public Map<String,Object> setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled, Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, carbonioFeatureChatsEnabled ? TRUE : FALSE);
@@ -156,7 +156,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public void unsetCarbonioFeatureChatsEnabled() throws com.zimbra.common.service.ServiceException {
         HashMap<String,Object> attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, "");
@@ -171,7 +171,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @since ZCS 23.1.0
      */
-    @ZAttr(id=3125)
+    @ZAttr(id=3129)
     public Map<String,Object> unsetCarbonioFeatureChatsEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureChatsEnabled, "");

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
@@ -111,7 +111,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @return carbonioFeatureChatsEnabled, or false if unset
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public boolean isCarbonioFeatureChatsEnabled() {
@@ -124,7 +124,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param carbonioFeatureChatsEnabled new value
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public void setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled) throws com.zimbra.common.service.ServiceException {
@@ -140,7 +140,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public Map<String,Object> setCarbonioFeatureChatsEnabled(boolean carbonioFeatureChatsEnabled, Map<String,Object> attrs) {
@@ -154,7 +154,7 @@ public abstract class ZAttrCos extends NamedEntry {
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public void unsetCarbonioFeatureChatsEnabled() throws com.zimbra.common.service.ServiceException {
@@ -169,7 +169,7 @@ public abstract class ZAttrCos extends NamedEntry {
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
      *
-     * @since ZCS 23.1.0
+     * @since ZCS 23.5.0
      */
     @ZAttr(id=3129)
     public Map<String,Object> unsetCarbonioFeatureChatsEnabled(Map<String,Object> attrs) {
@@ -391,6 +391,150 @@ public abstract class ZAttrCos extends NamedEntry {
     public Map<String,Object> unsetCarbonioFeatureMailsAppEnabled(Map<String,Object> attrs) {
         if (attrs == null) attrs = new HashMap<String,Object>();
         attrs.put(Provisioning.A_carbonioFeatureMailsAppEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @return carbonioFeatureMeetingEnabled, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public boolean isCarbonioFeatureMeetingEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioFeatureMeetingEnabled, false, true);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param carbonioFeatureMeetingEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public void setCarbonioFeatureMeetingEnabled(boolean carbonioFeatureMeetingEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, carbonioFeatureMeetingEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param carbonioFeatureMeetingEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public Map<String,Object> setCarbonioFeatureMeetingEnabled(boolean carbonioFeatureMeetingEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, carbonioFeatureMeetingEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public void unsetCarbonioFeatureMeetingEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Meeting feature enabled for account or COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3130)
+    public Map<String,Object> unsetCarbonioFeatureMeetingEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureMeetingEnabled, "");
+        return attrs;
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @return carbonioFeatureTeamEnabled, or false if unset
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public boolean isCarbonioFeatureTeamEnabled() {
+        return getBooleanAttr(Provisioning.A_carbonioFeatureTeamEnabled, false, true);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param carbonioFeatureTeamEnabled new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public void setCarbonioFeatureTeamEnabled(boolean carbonioFeatureTeamEnabled) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, carbonioFeatureTeamEnabled ? TRUE : FALSE);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param carbonioFeatureTeamEnabled new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public Map<String,Object> setCarbonioFeatureTeamEnabled(boolean carbonioFeatureTeamEnabled, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, carbonioFeatureTeamEnabled ? TRUE : FALSE);
+        return attrs;
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public void unsetCarbonioFeatureTeamEnabled() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Whether the Team feature enabled for account or COS
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.5.0
+     */
+    @ZAttr(id=3131)
+    public Map<String,Object> unsetCarbonioFeatureTeamEnabled(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<String,Object>();
+        attrs.put(Provisioning.A_carbonioFeatureTeamEnabled, "");
         return attrs;
     }
 


### PR DESCRIPTION
Adds:
- carbonioFeatureMeetingEnabled
- carbonioFeatureTeamEnabled

Redefines as new attribute:
- carbonioFeatureChatsEnabled
This will cause in installation having value at TRUE to be FALSE (wanted behavior)

See also: 
- https://github.com/Zextras/carbonio-ldap-utilities/pull/33
- https://github.com/Zextras/carbonio-build/pull/49