### PR TITLE
chore: [CO-691] Deprecate serverVersion* attributes + cleanup

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -15947,7 +15947,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerInheritedAttr = "zimbraServerInheritedAttr";
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @since ZCS 8.5.0
      */
@@ -15955,7 +15956,9 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerVersion = "zimbraServerVersion";
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @since ZCS 8.5.0
      */
@@ -15963,7 +15966,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerVersionBuild = "zimbraServerVersionBuild";
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @since ZCS 8.5.0
      */
@@ -15971,7 +15975,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerVersionMajor = "zimbraServerVersionMajor";
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @since ZCS 8.5.0
      */
@@ -15979,7 +15984,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraServerVersionMicro = "zimbraServerVersionMicro";
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @since ZCS 8.5.0
      */

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -8070,24 +8070,29 @@ TODO: delete them permanently from here
   <desc>For zimbra dnscache, whether or not to only use TCP when talking to the upstream Master DNS servers. Defaults to no</desc>
 </attr>
 
-<attr id="1598" name="zimbraServerVersion" type="string" cardinality="single" optionalIn="server" since="8.5.0">
+<attr id="1598" name="zimbraServerVersion" type="string" cardinality="single" optionalIn="server" since="8.5.0" deprecatedSince="23.6.0">
   <desc>Current version of ZCS installed on this server</desc>
+  <deprecateDesc>deprecated as not being used in Carbonio</deprecateDesc>
 </attr>
 
-<attr id="1599" name="zimbraServerVersionMajor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
+<attr id="1599" name="zimbraServerVersionMajor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0" deprecatedSince="23.6.0">
   <desc>Current major version of ZCS installed on this server</desc>
+  <deprecateDesc>deprecated as not being used in Carbonio</deprecateDesc>
 </attr>
 
-<attr id="1600" name="zimbraServerVersionMinor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
+<attr id="1600" name="zimbraServerVersionMinor" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0" deprecatedSince="23.6.0">
   <desc>Current minor version of ZCS installed on this server</desc>
+  <deprecateDesc>deprecated as not being used in Carbonio</deprecateDesc>
 </attr>
 
-<attr id="1601" name="zimbraServerVersionMicro" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
+<attr id="1601" name="zimbraServerVersionMicro" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0" deprecatedSince="23.6.0">
   <desc>Current micro level version of ZCS installed on this server</desc>
+  <deprecateDesc>deprecated as not being used in Carbonio</deprecateDesc>
 </attr>
 
-<attr id="1602" name="zimbraServerVersionBuild" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0">
+<attr id="1602" name="zimbraServerVersionBuild" type="integer" min="0" cardinality="single" optionalIn="server" since="8.5.0" deprecatedSince="23.6.0">
   <desc>Current build number of ZCS installed on this server for this version</desc>
+  <deprecateDesc>deprecated as not being used in Carbonio</deprecateDesc>
 </attr>
 
 <attr id="1603" name="zimbraReverseProxyUpstreamLoginServers" type="string" cardinality="multi" optionalIn="server,globalConfig" flags="serverInherited" since="8.5.0">

--- a/store/src/main/java/com/zimbra/cs/account/AuthTokenProperties.java
+++ b/store/src/main/java/com/zimbra/cs/account/AuthTokenProperties.java
@@ -5,263 +5,259 @@
 
 package com.zimbra.cs.account;
 
