### PR TITLE
fix: [CO-690] delegated account sent mail always read

### DIFF
--- a/store/src/main/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/MailSender.java
@@ -739,6 +739,9 @@ public class MailSender {
                             RuleManager.applyRulesToOutgoingMessage(octxtTarget, mbox, pm, sentFolderId, true, flags, null, convId);
                     for (ItemId itemId : addedItemIds) {
                         rollbacks.add(new RollbackData(mbox, itemId.getId()));
+                        if (returnItemId == null) {
+                            returnItemId = itemId;
+                        }
                     }
                 }
             }

--- a/store/src/main/java/com/zimbra/cs/mailbox/MailSender.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/MailSender.java
@@ -556,6 +556,14 @@ public class MailSender {
 
     /**
      * Sends a message.
+     * If request is delegated, save to sent behavior follows
+     * {@link Provisioning#A_zimbraPrefDelegatedSendSaveTarget}:
+     * - owner: saves the email only to delegated account, status read
+     * - sender: saves the email to original user account, status read
+     * - both: performs both above
+     * - none: does not save sent email
+     * Note: the email is sent in any case.
+     *
      */
     public ItemId sendMimeMessage(OperationContext octxt, Mailbox mbox, MimeMessage mm)
     throws ServiceException {
@@ -712,13 +720,10 @@ public class MailSender {
                 }
             }
 
-            // for delegated sends automatically save a copy to the "From" user's mailbox, unless we've been
-            // specifically requested not to do the save (for instance BES does its own save to Sent, so does'nt
-            // want it done here).
             if (allowSaveToSent && hasRecipients && !isDataSourceSender() && isDelegatedRequest &&
                     (PrefDelegatedSendSaveTarget.owner == acct.getPrefDelegatedSendSaveTarget() ||
                     PrefDelegatedSendSaveTarget.both == acct.getPrefDelegatedSendSaveTarget())) {
-                int flags = Flag.BITMASK_UNREAD | Flag.BITMASK_FROM_ME;
+                int flags = Flag.BITMASK_FROM_ME;
                 // save the sent copy using the target's credentials, as the sender doesn't necessarily have write access
                 OperationContext octxtTarget = new OperationContext(acct);
                 if (pm == null || pm.isAttachmentIndexingEnabled() != mbox.attachmentsIndexingEnabled()) {

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailSenderIT.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailSenderIT.java
@@ -25,6 +25,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+/**
+ * Bug: CO-690
+ */
 public class MailSenderIT {
 
   private static Provisioning prov;

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailSenderIT.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailSenderIT.java
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zimbra.cs.mailbox;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import javax.mail.Address;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMessage.RecipientType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class MailSenderIT {
+
+  private static Provisioning prov;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    prov = Provisioning.getInstance();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  @Test
+  public void shouldSaveSentEmailInDelegatedAccountWithReadStatus() throws Exception {
+
+    String delegatedId = UUID.randomUUID().toString();
+    String delegatedEmail = delegatedId + "@test.com";
+
+    String userId = UUID.randomUUID().toString();
+    String userEmail = userId + "@test.com";
+    // create delegated account
+    Map<String, Object> delegatedAttrs = new HashMap<>();
+    delegatedAttrs.put(Provisioning.A_zimbraPrefAllowAddressForDelegatedSender, userEmail);
+    delegatedAttrs.put(Provisioning.A_zimbraId, delegatedId);
+    Account delegatedAccount = prov.createAccount(delegatedEmail, "secret", delegatedAttrs);
+
+    // create user account
+    Map<String, Object> userAttrs = new HashMap<>();
+    userAttrs.put(Provisioning.A_zimbraPrefAllowAddressForDelegatedSender, userEmail);
+    userAttrs.put(Provisioning.A_zimbraId, userId);
+    Account userAccount = prov.createAccount(userEmail, "secret", userAttrs);
+
+    final Mailbox delegatedMailbox = MailboxManager.getInstance().getMailboxByAccount(delegatedAccount);
+
+    final MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+
+    // spy MailSender to avoid sending real email
+    final MailSender mailSender = spy(MailSender.class);
+    Address[] recipients = new Address[]{new InternetAddress(userEmail)};
+    doReturn(List.of(recipients)).when(mailSender).sendMessage(Mockito.any(Mailbox.class), Mockito.any(MimeMessage.class), Mockito.any(
+        java.util.Collection.class));
+    final OperationContext operationContext = new OperationContext(userAccount);
+    mimeMessage.setFrom(new InternetAddress(delegatedEmail));
+    mimeMessage.setRecipients(RecipientType.TO, recipients);
+    mimeMessage.setSubject("Test email");
+    mimeMessage.setText("Hello there!");
+    mimeMessage.setSender(new InternetAddress(userEmail));
+    // send email logged in as user, using delegated account
+    mailSender.sendMimeMessage(operationContext, delegatedMailbox, mimeMessage);
+
+    final Mailbox userMailbox = MailboxManager.getInstance().getMailboxByAccount(userAccount);
+    final OperationContext delegatedAccountOpCtx = new OperationContext(delegatedAccount);
+    // Check email is in delegated sent and read
+    final Folder delegatedSent = delegatedMailbox.getFolderByPath(delegatedAccountOpCtx, "sent");
+    Assert.assertEquals(0, delegatedSent.getUnreadCount());
+    Assert.assertEquals(1, delegatedSent.getSize());
+    // Check email is in user sent and read
+    final Folder userSent = userMailbox.getFolderByPath(operationContext, "sent");
+    Assert.assertEquals(0, userSent.getUnreadCount());
+    Assert.assertEquals(0, userSent.getSize());
+  }
+
+}


### PR DESCRIPTION
This fixes a behavior where an email sent as delegated account is left on status "unread" when in Sent folder of delegated account.
This fix makes the email status always "read".

## Test
Added IT test to check authenticated user Sent folder is empty, delegated account has Sent size 1, no unread.
This tests covers the behavior with default value of zimbraPrefDelegatedSendSaveTarget = "owner".
It means the sent email should be saved only on delegated account Sent folder.