### PR TITLE
chore: sonarqube execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
     }
     parameters {
         booleanParam defaultValue: false, description: 'Upload packages in playground repositories.', name: 'PLAYGROUND'
-        booleanParam defaultValue: false, description: 'Skip test and sonar steps.', name: 'SKIP_TEST_WITH_COVERAGE'
-        booleanParam defaultValue: false, description: 'Skip sonar step.', name: 'SKIP_SONARQUBE'
+        booleanParam defaultValue: false, description: 'Skip test and sonar analysis.', name: 'SKIP_TEST_WITH_COVERAGE'
+        booleanParam defaultValue: false, description: 'Skip sonar analysis.', name: 'SKIP_SONARQUBE'
     }
     environment {
         JAVA_OPTS='-Dfile.encoding=UTF8'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,13 +61,11 @@ pipeline {
         }
         stage('Sonarqube Analysis') {
             when {
-                expression {
-                    allOf {
-                        params.SKIP_SONARQUBE == false
-                        params.SKIP_TEST_WITH_COVERAGE == false
+                allOf {
+                    expression { params.SKIP_SONARQUBE == false }
+                    expression { params.SKIP_TEST_WITH_COVERAGE == false }
                     }
                 }
-            }
             steps {
                 withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
                     mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ pipeline {
         }
     }
     parameters {
-        booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
-        booleanParam defaultValue: false, description: 'Whether to skip the test all with coverage stage', name: 'SKIP_TEST_WITH_COVERAGE'
-        booleanParam defaultValue: false, description: 'Whether to skip sonarqube analysis', name: 'SKIP_SONARQUBE'
+        booleanParam defaultValue: false, description: 'Upload packages in playground repositories.', name: 'PLAYGROUND'
+        booleanParam defaultValue: false, description: 'Skip test and sonar steps.', name: 'SKIP_TEST_WITH_COVERAGE'
+        booleanParam defaultValue: false, description: 'Skip sonar step.', name: 'SKIP_SONARQUBE'
     }
     environment {
         JAVA_OPTS='-Dfile.encoding=UTF8'


### PR DESCRIPTION
# Issue
SonarQube was introduced in #213 . 
Unfortunately running CI with Skip tests or Skip Sonar does not skip sonar analysis.

# Changes
- fix the condition so when either skip tests or sonar as flagged, sonar analysis is not executed.
- update params description