-import java.util.Map;
-import java.util.Random;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AuthToken.Usage;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
+import java.util.Map;
+import java.util.Random;
 
 public class AuthTokenProperties implements Cloneable {
 
-    public static final String C_TYPE_ZIMBRA_USER = "zimbra";
-    public static final String C_TYPE_EXTERNAL_USER = "external";
-    public static final String C_TYPE_ZMG_APP = "zmgapp";
-    public static final String C_ID  = "id";
-    // original admin id
-    public static final String C_AID  = "aid";
-    public static final String C_EXP = "exp";
-    public static final String C_ADMIN = "admin";
-    public static final String C_DOMAIN = "domain";
-    public static final String C_DLGADMIN = "dlgadmin";
-    public static final String C_TYPE = "type";
-    public static final String C_EXTERNAL_USER_EMAIL = "email";
-    public static final String C_DIGEST = "digest";
-    public static final String C_VALIDITY_VALUE  = "vv";
-    public static final String C_AUTH_MECH = "am";
-    public static final String C_USAGE = "u";
-    //cookie ID for keeping track of account's cookies
-    public static final String C_TOKEN_ID = "tid";
-    //mailbox server version where this account resides
-    public static final String C_SERVER_VERSION = "version";
-    public static final String C_CSRF = "csrf";
-    public static final String C_KEY_VERSION = "kv";
- 
-    private String accountId;
-    private String adminAccountId;
-    private int validityValue = -1;
-    private long expires;
-    private String encoded;
-    private boolean isAdmin;
-    private boolean isDomainAdmin;
-    private boolean isDelegatedAdmin;
-    private String type;
-    private String externalUserEmail;
-    private String digest;
-    private String accessKey; // just a dummy placeholder for now until accesskey auth is implemented in ZimbraAuthToken
-    private String proxyAuthToken;
-    private AuthMech authMech;
-    private Integer tokenID = -1;
-    private String server_version;   // version of the mailbox server where this account resides
-    private boolean csrfTokenEnabled;
-    private Usage usage; // what this token will be used for
+  public static final String C_TYPE_ZIMBRA_USER = "zimbra";
+  public static final String C_TYPE_EXTERNAL_USER = "external";
+  public static final String C_TYPE_ZMG_APP = "zmgapp";
+  public static final String C_ID = "id";
+  // original admin id
+  public static final String C_AID = "aid";
+  public static final String C_EXP = "exp";
+  public static final String C_ADMIN = "admin";
+  public static final String C_DOMAIN = "domain";
+  public static final String C_DLGADMIN = "dlgadmin";
+  public static final String C_TYPE = "type";
+  public static final String C_EXTERNAL_USER_EMAIL = "email";
+  public static final String C_DIGEST = "digest";
+  public static final String C_VALIDITY_VALUE = "vv";
+  public static final String C_AUTH_MECH = "am";
+  public static final String C_USAGE = "u";
+  //cookie ID for keeping track of account's cookies
+  public static final String C_TOKEN_ID = "tid";
+  //mailbox server version where this account resides
+  public static final String C_SERVER_VERSION = "version";
+  public static final String C_CSRF = "csrf";
+  public static final String C_KEY_VERSION = "kv";
 
-    public AuthTokenProperties(Account acct, boolean isAdmin, Account adminAcct, long expires, AuthMech authMech, Usage usage) {
-        if (acct != null) {
-            accountId = acct.getId();
-            validityValue = acct.getAuthTokenValidityValue();
-            this.isAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsAdminAccount));
-            isDomainAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDomainAdminAccount));
-            isDelegatedAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDelegatedAdminAccount));
-            if (acct instanceof GuestAccount) {
-                type = C_TYPE_EXTERNAL_USER;
-                GuestAccount g = (GuestAccount) acct;
-                digest = g.getDigest();
-                accessKey = g.getAccessKey();
-                externalUserEmail = g.getName();
-            } else {
-                type = C_TYPE_ZIMBRA_USER;
-            }
-            server_version = getServerVersion(acct);
-        }
-        adminAccountId = adminAcct != null ? adminAcct.getId() : null;
-        this.expires = expires;
-        this.authMech = authMech;
-        this.usage = usage;
-        encoded = null;
-        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
+  private String accountId;
+  private String adminAccountId;
+  private int validityValue = -1;
+  private long expires;
+  private String encoded;
+  private boolean isAdmin;
+  private boolean isDomainAdmin;
+  private boolean isDelegatedAdmin;
+  private String type;
+  private String externalUserEmail;
+  private String digest;
+  private String accessKey; // just a dummy placeholder for now until accesskey auth is implemented in ZimbraAuthToken
+  private String proxyAuthToken;
+  private AuthMech authMech;
+  private Integer tokenID = -1;
+  private String server_version;   // version of the mailbox server where this account resides
+  private boolean csrfTokenEnabled;
+  private Usage usage; // what this token will be used for
+
+  public AuthTokenProperties(Account acct, boolean isAdmin, Account adminAcct, long expires,
+      AuthMech authMech, Usage usage) {
+    if (acct != null) {
+      accountId = acct.getId();
+      validityValue = acct.getAuthTokenValidityValue();
+      this.isAdmin = isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsAdminAccount));
+      isDomainAdmin =
+          isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDomainAdminAccount));
+      isDelegatedAdmin =
+          isAdmin && "TRUE".equals(acct.getAttr(Provisioning.A_zimbraIsDelegatedAdminAccount));
+      if (acct instanceof GuestAccount) {
+        type = C_TYPE_EXTERNAL_USER;
+        GuestAccount g = (GuestAccount) acct;
+        digest = g.getDigest();
+        accessKey = g.getAccessKey();
+        externalUserEmail = g.getName();
+      } else {
+        type = C_TYPE_ZIMBRA_USER;
+      }
+      server_version = getServerVersion(acct);
+    }
+    adminAccountId = adminAcct != null ? adminAcct.getId() : null;
+    this.expires = expires;
+    this.authMech = authMech;
+    this.usage = usage;
+    encoded = null;
+    tokenID = new Random().nextInt(Integer.MAX_VALUE - 1) + 1;
+  }
+
+  public AuthTokenProperties(String acctId, boolean zmgApp, String externalEmail, String pass,
+      String digest, long expires) {
+    accountId = acctId;
+    this.expires = expires;
+    externalUserEmail = externalEmail == null && !zmgApp ? "public" : externalEmail;
+    this.digest = digest != null ? digest : AuthToken.generateDigest(externalEmail, pass);
+    this.type = zmgApp ? C_TYPE_ZMG_APP : C_TYPE_EXTERNAL_USER;
+    tokenID = new Random().nextInt(Integer.MAX_VALUE - 1) + 1;
+    try {
+      Account acct = Provisioning.getInstance().getAccountById(accountId);
+      if (acct != null) {
+        server_version = getServerVersion(acct);
+      }
+    } catch (ServiceException e) {
+      ZimbraLog.account.error("Unable to get the user account: %s", accountId, e);
+    }
+  }
+
+  public AuthTokenProperties(Map<?, ?> map) throws AuthTokenException {
+    accountId = (String) map.get(C_ID);
+    adminAccountId = (String) map.get(C_AID);
+    expires = Long.parseLong((String) map.get(C_EXP));
+    String ia = (String) map.get(C_ADMIN);
+    isAdmin = "1".equals(ia);
+    String da = (String) map.get(C_DOMAIN);
+    isDomainAdmin = "1".equals(da);
+    String dlga = (String) map.get(C_DLGADMIN);
+    isDelegatedAdmin = "1".equals(dlga);
+    type = (String) map.get(C_TYPE);
+
+    try {
+      String authMechStr = (String) map.get(C_AUTH_MECH);
+      authMech = AuthMech.fromString(authMechStr);
+      String usageCode = (String) map.get(C_USAGE);
+      if (usageCode != null) {
+        usage = Usage.fromCode(usageCode);
+      } else {
+        usage = Usage.AUTH;
+      }
+    } catch (ServiceException e) {
+      throw new AuthTokenException("service exception", e);
+    }
+    externalUserEmail = (String) map.get(C_EXTERNAL_USER_EMAIL);
+    digest = (String) map.get(C_DIGEST);
+    String vv = (String) map.get(C_VALIDITY_VALUE);
+    if (vv != null) {
+      try {
+        validityValue = Integer.parseInt(vv);
+      } catch (NumberFormatException e) {
+        ZimbraLog.account.debug("invalid validity value : %s", vv, e);
+        validityValue = -1;
+      }
+    } else {
+      validityValue = -1;
     }
 
-    public AuthTokenProperties(String acctId, boolean zmgApp, String externalEmail, String pass, String digest, long expires) {
-        accountId = acctId;
-        this.expires = expires;
-        externalUserEmail = externalEmail == null && !zmgApp ? "public" : externalEmail;
-        this.digest = digest != null ? digest : AuthToken.generateDigest(externalEmail, pass);
-        this.type = zmgApp ? C_TYPE_ZMG_APP : C_TYPE_EXTERNAL_USER;
-        tokenID = new Random().nextInt(Integer.MAX_VALUE-1) + 1;
-        try {
-            Account acct = Provisioning.getInstance().getAccountById(accountId);
-            if (acct != null) {
-                server_version = getServerVersion(acct);
-            }
-        } catch (ServiceException e) {
-            ZimbraLog.account.error("Unable to get the user account: %s", accountId, e);
-        }
+    String tid = (String) map.get(C_TOKEN_ID);
+    if (tid != null) {
+      try {
+        tokenID = Integer.parseInt(tid);
+      } catch (NumberFormatException e) {
+        ZimbraLog.account.debug("invalid token id : %s", tid, e);
+        tokenID = -1;
+      }
+    } else {
+      tokenID = -1;
     }
+    server_version = (String) map.get(C_SERVER_VERSION);
 
-    public AuthTokenProperties(Map<?, ?> map) throws AuthTokenException {
-        accountId = (String) map.get(C_ID);
-        adminAccountId = (String) map.get(C_AID);
-        expires = Long.parseLong((String) map.get(C_EXP));
-        String ia = (String) map.get(C_ADMIN);
-        isAdmin = "1".equals(ia);
-        String da = (String) map.get(C_DOMAIN);
-        isDomainAdmin = "1".equals(da);
-        String dlga = (String) map.get(C_DLGADMIN);
-        isDelegatedAdmin = "1".equals(dlga);
-        type = (String)map.get(C_TYPE);
-
-        try {
-            String authMechStr = (String)map.get(C_AUTH_MECH);
-            authMech = AuthMech.fromString(authMechStr);
-            String usageCode = (String)map.get(C_USAGE);
-            if (usageCode != null) {
-                usage = Usage.fromCode(usageCode);
-            } else {
-                usage = Usage.AUTH;
-            }
-        } catch (ServiceException e) {
-            throw new AuthTokenException("service exception", e);
-        }
-        externalUserEmail = (String)map.get(C_EXTERNAL_USER_EMAIL);
-        digest = (String)map.get(C_DIGEST);
-        String vv = (String)map.get(C_VALIDITY_VALUE);
-        if (vv != null) {
-            try {
-                validityValue = Integer.parseInt(vv);
-            } catch (NumberFormatException e) {
-                ZimbraLog.account.debug("invalid validity value : %s", vv, e);
-                validityValue = -1;
-            }
-        } else {
-            validityValue = -1;
-        }
-
-        String tid = (String)map.get(C_TOKEN_ID);
-        if(tid !=null) {
-            try {
-                tokenID = Integer.parseInt(tid);
-            } catch (NumberFormatException e) {
-                ZimbraLog.account.debug("invalid token id : %s", tid, e);
-                tokenID = -1;
-            }
-        } else {
-            tokenID = -1;
-        }
-        server_version = (String)map.get(C_SERVER_VERSION);
-
-        String csrf = (String) map.get(C_CSRF);
-        if (csrf != null) {
-            csrfTokenEnabled = "1".equals(map.get(C_CSRF));
-        }
+    String csrf = (String) map.get(C_CSRF);
+    if (csrf != null) {
+      csrfTokenEnabled = "1".equals(map.get(C_CSRF));
     }
+  }
 
-    private String getServerVersion(Account acct) {
-        String server_version = null;
-        try {
-            Server server = acct.getServer();
-            if (server != null) {
-                server_version = server.getServerVersion();
-            } else {
-                server_version = Provisioning.getInstance().getLocalServer().getServerVersion();
-            }
-        } catch (ServiceException e) {
-            ZimbraLog.account.error("Unable to fetch server version for the user account", e);
-        }
-        return server_version;
-    }
+  //TODO: remove in future version of Carbonio
+  // when we deeply investigate authentication
+  // currently getting rid of this is causing the
+  // auth token expire as soon as it is provided
+  private String getServerVersion(Account acct) {
+    return null;
+  }
 
-    public String getAccountId() {
-        return accountId;
-    }
+  public String getAccountId() {
+    return accountId;
+  }
 
-    public String getAdminAccountId() {
-        return adminAccountId;
-    }
+  public String getAdminAccountId() {
+    return adminAccountId;
+  }
 
-    public int getValidityValue() {
-        return validityValue;
-    }
+  public int getValidityValue() {
+    return validityValue;
+  }
 
-    public long getExpires() {
-        return expires;
-    }
+  public long getExpires() {
+    return expires;
+  }
 
-    public String getEncoded() {
-        return encoded;
-    }
+  public String getEncoded() {
+    return encoded;
+  }
 
-    public boolean isAdmin() {
-        return isAdmin;
-    }
+  public void setEncoded(String encoded) {
+    this.encoded = encoded;
+  }
 
-    public boolean isDomainAdmin() {
-        return isDomainAdmin;
-    }
+  public boolean isAdmin() {
+    return isAdmin;
+  }
 
-    public boolean isDelegatedAdmin() {
-        return isDelegatedAdmin;
-    }
+  public boolean isDomainAdmin() {
+    return isDomainAdmin;
+  }
 
-    public String getType() {
-        return type;
-    }
+  public boolean isDelegatedAdmin() {
+    return isDelegatedAdmin;
+  }
 
-    public String getExternalUserEmail() {
-        return externalUserEmail;
-    }
+  public String getType() {
+    return type;
+  }
 
-    public String getDigest() {
-        return digest;
-    }
+  public String getExternalUserEmail() {
+    return externalUserEmail;
+  }
 
-    public String getAccessKey() {
-        return accessKey;
-    }
+  public String getDigest() {
+    return digest;
+  }
 
-    public String getProxyAuthToken() {
-        return proxyAuthToken;
-    }
+  public String getAccessKey() {
+    return accessKey;
+  }
 
-    public AuthMech getAuthMech() {
-        return authMech;
-    }
+  public String getProxyAuthToken() {
+    return proxyAuthToken;
+  }
 
-    public Integer getTokenID() {
-        return tokenID;
-    }
+  public void setProxyAuthToken(String proxyAuthToken) {
+    this.proxyAuthToken = proxyAuthToken;
+  }
 
-    public String getServerVersion() {
-        return server_version;
-    }
+  public AuthMech getAuthMech() {
+    return authMech;
+  }
 
-    public boolean isCsrfTokenEnabled() {
-        return csrfTokenEnabled;
-    }
+  public Integer getTokenID() {
+    return tokenID;
+  }
 
-    public Usage getUsage() {
-        return usage;
-    }
+  public void setTokenID(Integer tokenID) {
+    this.tokenID = tokenID;
+  }
 
-    public void setEncoded(String encoded) {
-        this.encoded = encoded;
-    }
+  public String getServerVersion() {
+    return server_version;
+  }
 
-    public void setProxyAuthToken(String proxyAuthToken) {
-        this.proxyAuthToken = proxyAuthToken;
-    }
+  public boolean isCsrfTokenEnabled() {
+    return csrfTokenEnabled;
+  }
 
-    public void setCsrfTokenEnabled(boolean csrfTokenEnabled) {
-        this.csrfTokenEnabled = csrfTokenEnabled;
-    }
+  public void setCsrfTokenEnabled(boolean csrfTokenEnabled) {
+    this.csrfTokenEnabled = csrfTokenEnabled;
+  }
 
-    public void setTokenID(Integer tokenID) {
-        this.tokenID = tokenID;
-    }
+  public Usage getUsage() {
+    return usage;
+  }
 
-    @Override
-    public AuthTokenProperties clone() throws CloneNotSupportedException {
-        return (AuthTokenProperties) super.clone();
-    }
+  @Override
+  public AuthTokenProperties clone() throws CloneNotSupportedException {
+    return (AuthTokenProperties) super.clone();
+  }
 }

--- a/store/src/main/java/com/zimbra/cs/account/Provisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/Provisioning.java
@@ -294,7 +294,6 @@ public abstract class Provisioning extends ZAttrProvisioning {
    * cached. For LdapProvisionig, each LDAP related method will cost one or more LDAP trips. The
    * only usage for useCache=false is zmconfigd. (bug 70975 and 71267)
    *
-   * @param useCache
    * @return
    */
   public static Provisioning getInstance(CacheMode origCacheMode) {
@@ -380,7 +379,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
    *       attr is updated
    * </ul>
    *
-   * Calls {@link #modifyAttrs(Map, boolean)} with <code>checkImmutable=false</code>.
+   * Calls {@link #modifyAttrs(com.zimbra.cs.account.Entry, java.util.Map, boolean)} with <code>checkImmutable=false</code>.
    */
   public void modifyAttrs(Entry e, Map<String, ? extends Object> attrs) throws ServiceException {
     modifyAttrs(e, attrs, false);
@@ -1054,7 +1053,6 @@ public abstract class Provisioning extends ZAttrProvisioning {
   /**
    * Auto provisioning account in EAGER mode.
    *
-   * @param domain
    * @return
    * @throws ServiceException
    */
@@ -1603,51 +1601,21 @@ public abstract class Provisioning extends ZAttrProvisioning {
   public List<Server> getAllWebClientServers() throws ServiceException {
     List<Server> mailboxservers = getAllServers(Provisioning.SERVICE_MAILBOX);
     List<Server> webclientservers = getAllServers(Provisioning.SERVICE_WEBCLIENT);
-
-    for (Server server : mailboxservers) {
-      String version = server.getAttr(Provisioning.A_zimbraServerVersion, null);
-      // We get all pre 8.5 servers first (ones which don't have the zimbraServerVersion set)
-      if (version != null) {
-        continue;
-      }
-      // Add it to the list of 8.5+ webclient servers and return this list
-      webclientservers.add(server);
-    }
-
+    webclientservers.addAll(mailboxservers);
     return webclientservers;
   }
 
   public List<Server> getAllAdminClientServers() throws ServiceException {
     List<Server> mailboxservers = getAllServers(Provisioning.SERVICE_MAILBOX);
     List<Server> adminclientservers = getAllServers(Provisioning.SERVICE_ADMINCLIENT);
-
-    for (Server server : mailboxservers) {
-      String version = server.getAttr(Provisioning.A_zimbraServerVersion, null);
-      // We get all pre 8.5 servers first (ones which don't have the zimbraServerVersion set)
-      if (version != null) {
-        continue;
-      }
-      // Add it to the list of 8.5+ adminclient servers and return this list
-      adminclientservers.add(server);
-    }
-
+    adminclientservers.addAll(mailboxservers);
     return adminclientservers;
   }
 
   public List<Server> getAllZimletServers() throws ServiceException {
     List<Server> mailboxservers = getAllServers(Provisioning.SERVICE_MAILBOX);
     List<Server> zimletservers = getAllServers(Provisioning.SERVICE_ZIMLET);
-
-    for (Server server : mailboxservers) {
-      String version = server.getAttr(Provisioning.A_zimbraServerVersion, null);
-      // We get all pre 8.5 servers first (ones which don't have the zimbraServerVersion set)
-      if (version != null) {
-        continue;
-      }
-      // Add it to the list of 8.5+ zimlet servers and return this list
-      zimletservers.add(server);
-    }
-
+    zimletservers.addAll(mailboxservers);
     return zimletservers;
   }
 
@@ -1666,17 +1634,7 @@ public abstract class Provisioning extends ZAttrProvisioning {
   public List<Server> getAllMailClientServers() throws ServiceException {
     List<Server> mailboxservers = getAllServers(Provisioning.SERVICE_MAILBOX);
     List<Server> mailclientservers = getAllServers(Provisioning.SERVICE_MAILCLIENT);
-
-    for (Server server : mailboxservers) {
-      String version = server.getAttr(Provisioning.A_zimbraServerVersion, null);
-      // We get all pre 8.5 servers first (ones which don't have the zimbraServerVersion set)
-      if (version != null) {
-        continue;
-      }
-      // Add it to the list of 8.5+ mailclient servers and return this list
-      mailclientservers.add(server);
-    }
-
+    mailclientservers.addAll(mailboxservers);
     return mailclientservers;
   }
 
@@ -2057,7 +2015,6 @@ public abstract class Provisioning extends ZAttrProvisioning {
    *
    * @param server
    * @param opts
-   * @param visitor
    * @throws ServiceException
    */
   public List<NamedEntry> searchAccountsOnServer(Server server, SearchAccountsOptions opts)

--- a/store/src/main/java/com/zimbra/cs/account/Server.java
+++ b/store/src/main/java/com/zimbra/cs/account/Server.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 /**
  * @author schemers
- *     <p>Window - Preferences - Java - Code Style - Code Templates
+ * <p>Window - Preferences - Java - Code Style - Code Templates
  */
 public class Server extends ZAttrServer {
 
@@ -51,7 +51,9 @@ public class Server extends ZAttrServer {
    */
   public boolean mailTransportMatches(String mailTransport) {
     // if there is no mailTransport, it sure "matches"
-    if (mailTransport == null) return true;
+    if (mailTransport == null) {
+      return true;
+    }
 
     String serviceName = getAttr(Provisioning.A_zimbraServiceHostname, null);
 
@@ -101,51 +103,23 @@ public class Server extends ZAttrServer {
   }
 
   public boolean hasWebClientService() {
-    // Figure out if this a pre 8.5 server (i.e if zimbraServerVersion is not set)
-    String version = this.getAttr(Provisioning.A_zimbraServerVersion, null);
-    if (version != null) {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_WEBCLIENT);
-    } else {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_MAILBOX);
-    }
+    return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
+        .contains(Provisioning.SERVICE_WEBCLIENT);
   }
 
   public boolean hasAdminClientService() {
-    // Figure out if this a pre 8.5 server (i.e if zimbraServerVersion is not set)
-    String version = this.getAttr(Provisioning.A_zimbraServerVersion, null);
-    if (version != null) {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_ADMINCLIENT);
-    } else {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_MAILBOX);
-    }
+    return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
+        .contains(Provisioning.SERVICE_ADMINCLIENT);
   }
 
   public boolean hasMailClientService() {
-    // Figure out if this a pre 8.5 server (i.e if zimbraServerVersion is not set)
-    String version = this.getAttr(Provisioning.A_zimbraServerVersion, null);
-    if (version != null) {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_MAILCLIENT);
-    } else {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_MAILBOX);
-    }
+    return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
+        .contains(Provisioning.SERVICE_MAILCLIENT);
   }
 
   public boolean hasZimletService() {
-    // Figure out if this a pre 8.5 server (i.e if zimbraServerVersion is not set)
-    String version = this.getAttr(Provisioning.A_zimbraServerVersion, null);
-    if (version != null) {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_ZIMLET);
-    } else {
-      return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
-          .contains(Provisioning.SERVICE_MAILBOX);
-    }
+    return getMultiAttrSet(Provisioning.A_zimbraServiceEnabled)
+        .contains(Provisioning.SERVICE_ZIMLET);
   }
 
   public boolean isLocalServer() throws ServiceException {

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -46632,7 +46632,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @return zimbraServerVersion, or null if unset
      *
@@ -46644,7 +46645,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @param zimbraServerVersion new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46659,7 +46661,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @param zimbraServerVersion new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46675,7 +46678,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46689,7 +46693,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current version of ZCS installed on this server
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46704,7 +46709,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @return zimbraServerVersionBuild, or -1 if unset
      *
@@ -46716,7 +46723,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @param zimbraServerVersionBuild new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46731,7 +46740,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @param zimbraServerVersionBuild new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46747,7 +46758,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46761,7 +46774,9 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current build number of ZCS installed on this server for this version
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current build number of ZCS installed on this server for
+     * this version
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46776,7 +46791,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @return zimbraServerVersionMajor, or -1 if unset
      *
@@ -46788,7 +46804,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @param zimbraServerVersionMajor new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46803,7 +46820,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @param zimbraServerVersionMajor new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46819,7 +46837,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46833,7 +46852,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current major version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current major version of ZCS installed on this server
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46848,7 +46868,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @return zimbraServerVersionMicro, or -1 if unset
      *
@@ -46860,7 +46881,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @param zimbraServerVersionMicro new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46875,7 +46897,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @param zimbraServerVersionMicro new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46891,7 +46914,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46905,7 +46929,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current micro level version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current micro level version of ZCS installed on this server
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -46920,7 +46945,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @return zimbraServerVersionMinor, or -1 if unset
      *
@@ -46932,7 +46958,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @param zimbraServerVersionMinor new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -46947,7 +46974,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @param zimbraServerVersionMinor new value
      * @param attrs existing map to populate, or null to create a new map
@@ -46963,7 +46991,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -46977,7 +47006,8 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Current minor version of ZCS installed on this server
+     * Deprecated since: 23.6.0. deprecated as not being used in Carbonio.
+     * Orig desc: Current minor version of ZCS installed on this server
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/httpclient/URLUtil.java
+++ b/store/src/main/java/com/zimbra/cs/httpclient/URLUtil.java
@@ -15,7 +15,6 @@ import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.AdminConstants;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Provisioning.MailMode;
@@ -23,262 +22,276 @@ import com.zimbra.cs.account.Server;
 
 /**
  * @author jhahm
- *
+ * <p>
  * TODO To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Style - Code Templates
  */
 public class URLUtil {
 
-    public static final String PROTO_HTTP  = "http";
-    public static final String PROTO_HTTPS = "https";
+  public static final String PROTO_HTTP = "http";
+  public static final String PROTO_HTTPS = "https";
 
-    public static int DEFAULT_HTTP_PORT = 80;
-    public static int DEFAULT_HTTPS_PORT = 443;
+  public static int DEFAULT_HTTP_PORT = 80;
+  public static int DEFAULT_HTTPS_PORT = 443;
 
-    /**
-     * Return the URL where SOAP service is available for given store server.
-     *
-     * @see getMailURL()
-     */
-    public static String getSoapURL(Server server, boolean preferSSL) throws ServiceException {
-        return URLUtil.getServiceURL(server, AccountConstants.USER_SERVICE_URI, preferSSL);
+  /**
+   * Return the URL where SOAP service is available for given store server.
+   *
+   * @see getMailURL()
+   */
+  public static String getSoapURL(Server server, boolean preferSSL) throws ServiceException {
+    return URLUtil.getServiceURL(server, AccountConstants.USER_SERVICE_URI, preferSSL);
+  }
+
+  public static String getSoapPublicURL(Server server, Domain domain, boolean preferSSL)
+      throws ServiceException {
+    return URLUtil.getPublicURLForDomain(server, domain, AccountConstants.USER_SERVICE_URI,
+        preferSSL);
+  }
+
+  /**
+   * Returns absolute URL with scheme, host, and port for admin app on server. Admin app only runs
+   * over SSL.
+   *
+   * @param server
+   * @param path   what follows port number; begins with slash
+   * @return
+   */
+  public static String getAdminURL(Server server, String path) {
+    String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
+    int port = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
+    StringBuffer sb = new StringBuffer(128);
+    sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port)
+        .append(path);
+    return sb.toString();
+  }
+
+  /**
+   * Returns absolute URL with scheme, host, and port for MTA auth on server.
+   *
+   * @param server
+   * @return MTA Auth URL String
+   */
+  public static String getMtaAuthURL(Server server) {
+    String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
+    int port = server.getMtaAuthPort();
+    String path = AdminConstants.ADMIN_SERVICE_URI;
+    return LC.zimbra_admin_service_scheme.value() + hostname + ":" + port + path;
+  }
+
+  /**
+   * Returns absolute URL with scheme, host, and port for admin app on server. Admin app only runs
+   * over SSL.
+   *
+   * @param server
+   * @param path   what follows port number; begins with slash
+   * @return
+   * @checkPort verify if the port is valid
+   */
+  public static String getAdminURL(Server server, String path, boolean checkPort)
+      throws ServiceException {
+    String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
+    int port = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
+      if (checkPort && port <= 0) {
+          throw ServiceException.FAILURE(
+              "server " + server.getName() + " does not have admin port enabled", null);
+      }
+    StringBuffer sb = new StringBuffer(128);
+    sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port)
+        .append(path);
+    return sb.toString();
+  }
+
+
+  /**
+   * Returns absolute URL with scheme, host, and port for admin app on server. Admin app only runs
+   * over SSL. Uses port from localconfig.
+   *
+   * @param server hostname
+   * @return
+   */
+  public static String getAdminURL(String hostname) {
+    int port = (int) LC.zimbra_admin_service_port.longValue();
+    StringBuffer sb = new StringBuffer(128);
+    sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port)
+        .append(AdminConstants.ADMIN_SERVICE_URI);
+    return sb.toString();
+  }
+
+  /**
+   * Returns absolute URL with scheme, host, and port for admin app on server. Admin app only runs
+   * over SSL.
+   *
+   * @param server
+   * @param path   what follows port number; begins with slash
+   * @return
+   */
+  public static String getAdminURL(Server server) {
+    return getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
+  }
+
+  /**
+   * Utility method to translate zimbraMtaAuthHost -> zimbraMtaAuthURL.
+   * <p>
+   * Not the best place for this method, but do not want to pollute Provisioning with utility
+   * methods either.
+   */
+  public static String getMtaAuthURL(String authHost) throws ServiceException {
+    for (Server server : Provisioning.getInstance().getAllServers()) {
+      String serviceName = server.getAttr(Provisioning.A_zimbraServiceHostname, null);
+      if (authHost.equalsIgnoreCase(serviceName)) {
+        return URLUtil.getSoapURL(server, true);
+      }
+    }
+    throw ServiceException.INVALID_REQUEST("specified " + Provisioning.A_zimbraMtaAuthHost
+        + " does not correspond to a valid service hostname: " + authHost, null);
+  }
+
+  /**
+   * Returns absolute public URL with scheme, host, and port for mail app on server.
+   *
+   * @param server
+   * @param domain
+   * @param path      what follows port number; begins with slash
+   * @param preferSSL if both SSL and and non-SSL are available, whether to prefer SSL
+   * @return desired URL
+   */
+  public static String getPublicURLForDomain(Server server, Domain domain, String path,
+      boolean preferSSL) throws ServiceException {
+    String publicURLForDomain = getPublicURLForDomain(domain, path);
+      if (publicURLForDomain != null) {
+          return publicURLForDomain;
+      }
+
+    // fallback to server setting if domain is not configured with public service hostname
+    return URLUtil.getServiceURL(server, path, preferSSL);
+  }
+
+  private static String getPublicURLForDomain(Domain domain, String path) {
+      if (domain == null) {
+          return null;
+      }
+
+    String hostname = domain.getAttr(Provisioning.A_zimbraPublicServiceHostname, null);
+      if (hostname == null) {
+          return null;
+      }
+
+    String proto = domain.getAttr(Provisioning.A_zimbraPublicServiceProtocol, PROTO_HTTP);
+
+    int defaultPort = PROTO_HTTP.equals(proto) ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT;
+    int port = domain.getIntAttr(Provisioning.A_zimbraPublicServicePort, defaultPort);
+
+    boolean printPort = ((PROTO_HTTP.equals(proto) && port != DEFAULT_HTTP_PORT) ||
+        (PROTO_HTTPS.equals(proto) && port != DEFAULT_HTTPS_PORT));
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(proto).append("://").append(hostname);
+      if (printPort) {
+          buf.append(":").append(port);
+      }
+    buf.append(path);
+    return buf.toString();
+  }
+
+  public static String getPublicAdminConsoleURLForDomain(Server server, Domain domain)
+      throws ServiceException {
+    String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, false);
+    if (publicAdminUrl == null) {
+      publicAdminUrl = URLUtil.getAdminURL(server, server.getAdminURL());
+    }
+    return publicAdminUrl;
+  }
+
+  public static String getPublicAdminSoapURLForDomain(Server server, Domain domain)
+      throws ServiceException {
+    String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, true);
+    if (publicAdminUrl == null) {
+      publicAdminUrl = URLUtil.getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
+    }
+    return publicAdminUrl;
+  }
+
+  private static String getAdminConsoleProxyUrl(Server server, Domain domain,
+      boolean isAdminSoapURL) throws ServiceException {
+    if (domain == null) {
+      return null;
+    }
+    String adminReference = domain.getWebClientAdminReference();
+    if (adminReference != null) {
+      return adminReference;
+    }
+    String hostname = domain.getAttr(Provisioning.A_zimbraPublicServiceHostname, null);
+    if (hostname == null) {
+      return null;
+    }
+    String proto = PROTO_HTTPS;
+
+    String portString = Provisioning.getInstance().getConfig()
+        .getAttr(Provisioning.A_zimbraAdminProxyPort, null);
+    if (portString == null) {
+      return null;
+    }
+    int port = 9071;
+    try {
+      port = Integer.parseInt(portString);
+    } catch (NumberFormatException nfe) {
+      throw ServiceException.FAILURE("unable to parse zimbraAdminProxyPort", nfe);
+    }
+    boolean printPort = port != DEFAULT_HTTPS_PORT;
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(proto).append("://").append(hostname);
+    if (printPort) {
+      buf.append(":").append(port);
+    }
+    if (isAdminSoapURL) {
+      buf.append(AdminConstants.ADMIN_SERVICE_URI);
+    } else {
+      buf.append(server.getAdminURL());
+    }
+    return buf.toString();
+
+  }
+
+  public static String getServiceURL(Server server, String path, boolean useSSL)
+      throws ServiceException {
+
+    String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
+      if (hostname == null) {
+          throw ServiceException.INVALID_REQUEST(
+              "server " + server.getName() + " does not have "
+                  + Provisioning.A_zimbraServiceHostname,
+              null);
+      }
+
+    String modeString = server.getAttr(Provisioning.A_zimbraMailMode, null);
+      if (modeString == null) {
+          throw ServiceException.INVALID_REQUEST(
+              "server " + server.getName() + " does not have " + Provisioning.A_zimbraMailMode
+                  + " set, maybe it is not a store server?", null);
+      }
+    MailMode mailMode = Provisioning.MailMode.fromString(modeString);
+
+    String proto;
+    int port;
+    if ((mailMode != MailMode.http && useSSL) || mailMode == MailMode.https) {
+      proto = PROTO_HTTPS;
+      port = server.getIntAttr(Provisioning.A_zimbraMailSSLPort, DEFAULT_HTTPS_PORT);
+    } else {
+      proto = PROTO_HTTP;
+      port = server.getIntAttr(Provisioning.A_zimbraMailPort, DEFAULT_HTTP_PORT);
     }
 
-    public static String getSoapPublicURL(Server server, Domain domain, boolean preferSSL) throws ServiceException {
-        return URLUtil.getPublicURLForDomain(server, domain, AccountConstants.USER_SERVICE_URI, preferSSL);
-    }
+    StringBuilder buf = new StringBuilder();
+    buf.append(proto).append("://").append(hostname);
+    buf.append(":").append(port);
+    buf.append(path);
+    return buf.toString();
+  }
 
-    /**
-     * Returns absolute URL with scheme, host, and port for admin app on server.
-     * Admin app only runs over SSL.
-     * @param server
-     * @param path what follows port number; begins with slash
-     * @return
-     */
-    public static String getAdminURL(Server server, String path) {
-        String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
-        int port = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
-        StringBuffer sb = new StringBuffer(128);
-        sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port).append(path);
-        return sb.toString();
-    }
-
-    /**
-     * Returns absolute URL with scheme, host, and port for MTA auth on server.
-     * @param server
-     * @param path what follows port number; begins with slash
-     * @return
-     */
-    public static String getMtaAuthURL(Server server) {
-        String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
-        int port;
-        try {
-            Integer majorVersion = server.getServerVersionMajor();
-            Integer minorVersion = server.getServerVersionMinor();
-            if (majorVersion.equals(8)) {
-                port = minorVersion >= 7 ? server.getMtaAuthPort() : server.getAdminPort();
-            } else if (majorVersion > 8) {
-                port = server.getMtaAuthPort();
-            } else {
-                port = server.getAdminPort();
-            }
-        } catch (NumberFormatException e) {
-            port = server.getMtaAuthPort();
-            ZimbraLog.misc.warn("cannot determine server version; defaulting to port %d for MTA auth", port);
-        }
-        StringBuffer sb = new StringBuffer(128);
-        String path = AdminConstants.ADMIN_SERVICE_URI;
-        sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port).append(path);
-        return sb.toString();
-    }
-
-    /**
-     * Returns absolute URL with scheme, host, and port for admin app on server.
-     * Admin app only runs over SSL.
-     * @param server
-     * @param path what follows port number; begins with slash
-     * @checkPort verify if the port is valid
-     * @return
-     */
-    public static String getAdminURL(Server server, String path, boolean checkPort) throws ServiceException {
-        String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
-        int port = server.getIntAttr(Provisioning.A_zimbraAdminPort, 0);
-        if (checkPort && port <= 0)
-            throw ServiceException.FAILURE("server " + server.getName() + " does not have admin port enabled", null);
-        StringBuffer sb = new StringBuffer(128);
-        sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port).append(path);
-        return sb.toString();
-    }
-
-
-    /**
-     * Returns absolute URL with scheme, host, and port for admin app on server.
-     * Admin app only runs over SSL. Uses port from localconfig.
-     * @param server hostname
-     * @return
-     */
-    public static String getAdminURL(String hostname) {
-        int port = (int) LC.zimbra_admin_service_port.longValue();
-        StringBuffer sb = new StringBuffer(128);
-        sb.append(LC.zimbra_admin_service_scheme.value()).append(hostname).append(":").append(port).append(AdminConstants.ADMIN_SERVICE_URI);
-        return sb.toString();
-    }
-
-    /**
-     * Returns absolute URL with scheme, host, and port for admin app on server.
-     * Admin app only runs over SSL.
-     * @param server
-     * @param path what follows port number; begins with slash
-     * @return
-     */
-    public static String getAdminURL(Server server) {
-        return getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
-    }
-
-    /**
-     * Utility method to translate zimbraMtaAuthHost -> zimbraMtaAuthURL.
-     *
-     * Not the best place for this method, but do not want to pollute
-     * Provisioning with utility methods either.
-     */
-    public static String getMtaAuthURL(String authHost) throws ServiceException {
-        for (Server server : Provisioning.getInstance().getAllServers()) {
-            String serviceName = server.getAttr(Provisioning.A_zimbraServiceHostname, null);
-            if (authHost.equalsIgnoreCase(serviceName)) {
-                return URLUtil.getSoapURL(server, true);
-            }
-        }
-        throw ServiceException.INVALID_REQUEST("specified " + Provisioning.A_zimbraMtaAuthHost + " does not correspond to a valid service hostname: " + authHost, null);
-    }
-
-    /**
-     * Returns absolute public URL with scheme, host, and port for mail app on server.
-     *
-     * @param server
-     * @param domain
-     * @param path what follows port number; begins with slash
-     * @param preferSSL if both SSL and and non-SSL are available, whether to prefer SSL
-     * @return desired URL
-     */
-    public static String getPublicURLForDomain(Server server, Domain domain, String path, boolean preferSSL) throws ServiceException {
-        String publicURLForDomain = getPublicURLForDomain(domain, path);
-        if (publicURLForDomain != null)
-            return publicURLForDomain;
-
-        // fallback to server setting if domain is not configured with public service hostname
-        return URLUtil.getServiceURL(server, path, preferSSL);
-    }
-
-    private static String getPublicURLForDomain(Domain domain, String path) {
-        if (domain == null)
-            return null;
-
-        String hostname = domain.getAttr(Provisioning.A_zimbraPublicServiceHostname, null);
-        if (hostname == null)
-            return null;
-
-        String proto = domain.getAttr(Provisioning.A_zimbraPublicServiceProtocol, PROTO_HTTP);
-
-        int defaultPort = PROTO_HTTP.equals(proto) ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT;
-        int port = domain.getIntAttr(Provisioning.A_zimbraPublicServicePort, defaultPort);
-
-        boolean printPort = ((PROTO_HTTP.equals(proto) && port != DEFAULT_HTTP_PORT) ||
-                             (PROTO_HTTPS.equals(proto) && port != DEFAULT_HTTPS_PORT));
-
-        StringBuilder buf = new StringBuilder();
-        buf.append(proto).append("://").append(hostname);
-        if (printPort)
-            buf.append(":").append(port);
-        buf.append(path);
-        return buf.toString();
-    }
-
-    public static String getPublicAdminConsoleURLForDomain(Server server, Domain domain) throws ServiceException {
-        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, false);
-        if (publicAdminUrl == null) {
-            publicAdminUrl = URLUtil.getAdminURL(server, server.getAdminURL());
-        }
-        return publicAdminUrl;
-    }
-
-    public static String getPublicAdminSoapURLForDomain(Server server, Domain domain) throws ServiceException {
-        String publicAdminUrl = getAdminConsoleProxyUrl(server, domain, true);
-        if (publicAdminUrl == null) {
-            publicAdminUrl = URLUtil.getAdminURL(server, AdminConstants.ADMIN_SERVICE_URI);
-        }
-        return publicAdminUrl;
-    }
-
-    private static String getAdminConsoleProxyUrl(Server server, Domain domain, boolean isAdminSoapURL) throws ServiceException {
-        if (domain == null) {
-            return null;
-        }
-        String adminReference = domain.getWebClientAdminReference();
-        if (adminReference != null) {
-            return adminReference;
-        }
-        String hostname = domain.getAttr(Provisioning.A_zimbraPublicServiceHostname, null);
-        if (hostname == null) {
-            return null;
-        }
-        String proto = PROTO_HTTPS;
-
-        String portString = Provisioning.getInstance().getConfig().getAttr(Provisioning.A_zimbraAdminProxyPort, null);
-        if (portString == null) {
-            return null;
-        }
-        int port = 9071;
-        try {
-            port = Integer.parseInt(portString);
-        } catch (NumberFormatException nfe) {
-            throw ServiceException.FAILURE("unable to parse zimbraAdminProxyPort", nfe);
-        }
-        boolean printPort = port != DEFAULT_HTTPS_PORT;
-
-        StringBuilder buf = new StringBuilder();
-        buf.append(proto).append("://").append(hostname);
-        if (printPort) {
-            buf.append(":").append(port);
-        }
-        if (isAdminSoapURL) {
-            buf.append(AdminConstants.ADMIN_SERVICE_URI);
-        } else {
-            buf.append(server.getAdminURL());
-        }
-        return buf.toString();
-
-    }
-
-    public static String getServiceURL(Server server, String path, boolean useSSL) throws ServiceException {
-
-        String hostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
-        if (hostname == null)
-            throw ServiceException.INVALID_REQUEST("server " + server.getName() + " does not have " + Provisioning.A_zimbraServiceHostname, null);
-
-    	String modeString = server.getAttr(Provisioning.A_zimbraMailMode, null);
-    	if (modeString == null)
-    		throw ServiceException.INVALID_REQUEST("server " + server.getName() + " does not have " + Provisioning.A_zimbraMailMode + " set, maybe it is not a store server?", null);
-        MailMode mailMode = Provisioning.MailMode.fromString(modeString);
-
-    	String proto;
-    	int port;
-    	if ((mailMode != MailMode.http && useSSL) || mailMode == MailMode.https) {
-    	    proto = PROTO_HTTPS;
-        	port = server.getIntAttr(Provisioning.A_zimbraMailSSLPort, DEFAULT_HTTPS_PORT);
-    	} else {
-    	    proto = PROTO_HTTP;
-        	port = server.getIntAttr(Provisioning.A_zimbraMailPort, DEFAULT_HTTP_PORT);
-    	}
-
-    	StringBuilder buf = new StringBuilder();
-    	buf.append(proto).append("://").append(hostname);
-        buf.append(":").append(port);
-        buf.append(path);
-    	return buf.toString();
-    }
-
-    public static boolean reverseProxiedMode(Server server) throws ServiceException {
-        String referMode = server.getAttr(Provisioning.A_zimbraMailReferMode, "wronghost");
-        return Provisioning.MAIL_REFER_MODE_REVERSE_PROXIED.equals(referMode);
-    }
+  public static boolean reverseProxiedMode(Server server) throws ServiceException {
+    String referMode = server.getAttr(Provisioning.A_zimbraMailReferMode, "wronghost");
+    return Provisioning.MAIL_REFER_MODE_REVERSE_PROXIED.equals(referMode);
+  }
 }

