### PR TITLE
chore: remove tag from CI

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,9 +1,9 @@
 {
   "git": {
-    "requireUpstream": true,
+    "requireUpstream": false,
     "commitMessage": "chore: release ${version}",
     "tagName": "${version}",
-    "tag": true,
+    "tag": false,
     "push": true
   },
   "plugins": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     }
     parameters {
         booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
-        booleanParam defaultValue: false, description: 'Bump version + CHANGELOG + commit + push + tag', name: 'TAG'
         booleanParam defaultValue: false, description: 'Whether to skip the test all with coverage stage', name: 'SKIP_TEST_WITH_COVERAGE'
     }
     environment {
@@ -119,24 +118,6 @@ pipeline {
                     }
                     }
                 }
-                }
-            }
-        }
-        stage("Tag") {
-            when {
-                allOf {
-                    expression { params.TAG == true }
-                    branch 'main'
-                }
-            }
-            steps {
-                withCredentials([gitUsernamePassword(credentialsId: 'jenkins-integration-with-github-account',
-                        gitToolName: 'git-tool')]) {
-                    sh 'git config user.name $GITHUB_BOT_PR_CREDS_USR'
-                    sh 'git config user.email bot@zextras.com'
-                    sh 'git config user.password $GITHUB_BOT_PR_CREDS_PSW'
-                    sh 'git checkout main' //avoid detached head
-                    sh 'release-it --ci'
                 }
             }
         }


### PR DESCRIPTION
**TAG options from CI does not work properly**, because on checkout it does not get all commit history, thus making changelog not working. **I propose to remove it to avoid accidents.**
Since we do the release "manually" another tool, what is left is "release-it" config to automate:
- version bump
- CHANGELOG
- push

The flow of release will be in future, roughly: 
- merge devel to main
- create release branch + execute release-it
- merge release branch into main
- TAG
- Build tag
- Merge main to devel