### PR TITLE
feat: [CO-665] add web.clamav.signature.provider template

### DIFF
--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfGen.java
@@ -2325,6 +2325,9 @@ public class ProxyConfGen {
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("stream.chats.messaging.xmpp")),
           new File(mConfIncludesDir, getConfFileName("stream.chats.messaging.xmpp")));
+      expandTemplate(
+          new File(mTemplateDir, getConfTemplateFileName("web.clamav.signature.provider")),
+          new File(mConfIncludesDir, getConfFileName("web.clamav.signature.provider")));
       // Templates for ssl mapping
       expandTemplate(
           new File(mTemplateDir, getConfTemplateFileName("map.crt")),


### PR DESCRIPTION
**What has changed:**
- proxyconfgen adds nginx conf for web.clamav.signature.provider service

**Related PRs:**
- https://github.com/Zextras/carbonio-nginx-conf/pull/57
- https://bitbucket.org/zextras/carbonio-thirds/pull-requests/19