--- a/store/src/main/java/com/zimbra/cs/index/SearchParams.java
+++ b/store/src/main/java/com/zimbra/cs/index/SearchParams.java
@@ -987,9 +987,9 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
             }
             try {
                 String[] split = value.split(",");
-                ArrayList<ItemId> itemIds = new ArrayList<ItemId>();
-                for (int i = 0; i < split.length; i++) {
-                    itemIds.add(new ItemId(split[i],zsc));
+                ArrayList<ItemId> itemIds = new ArrayList<>();
+                for (String s : split) {
+                    itemIds.add(new ItemId(s, zsc));
                 }
                 return new ExpandResults(value,itemIds);
             } catch (Exception e) {
@@ -1009,24 +1009,17 @@ public final class SearchParams implements Cloneable, ZimbraSearchParams {
                 .build();
 
         public ExpandResults toLegacyExpandResults(Server server) {
-            if (server != null && server.getServerVersion() == null) {
-                if (LEGACY_MAP.containsKey(this.name)) {
-                    return this;
-                } else {
-                    //pre 8.5; no way to know which version
-                    //assume HELIX as lowest common - fetch="1|hits|all|{item-id}"
-                    ExpandResults mapped = ALL;
-                    if (this == FIRST_MSG || this == U_OR_FIRST_MSG || this == U1_OR_FIRST_MSG) {
-                        mapped = FIRST;
-                    } else if (this == HITS_OR_FIRST_MSG) {
-                        mapped = HITS;
-                    }
-                    ZimbraLog.search.debug("mapped current ExpandResults %s to %s for legacy server %s", this, mapped, server.getName());
-                    return mapped;
-                }
-            } else {
-                //for now 8.5+ supports the same set of expands; would add code here if 8.6 or 9.0 changes it
+            if (server == null || LEGACY_MAP.containsKey(this.name)) {
                 return this;
+            } else {
+                ExpandResults mapped = ALL;
+                if (this == FIRST_MSG || this == U_OR_FIRST_MSG || this == U1_OR_FIRST_MSG) {
+                    mapped = FIRST;
+                } else if (this == HITS_OR_FIRST_MSG) {
+                    mapped = HITS;
+                }
+                ZimbraLog.search.debug("mapped current ExpandResults %s to %s for legacy server %s", this, mapped, server.getName());
+                return mapped;
             }
         }
     }

--- a/store/src/main/java/com/zimbra/cs/util/JMSession.java
+++ b/store/src/main/java/com/zimbra/cs/util/JMSession.java
@@ -53,15 +53,7 @@ public final class JMSession {
         // Assume that most malformed base64 errors occur due to incorrect delimiters,
         // as opposed to errors in the data itself.  See bug 11213 for more details.
         System.setProperty("mail.mime.base64.ignoreerrors", "true");
-
-        try {
-            Security.addProvider(new OAuth2Provider(Provisioning.getInstance().getLocalServer()
-                .getServerVersionMajor()));
-        } catch (ServiceException e) {
-            ZimbraLog.smtp.warn("Exception in getting zimbra server version", e);
-            Security.addProvider(new OAuth2Provider(1));
-        }
-
+        Security.addProvider(new OAuth2Provider(1));
         Properties props = new Properties();
         props.setProperty("mail.mime.address.strict", "false");
         sSession = Session.getInstance(props);

--- a/store/src/main/java/com/zimbra/cs/util/WebClientServiceUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/WebClientServiceUtil.java
@@ -5,20 +5,6 @@
 
 package com.zimbra.cs.util;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.http.HttpException;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
-
 import com.zimbra.common.httpclient.HttpClientUtil;
 import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.service.ServiceException;
@@ -33,232 +19,266 @@ import com.zimbra.cs.httpclient.HttpProxyUtil;
 import com.zimbra.cs.httpclient.URLUtil;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.zimlet.ZimletUtil;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 
 /**
  * Util class for sending service related requests from service node to ui nodes
  */
 public class WebClientServiceUtil {
 
-    public static final String PARAM_AUTHTOKEN = "authtoken";
-    private static final String FLUSH_UISTRINGS_ON_UI_NODE = "/fromservice/flushuistrings";
+  public static final String PARAM_AUTHTOKEN = "authtoken";
+  private static final String FLUSH_UISTRINGS_ON_UI_NODE = "/fromservice/flushuistrings";
 
-    /**
-     * @return true if server is in split mode or LC key debug_local_split is set to true
-     */
-    public static boolean isServerInSplitMode() {
-        return DebugConfig.debugLocalSplit || WebSplitUtil.isZimbraServiceSplitEnabled();
+  /**
+   * @return true if server is in split mode or LC key debug_local_split is set to true
+   */
+  public static boolean isServerInSplitMode() {
+    return DebugConfig.debugLocalSplit || WebSplitUtil.isZimbraServiceSplitEnabled();
+  }
+
+  /**
+   * send service request to every ui node
+   *
+   * @param serviceUrl the url that should be matched and handled by ServiceServlet in
+   *                   ZimbraWebClient
+   * @throws ServiceException
+   */
+  public static void sendServiceRequestToEveryUiNode(String serviceUrl) throws ServiceException {
+    List<Server> servers = Provisioning.getInstance().getAllServers(Provisioning.SERVICE_WEBCLIENT);
+    if (servers == null || servers.isEmpty()) {
+      servers.add(Provisioning.getInstance().getLocalServer());
     }
-
-    /**
-     * send service request to every ui node
-     * @param serviceUrl the url that should be matched and handled by ServiceServlet in ZimbraWebClient
-     * @throws ServiceException
-     */
-    public static void sendServiceRequestToEveryUiNode(String serviceUrl) throws ServiceException {
-        List<Server> servers = Provisioning.getInstance().getAllServers(Provisioning.SERVICE_WEBCLIENT);
-        if (servers == null || servers.isEmpty()) {
-            servers.add(Provisioning.getInstance().getLocalServer());
-        }
-        AuthToken authToken = AuthProvider.getAdminAuthToken();
-        ZimbraLog.misc.debug("got admin auth token");
-        //sequentially flush each node
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-        HttpProxyUtil.configureProxy(clientBuilder);
-        for (Server server : servers) {
-            if (isServerAtLeast8dot5(server)) {
-                HttpRequestBase method = null;
-                try {
-                    method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
-                    ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
-                    try {
-                        method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
-                    } catch (AuthTokenException e) {
-                        ZimbraLog.misc.warn(e);
-                    }
-                    HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
-                    int respCode = httpResp.getStatusLine().getStatusCode();
-                    if (respCode != 200) {
-                        ZimbraLog.misc.warn("service failed, return code: %d", respCode);
-                    }
-                } catch (Exception e) {
-                    ZimbraLog.misc.warn("service failed for node %s", server.getName(), e);
-                } finally {
-                    if (method != null) {
-                        method.releaseConnection();
-                    }
-                }
-            }
-        }
-        if (authToken != null && authToken.isRegistered()) {
-            try {
-                authToken.deRegister();
-                ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s", authToken.isRegistered());
-            } catch (AuthTokenException e) {
-                ZimbraLog.misc.warn("failed to de-register auth token", e);
-            }
-        }
-    }
-
-    /**
-     * send service request to one random ui node, keep trying until succeeds.
-     * @param serviceUrl the url that should be matched and handled by ServiceServlet in ZimbraWebClient
-     * @return response from ui node in String
-     * @throws ServiceException
-     */
-    public static String sendServiceRequestToOneRandomUiNode(String serviceUrl) throws ServiceException {
-        return sendServiceRequestToOneRandomUiNode(serviceUrl, Collections.<String,String>emptyMap());
-    }
-
-    /**
-     * send service request to one random ui node, keep trying until succeeds.
-     * @param serviceUrl the url that should be matched and handled by ServiceServlet in ZimbraWebClient
-     *        reqHeaders the map of req/rsp attributes that need to be set by the UI node
-     * @return response from ui node in String
-     * @throws ServiceException
-     */
-    public static String sendServiceRequestToOneRandomUiNode(String serviceUrl, Map<String, String> reqHeaders) throws ServiceException {
-        List<Server> servers = Provisioning.getInstance().getAllServers(Provisioning.SERVICE_WEBCLIENT);
-        if (servers == null || servers.isEmpty()) {
-            servers.add(Provisioning.getInstance().getLocalServer());
-        }
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-        HttpProxyUtil.configureProxy(clientBuilder);
-        AuthToken authToken = AuthProvider.getAdminAuthToken();
-        ZimbraLog.misc.debug("got admin auth token");
-        String resp = "";
-        for (Server server : servers) {
-            if (isServerAtLeast8dot5(server)) {
-                HttpRequestBase method = null;
-                try {
-                    method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
-                    ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
-                    method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
-                    // Add all the req headers passed to this function as well
-                    for (Map.Entry<String, String> entry : reqHeaders.entrySet()) {
-                        method.addHeader(entry.getKey(), entry.getValue());
-                        ZimbraLog.misc.debug("adding request header %s=%s", entry.getKey(), entry.getValue());
-                    }
-                    HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
-                    int result = httpResp.getStatusLine().getStatusCode();
-                    ZimbraLog.misc.debug("resp: %d", result);
-                    resp = EntityUtils.toString(httpResp.getEntity());
-                    ZimbraLog.misc.debug("got response from ui node: %s", resp);
-                    break; //try ui nodes one by one until one succeeds.
-                } catch (IOException | HttpException e) {
-                    ZimbraLog.misc.warn("failed to get response from ui node", e);
-                } catch (AuthTokenException e) {
-                    ZimbraLog.misc.warn("failed to get authToken", e);
-                } finally {
-                    if (method != null) {
-                        method.releaseConnection();
-                    }
-                }
-            }
-        }
-        if (authToken != null && authToken.isRegistered()) {
-            try {
-                authToken.deRegister();
-                ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s", authToken.isRegistered());
-            } catch (AuthTokenException e) {
-                ZimbraLog.misc.warn("failed to de-register authToken", e);
-            }
-        }
-        return resp;
-    }
-
-    public static String sendServiceRequestToUiNode(Server server, String serviceUrl) throws ServiceException {
-        if (isServerAtLeast8dot5(server)) {
-            HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-            HttpProxyUtil.configureProxy(clientBuilder);
-            AuthToken authToken = AuthProvider.getAdminAuthToken();
-            ZimbraLog.misc.debug("got admin auth token");
-            String resp = "";
-            HttpRequestBase method = null;
-            try {
-                method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
-                ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
-                method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
-                HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
-                int result = httpResp.getStatusLine().getStatusCode();
-                ZimbraLog.misc.debug("resp: %d", result);
-                resp = EntityUtils.toString(httpResp.getEntity());
-                ZimbraLog.misc.debug("got response from ui node: %s", resp);
-            } catch (IOException | HttpException e) {
-                ZimbraLog.misc.warn("failed to get response from ui node", e);
-            } catch (AuthTokenException e) {
-                ZimbraLog.misc.warn("failed to get authToken", e);
-            } finally {
-                if (method != null) {
-                    method.releaseConnection();
-                }
-            }
-            if (authToken != null && authToken.isRegistered()) {
-                try {
-                    authToken.deRegister();
-                    ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s", authToken.isRegistered());
-                } catch (AuthTokenException e) {
-                    ZimbraLog.misc.warn("failed to de-register authToken", e);
-                }
-            }
-            return resp;
-        }
-        return "";
-    }
-
-    public static void flushUistringsCache() throws ServiceException {
-        sendServiceRequestToEveryUiNode(FLUSH_UISTRINGS_ON_UI_NODE);
-    }
-
-    public static void sendFlushZimletRequestToUiNode(Server server) throws ServiceException {
-        sendServiceRequestToUiNode(server, "/fromservice/flushzimlets");
-    }
-
-    private static void postToUiNode(Server server, HttpPost method, String authToken) throws ServiceException {
-        HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-        HttpProxyUtil.configureProxy(clientBuilder);
+    AuthToken authToken = AuthProvider.getAdminAuthToken();
+    ZimbraLog.misc.debug("got admin auth token");
+    //sequentially flush each node
+    HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+        .newHttpClient();
+    HttpProxyUtil.configureProxy(clientBuilder);
+    for (Server server : servers) {
+      if (isServerAtLeast8dot5(server)) {
+        HttpRequestBase method = null;
         try {
-            method.addHeader(PARAM_AUTHTOKEN, authToken);
-            ZimbraLog.zimlet.debug("connecting to ui node %s", server.getName());
-            HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
-            int respCode = httpResp.getStatusLine().getStatusCode();
-            if (respCode != 200) {
-                ZimbraLog.zimlet.warn("operation failed, return code: %d", respCode);
-            }
+          method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
+          ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
+          try {
+            method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
+          } catch (AuthTokenException e) {
+            ZimbraLog.misc.warn(e);
+          }
+          HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
+          int respCode = httpResp.getStatusLine().getStatusCode();
+          if (respCode != 200) {
+            ZimbraLog.misc.warn("service failed, return code: %d", respCode);
+          }
         } catch (Exception e) {
-            ZimbraLog.zimlet.warn("operation failed for node %s", server.getName(), e);
+          ZimbraLog.misc.warn("service failed for node %s", server.getName(), e);
         } finally {
-            if (method != null) {
-                method.releaseConnection();
-            }
+          if (method != null) {
+            method.releaseConnection();
+          }
         }
+      }
     }
+    if (authToken != null && authToken.isRegistered()) {
+      try {
+        authToken.deRegister();
+        ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s", authToken.isRegistered());
+      } catch (AuthTokenException e) {
+        ZimbraLog.misc.warn("failed to de-register auth token", e);
+      }
+    }
+  }
 
-    public static void sendDeployZimletRequestToUiNode(Server server, String zimlet, String authToken, byte[] data)
-            throws ServiceException {
-        if (isServerAtLeast8dot5(server)) {
-            HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-            HttpProxyUtil.configureProxy(clientBuilder);
-            HttpPost method = new HttpPost(URLUtil.getServiceURL(server, "/fromservice/deployzimlet", false));
-            method.addHeader(ZimletUtil.PARAM_ZIMLET, zimlet);
-            ZimbraLog.zimlet.info("connecting to ui node %s, data size %d", server.getName(), data.length);
+  /**
+   * send service request to one random ui node, keep trying until succeeds.
+   *
+   * @param serviceUrl the url that should be matched and handled by ServiceServlet in
+   *                   ZimbraWebClient
+   * @return response from ui node in String
+   * @throws ServiceException
+   */
+  public static String sendServiceRequestToOneRandomUiNode(String serviceUrl)
+      throws ServiceException {
+    return sendServiceRequestToOneRandomUiNode(serviceUrl, Collections.<String, String>emptyMap());
+  }
 
-            method.setEntity(new ByteArrayEntity(data));
-            postToUiNode(server, method, authToken);
+  /**
+   * send service request to one random ui node, keep trying until succeeds.
+   *
+   * @param serviceUrl the url that should be matched and handled by ServiceServlet in
+   *                   ZimbraWebClient reqHeaders the map of req/rsp attributes that need to be set
+   *                   by the UI node
+   * @return response from ui node in String
+   * @throws ServiceException
+   */
+  public static String sendServiceRequestToOneRandomUiNode(String serviceUrl,
+      Map<String, String> reqHeaders) throws ServiceException {
+    List<Server> servers = Provisioning.getInstance().getAllServers(Provisioning.SERVICE_WEBCLIENT);
+    if (servers == null || servers.isEmpty()) {
+      servers.add(Provisioning.getInstance().getLocalServer());
+    }
+    HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+        .newHttpClient();
+    HttpProxyUtil.configureProxy(clientBuilder);
+    AuthToken authToken = AuthProvider.getAdminAuthToken();
+    ZimbraLog.misc.debug("got admin auth token");
+    String resp = "";
+    for (Server server : servers) {
+      if (isServerAtLeast8dot5(server)) {
+        HttpRequestBase method = null;
+        try {
+          method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
+          ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
+          method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
+          // Add all the req headers passed to this function as well
+          for (Map.Entry<String, String> entry : reqHeaders.entrySet()) {
+            method.addHeader(entry.getKey(), entry.getValue());
+            ZimbraLog.misc.debug("adding request header %s=%s", entry.getKey(), entry.getValue());
+          }
+          HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
+          int result = httpResp.getStatusLine().getStatusCode();
+          ZimbraLog.misc.debug("resp: %d", result);
+          resp = EntityUtils.toString(httpResp.getEntity());
+          ZimbraLog.misc.debug("got response from ui node: %s", resp);
+          break; //try ui nodes one by one until one succeeds.
+        } catch (IOException | HttpException e) {
+          ZimbraLog.misc.warn("failed to get response from ui node", e);
+        } catch (AuthTokenException e) {
+          ZimbraLog.misc.warn("failed to get authToken", e);
+        } finally {
+          if (method != null) {
+            method.releaseConnection();
+          }
         }
+      }
     }
-
-    private static boolean isServerAtLeast8dot5(Server server) {
-        return true;
+    if (authToken != null && authToken.isRegistered()) {
+      try {
+        authToken.deRegister();
+        ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s", authToken.isRegistered());
+      } catch (AuthTokenException e) {
+        ZimbraLog.misc.warn("failed to de-register authToken", e);
+      }
     }
+    return resp;
+  }
 
-    public static void sendUndeployZimletRequestToUiNode(Server server, String zimlet, String authToken)
-            throws ServiceException {
-        if (isServerAtLeast8dot5(server)) {
-            HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr().newHttpClient();
-            HttpProxyUtil.configureProxy(clientBuilder);
-            HttpPost method = new HttpPost(URLUtil.getServiceURL(server, "/fromservice/undeployzimlet", false));
-            method.addHeader(ZimletUtil.PARAM_ZIMLET, zimlet);
-            postToUiNode(server, method, authToken);
+  public static String sendServiceRequestToUiNode(Server server, String serviceUrl)
+      throws ServiceException {
+    if (isServerAtLeast8dot5(server)) {
+      HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+          .newHttpClient();
+      HttpProxyUtil.configureProxy(clientBuilder);
+      AuthToken authToken = AuthProvider.getAdminAuthToken();
+      ZimbraLog.misc.debug("got admin auth token");
+      String resp = "";
+      HttpRequestBase method = null;
+      try {
+        method = new HttpGet(URLUtil.getServiceURL(server, serviceUrl, false));
+        ZimbraLog.misc.debug("connecting to ui node %s", server.getName());
+        method.addHeader(PARAM_AUTHTOKEN, authToken.getEncoded());
+        HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
+        int result = httpResp.getStatusLine().getStatusCode();
+        ZimbraLog.misc.debug("resp: %d", result);
+        resp = EntityUtils.toString(httpResp.getEntity());
+        ZimbraLog.misc.debug("got response from ui node: %s", resp);
+      } catch (IOException | HttpException e) {
+        ZimbraLog.misc.warn("failed to get response from ui node", e);
+      } catch (AuthTokenException e) {
+        ZimbraLog.misc.warn("failed to get authToken", e);
+      } finally {
+        if (method != null) {
+          method.releaseConnection();
         }
+      }
+      if (authToken != null && authToken.isRegistered()) {
+        try {
+          authToken.deRegister();
+          ZimbraLog.misc.debug("de-registered auth token, isRegistered?%s",
+              authToken.isRegistered());
+        } catch (AuthTokenException e) {
+          ZimbraLog.misc.warn("failed to de-register authToken", e);
+        }
+      }
+      return resp;
     }
+    return "";
+  }
+
+  public static void flushUistringsCache() throws ServiceException {
+    sendServiceRequestToEveryUiNode(FLUSH_UISTRINGS_ON_UI_NODE);
+  }
+
+  public static void sendFlushZimletRequestToUiNode(Server server) throws ServiceException {
+    sendServiceRequestToUiNode(server, "/fromservice/flushzimlets");
+  }
+
+  private static void postToUiNode(Server server, HttpPost method, String authToken)
+      throws ServiceException {
+    HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+        .newHttpClient();
+    HttpProxyUtil.configureProxy(clientBuilder);
+    try {
+      method.addHeader(PARAM_AUTHTOKEN, authToken);
+      ZimbraLog.zimlet.debug("connecting to ui node %s", server.getName());
+      HttpResponse httpResp = HttpClientUtil.executeMethod(clientBuilder.build(), method);
+      int respCode = httpResp.getStatusLine().getStatusCode();
+      if (respCode != 200) {
+        ZimbraLog.zimlet.warn("operation failed, return code: %d", respCode);
+      }
+    } catch (Exception e) {
+      ZimbraLog.zimlet.warn("operation failed for node %s", server.getName(), e);
+    } finally {
+      if (method != null) {
+        method.releaseConnection();
+      }
+    }
+  }
+
+  public static void sendDeployZimletRequestToUiNode(Server server, String zimlet, String authToken,
+      byte[] data)
+      throws ServiceException {
+    if (isServerAtLeast8dot5(server)) {
+      HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+          .newHttpClient();
+      HttpProxyUtil.configureProxy(clientBuilder);
+      HttpPost method = new HttpPost(
+          URLUtil.getServiceURL(server, "/fromservice/deployzimlet", false));
+      method.addHeader(ZimletUtil.PARAM_ZIMLET, zimlet);
+      ZimbraLog.zimlet.info("connecting to ui node %s, data size %d", server.getName(),
+          data.length);
+
+      method.setEntity(new ByteArrayEntity(data));
+      postToUiNode(server, method, authToken);
+    }
+  }
+
+  private static boolean isServerAtLeast8dot5(Server server) {
+    return true;
+  }
+
+  public static void sendUndeployZimletRequestToUiNode(Server server, String zimlet,
+      String authToken)
+      throws ServiceException {
+    if (isServerAtLeast8dot5(server)) {
+      HttpClientBuilder clientBuilder = ZimbraHttpConnectionManager.getExternalHttpConnMgr()
+          .newHttpClient();
+      HttpProxyUtil.configureProxy(clientBuilder);
+      HttpPost method = new HttpPost(
+          URLUtil.getServiceURL(server, "/fromservice/undeployzimlet", false));
+      method.addHeader(ZimletUtil.PARAM_ZIMLET, zimlet);
+      postToUiNode(server, method, authToken);
+    }
+  }
 }

--- a/store/src/main/java/com/zimbra/cs/util/WebClientServiceUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/WebClientServiceUtil.java
@@ -248,10 +248,6 @@ public class WebClientServiceUtil {
     }
 
     private static boolean isServerAtLeast8dot5(Server server) {
-        if (server.getServerVersion() == null) {
-            ZimbraLog.misc.info("ui node %s is on version pre 8.5, aborting", server.getName());
-            return false;
-        }
         return true;
     }
 

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfVar.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/ProxyConfVar.java
@@ -11,17 +11,16 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import java.io.PrintStream;
 import java.util.Formatter;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 class ProxyConfVar {
 
   public static final String UNKNOWN_HEADER_NAME = "X-Zimbra-Unknown-Header";
   public static final Pattern RE_HEADER = Pattern.compile("^([^:]+):\\s+(.*)$");
-  static Entry configSource = null;
-  static Entry serverSource = null;
   protected static Log mLog = LogFactory.getLog(ProxyConfGen.class);
   protected static Provisioning mProv = Provisioning.getInstance();
+  static Entry configSource = null;
+  static Entry serverSource = null;
   String mKeyword;
   String mAttribute;
   ProxyConfValueType mValueType;
@@ -260,18 +259,10 @@ class ProxyConfVar {
 
   String generateServerDirective(Server server, String serverName, int serverPort) {
     int timeout = server.getIntAttr(ZAttrProvisioning.A_zimbraMailProxyReconnectTimeout, 60);
-    String version = server.getAttr(ZAttrProvisioning.A_zimbraServerVersion, "");
     int maxFails = server.getIntAttr(ZAttrProvisioning.A_zimbraMailProxyMaxFails, 1);
-    if (maxFails != 1 && !Objects.equals(version, "")) {
-      return String.format(
-          "%s:%d fail_timeout=%ds max_fails=%d version=%s",
-          serverName, serverPort, timeout, maxFails, version);
-    } else if (maxFails != 1) {
+    if (maxFails != 1) {
       return String.format(
           "%s:%d fail_timeout=%ds max_fails=%d", serverName, serverPort, timeout, maxFails);
-    } else if (!Objects.equals(version, "")) {
-      return String.format(
-          "%s:%d fail_timeout=%ds version=%s", serverName, serverPort, timeout, version);
     } else {
       return String.format("%s:%d fail_timeout=%ds", serverName, serverPort, timeout);
     }


### PR DESCRIPTION
**What has changed:**
- All serverVersion attributes are marked deprecated and will be cleaned

- All logic relying on serverVersion* attributes has been cleaned up from mailbox codebase, except few occurences defined in some Auth* classes (ZimbraAuthToken, AuthTokenProperties, ZimbraJWToken and JWTUtil)

**Related PRs:**
- https://github.com/Zextras/carbonio-build/pull/57
- https://github.com/Zextras/carbonio-ldap-utilities/pull/41

**Refer Jira ticket CO-691 for further information**