### PR TITLE
fix: [CO-695] enable async support in guice servlet filter

### DIFF
--- a/store/conf/web.xml
+++ b/store/conf/web.xml
@@ -18,6 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <filter>
     <filter-name>guiceFilter</filter-name>
     <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
+    <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>

--- a/store/conf/web.xml.production
+++ b/store/conf/web.xml.production
@@ -14,6 +14,7 @@
   <filter>
       <filter-name>guiceFilter</filter-name>
       <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
+      <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>


### PR DESCRIPTION
**What has changed:**

- this enables asynchronous processing of HTTP requests.
In this particular case NoOpRequests were failing due to missing async support on this filter added [here](https://github.com/Zextras/carbonio-mailbox/pull/167/files#diff-9ded4d1dc53a47fff734d8bc22e5ca1a95d1454482e9b74cee20d30d69bb528cR18).

**For more details refer:** CO-695 on jira.