### PR TITLE
feat: [CO-675] Let admin set arbitrary PublicService & Virtual hostname

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminAccessControl.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminAccessControl.java
@@ -289,6 +289,10 @@ public abstract class AdminAccessControl {
         }
     }
 
+    public boolean isGlobalAdmin() {
+        return AccessControlUtil.isGlobalAdmin(mAuthedAcct);
+    }
+
     public boolean isDomainAdminOnly() {
         return mAccessMgr.isDomainAdminOnly(mAuthToken);
     }

--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminAccessControl.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminAccessControl.java
@@ -289,6 +289,13 @@ public abstract class AdminAccessControl {
         }
     }
 
+    /**
+     * Checks if an authenticated user is a global admin.
+     * @return true if an authenticated user is a global admin, otherwise false.
+     *
+     * @author Yuliya Aheeva
+     * @since 23.6.0
+     */
     public boolean isGlobalAdmin() {
         return AccessControlUtil.isGlobalAdmin(mAuthedAcct);
     }

--- a/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  */
 public class ModifyDomain extends AdminDocumentHandler {
 
-  public boolean domainAuthSufficient(Map context) {
+  public boolean domainAuthSufficient(Map<String, Object>context) {
     return true;
   }
 
@@ -102,7 +102,6 @@ public class ModifyDomain extends AdminDocumentHandler {
    *
    * @param domain domain being updated
    * @param publicServiceHostname value to check against domain
-   * @throws ServiceException exception if public service hostname not valid
    */
   private boolean isPublicServiceHostnameCompliant(Domain domain, String publicServiceHostname) {
     return isFQDNCompliant(domain.getDomainName(), publicServiceHostname);

--- a/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/ModifyDomain.java
@@ -68,7 +68,7 @@ public class ModifyDomain extends AdminDocumentHandler {
           Provisioning.A_zimbraDomainName + " cannot be changed.", null);
     }
 
-    if (!hasRight(adminAccessControl, prov.getConfig())) {
+    if (!hasAdminRightAndCanModifyConfig(adminAccessControl, prov.getConfig())) {
       if (!Objects.isNull(gotPublicServiceHostname)
           && !(isPublicServiceHostnameCompliant(domain, gotPublicServiceHostname))) {
         throw ServiceException.FAILURE(
@@ -112,7 +112,7 @@ public class ModifyDomain extends AdminDocumentHandler {
    * @author Yuliya Aheeva
    * @since 23.6.0
    */
-  protected boolean hasRight(AdminAccessControl adminAccessControl, Config config)
+  protected boolean hasAdminRightAndCanModifyConfig(AdminAccessControl adminAccessControl, Config config)
       throws ServiceException {
     return adminAccessControl.isGlobalAdmin()
         || adminAccessControl.hasRight(config, Admin.R_modifyGlobalConfig);

--- a/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -6,6 +6,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
@@ -27,12 +28,29 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class ModifyDomainIT {
+  public static final String DELEGATED = "delegated";
+  public static final String WITH_RIGHT = "_with_right";
+  public static final String GLOBAL = "global";
+  public static final String DOMAIN_NAME = "demo.zextras.io";
+  private final String virtual1 = "virtual1" + DOMAIN_NAME;
+  private final String virtual2 = "virtual2" + DOMAIN_NAME;
+
   private Provisioning provisioning;
+  private Domain domain;
+
 
   @Before
   public void setUp() throws Exception {
     MailboxTestUtil.initServer();
     provisioning = Provisioning.getInstance();
+    domain = provisioning.createDomain(
+        DOMAIN_NAME,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, DOMAIN_NAME);
+                put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtual1, virtual2});
+              }
+            });
   }
 
   @After
@@ -46,13 +64,14 @@ public class ModifyDomainIT {
 
   @Rule public ExpectedException expectedEx = ExpectedException.none();
 
-  private Account createAdminAccount(Domain domain, String key) throws ServiceException {
+
+  private Account createAdminAccount(String attribute, String name) throws ServiceException {
     return provisioning.createAccount(
-        "admin@" + domain.getDomainName(),
+        name + "@" + DOMAIN_NAME,
         "testPwd",
         new HashMap<>() {
           {
-            put(key, "TRUE");
+            put(attribute, "TRUE");
           }
         });
   }
@@ -75,21 +94,13 @@ public class ModifyDomainIT {
   @Test
   public void shouldThrowExceptionForDelegatedAdminIfPublicServiceHostnameNotCompliantWithDomain()
       throws ServiceException {
-    final String domainName = "demo.zextras.io";
-    final Domain domain = provisioning.createDomain(
-        domainName,
-        new HashMap<>() {
-          {
-            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-          }
-        });
     final String newPubServiceHostname = "newdemo.zextras.io";
     expectedEx.expect(ServiceException.class);
     expectedEx.expectMessage(
         "Public service hostname must be a valid FQDN and compatible with current domain (or its"
             + " aliases).");
-
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount);
+    final Account adminAccount = createAdminAccount(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount,
+        DELEGATED);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -99,22 +110,35 @@ public class ModifyDomainIT {
           }
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
-    new DumbModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    new MockedModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+  }
+
+  @Test
+  public void shouldAllowDelegatedAdminWithRightChangePublicServiceHostnameNotCompliantWithDomain()
+      throws ServiceException {
+    final String newPubServiceHostname = "newdemo.zextras.io";
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, DELEGATED + WITH_RIGHT);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, newPubServiceHostname);
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new MockedModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(
+        newPubServiceHostname, provisioning.getDomainByName(DOMAIN_NAME).getPublicServiceHostname());
   }
 
   @Test
   public void shouldAllowGlobalAdminChangePublicServiceHostnameIfNotCompliantWithDomain()
       throws ServiceException {
-    final String domainName = "demo.zextras.io";
-    final Domain domain = provisioning.createDomain(
-        domainName,
-        new HashMap<>() {
-          {
-            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-          }
-        });
     final String newPubServiceHostname = "newdemo.zextras.io";
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -126,21 +150,14 @@ public class ModifyDomainIT {
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertEquals(
-        newPubServiceHostname, provisioning.getDomainByName(domainName).getPublicServiceHostname());
+        newPubServiceHostname, provisioning.getDomainByName(DOMAIN_NAME).getPublicServiceHostname());
   }
 
   @Test
   public void shouldUpdatePublicServiceHostnameIfCompliantWithDomain() throws ServiceException {
-    final String domainName = "demo.zextras.io";
-    final Domain domain = provisioning.createDomain(
-        domainName,
-        new HashMap<>() {
-          {
-            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-          }
-        });
     final String newPubServiceHostname = "this.domain.is.legit.demo.zextras.io";
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, DELEGATED);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -150,29 +167,21 @@ public class ModifyDomainIT {
           }
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
-    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    new MockedModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertEquals(
-        newPubServiceHostname, provisioning.getDomainByName(domainName).getPublicServiceHostname());
+        newPubServiceHostname, provisioning.getDomainByName(DOMAIN_NAME).getPublicServiceHostname());
   }
 
   @Test
   public void shouldThrowExceptionForDelegatedAdminIfVirtualHostnameNotCompliantWithDomain()
       throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
     final String virtualHostname = "virtual.whatever.not.compliant";
     expectedEx.expect(ServiceException.class);
     expectedEx.expectMessage(
         "Virtual hostnames must be valid FQDNs and compatible with current domain (or its"
             + " aliases).");
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, DELEGATED);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -182,24 +191,35 @@ public class ModifyDomainIT {
           }
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
-    new DumbModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertEquals(0, provisioning.getDomainByName(domainName).getVirtualHostname().length);
+    new MockedModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(0, provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname().length);
+  }
+
+  @Test
+  public void shouldAllowDelegatedAdminWithRightChangeVirtualHostnameIfNotCompliantWithDomain()
+      throws ServiceException {
+    final String virtualHostname = "virtual.whatever.not.compliant";
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, DELEGATED + WITH_RIGHT);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtualHostname});
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new MockedModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(virtualHostname, provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname()[0]);
   }
 
   @Test
   public void shouldAllowGlobalAdminChangeVirtualHostnameIfNotCompliantWithDomain()
       throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
     final String virtualHostname = "virtual.whatever.not.compliant";
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -210,7 +230,7 @@ public class ModifyDomainIT {
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertEquals(virtualHostname, provisioning.getDomainByName(domainName).getVirtualHostname()[0]);
+    assertEquals(virtualHostname, provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname()[0]);
   }
 
   /**
@@ -218,17 +238,9 @@ public class ModifyDomainIT {
    */
   @Test
   public void shouldAddVirtualHostnameIfCompliantWithDomain() throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final String virtualHostname = "virtual." + domainName;
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final String virtualHostname = "new.virtual." + DOMAIN_NAME;
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -240,7 +252,7 @@ public class ModifyDomainIT {
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertTrue(
-        Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname())
+        Arrays.stream(provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname())
             .collect(Collectors.toList())
             .contains(virtualHostname));
   }
@@ -250,18 +262,10 @@ public class ModifyDomainIT {
    */
   @Test
   public void shouldAddMultipleVirtualHostnamesIfCompliantWithDomain() throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final String virtualHostname = "virtual." + domainName;
-    final String virtualHostname2 = "virtual2." + domainName;
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final String virtualHostname = "virtual." + UUID.randomUUID() + DOMAIN_NAME;
+    final String virtualHostname2 = "virtual2." + UUID.randomUUID() + DOMAIN_NAME;
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final String[] vHostnames = {virtualHostname, virtualHostname2};
@@ -273,9 +277,9 @@ public class ModifyDomainIT {
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertEquals(2, provisioning.getDomainByName(domainName).getVirtualHostname().length);
+    assertEquals(2, provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname().length);
     assertTrue(
-        Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname())
+        Arrays.stream(provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname())
             .collect(Collectors.toList())
             .containsAll(Arrays.stream(vHostnames).collect(Collectors.toList())));
   }
@@ -283,32 +287,24 @@ public class ModifyDomainIT {
   @Test
   public void shouldAddMultipleVirtualHostnamesAndPublicServiceHostnameIfFQDNSEqualToDomain()
       throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
-    final String[] vHostnames = {domainName};
+    final String[] vHostnames = {DOMAIN_NAME};
     final HashMap<String, Object> attrsToUpdate =
         new HashMap<>() {
           {
-            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, domainName);
+            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, DOMAIN_NAME);
             put(ZAttrProvisioning.A_zimbraVirtualHostname, vHostnames);
           }
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertEquals(1, provisioning.getDomainByName(domainName).getVirtualHostname().length);
-    assertEquals(domainName, provisioning.getDomainByName(domainName).getPublicServiceHostname());
+    assertEquals(1, provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname().length);
+    assertEquals(DOMAIN_NAME, provisioning.getDomainByName(DOMAIN_NAME).getPublicServiceHostname());
     assertTrue(
-        Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname())
+        Arrays.stream(provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname())
             .collect(Collectors.toList())
             .containsAll(Arrays.stream(vHostnames).collect(Collectors.toList())));
   }
@@ -319,17 +315,9 @@ public class ModifyDomainIT {
   public void shouldThrowDomainNameImmutableWhenModifyingDomainName() throws ServiceException {
     expectedEx.expect(ServiceException.class);
     expectedEx.expectMessage(ZAttrProvisioning.A_zimbraDomainName + " cannot be changed.");
-    final String domainName = "demo4.zextras.io";
     final String newDomainName = "newDemo4.zextras.io";
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -347,19 +335,8 @@ public class ModifyDomainIT {
    */
   @Test
   public void shouldRemoveVirtualHostnamesWhenVirtualHostnamesEmptyArray() throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final String virtual1 = "virtual1" + domainName;
-    final String virtual2 = "virtual2" + domainName;
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-                put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtual1, virtual2});
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -371,7 +348,7 @@ public class ModifyDomainIT {
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertEquals(
-        0, Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname()).count());
+        0, Arrays.stream(provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname()).count());
   }
 
   /**
@@ -380,19 +357,8 @@ public class ModifyDomainIT {
   @Test
   public void shouldNotRemoveVirtualHostnamesWhenVirtualHostnamesNotPassed()
       throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final String virtual1 = "virtual1" + domainName;
-    final String virtual2 = "virtual2" + domainName;
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-                put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtual1, virtual2});
-              }
-            });
-    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Account adminAccount = createAdminAccount(
+        ZAttrProvisioning.A_zimbraIsAdminAccount, GLOBAL);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -400,15 +366,21 @@ public class ModifyDomainIT {
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertEquals(
-        2, Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname()).count());
+        2, Arrays.stream(provisioning.getDomainByName(DOMAIN_NAME).getVirtualHostname()).count());
   }
 
   //skip checking delegated admin rights
-  private static class DumbModifyDomain extends ModifyDomain {
+  private static class MockedModifyDomain extends ModifyDomain {
     @Override
     protected AdminAccessControl checkDomainRight(ZimbraSoapContext zsc, Domain d, Object needed)
         throws ServiceException {
       return AdminAccessControl.getAdminAccessControl(zsc);
+    }
+
+    @Override
+    protected boolean hasRight(AdminAccessControl adminAccessControl, Config config) {
+      return adminAccessControl.mAuthedAcct.getName()
+          .equals(DELEGATED + WITH_RIGHT + "@" + DOMAIN_NAME);
     }
   }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -19,38 +19,47 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class ModifyDomainIT {
+  private Provisioning provisioning;
 
-  private static Provisioning provisioning;
-
-  @BeforeClass
-  public static void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     MailboxTestUtil.initServer();
     provisioning = Provisioning.getInstance();
   }
 
+  @After
+  public void clearData() {
+    try {
+      MailboxTestUtil.clearData();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
   @Rule public ExpectedException expectedEx = ExpectedException.none();
 
-  private Account createDelegatedAdminForDomain(Domain domain) throws ServiceException {
+  private Account createAdminAccount(Domain domain, String key) throws ServiceException {
     return provisioning.createAccount(
         "admin@" + domain.getDomainName(),
         "testPwd",
         new HashMap<>() {
           {
-            put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
-            put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
+            put(key, "TRUE");
           }
         });
   }
 
   private HashMap<String, Object> getSoapContextFromAccount(Account account)
       throws ServiceException {
-    return new HashMap<String, Object>() {
+    return new HashMap<>() {
       {
         put(
             SoapEngine.ZIMBRA_CONTEXT,
@@ -64,23 +73,23 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldThrowServiceExceptionIfPublicServiceHostnameNotComplaintWithDomain()
+  public void shouldThrowExceptionForDelegatedAdminIfPublicServiceHostnameNotComplaintWithDomain()
       throws ServiceException {
     final String domainName = "demo.zextras.io";
+    final Domain domain = provisioning.createDomain(
+        domainName,
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+          }
+        });
     final String newPubServiceHostname = "newdemo.zextras.io";
     expectedEx.expect(ServiceException.class);
     expectedEx.expectMessage(
         "Public service hostname must be a valid FQDN and compatible with current domain (or its"
             + " aliases).");
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -90,22 +99,22 @@ public class ModifyDomainIT {
           }
         };
     modifyDomainRequest.setAttrs(attrsToUpdate);
-    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    new DumbModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
   }
 
   @Test
-  public void shouldUpdatePublicServiceHostnameIfCompliantWithDomain() throws ServiceException {
-    final String domainName = "demo2.zextras.io";
-    final String newPubServiceHostname = "this.domain.is.legit.demo2.zextras.io";
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+  public void shouldAllowGlobalAdminChangePublicServiceHostnameIfNotComplaintWithDomain()
+      throws ServiceException {
+    final String domainName = "demo.zextras.io";
+    final Domain domain = provisioning.createDomain(
+        domainName,
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+          }
+        });
+    final String newPubServiceHostname = "newdemo.zextras.io";
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -120,10 +129,92 @@ public class ModifyDomainIT {
         newPubServiceHostname, provisioning.getDomainByName(domainName).getPublicServiceHostname());
   }
 
+  @Test
+  public void shouldUpdatePublicServiceHostnameIfCompliantWithDomain() throws ServiceException {
+    final String domainName = "demo.zextras.io";
+    final Domain domain = provisioning.createDomain(
+        domainName,
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+          }
+        });
+    final String newPubServiceHostname = "this.domain.is.legit.demo.zextras.io";
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraPublicServiceHostname, newPubServiceHostname);
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(
+        newPubServiceHostname, provisioning.getDomainByName(domainName).getPublicServiceHostname());
+  }
+
+  @Test
+  public void shouldThrowExceptionForDelegatedAdminIfVirtualHostnameNotCompliantWithDomain()
+      throws ServiceException {
+    final String domainName = UUID.randomUUID() + ".zextras.io";
+    final String virtualHostname = "virtual.whatever.not.compliant";
+    expectedEx.expect(ServiceException.class);
+    expectedEx.expectMessage(
+        "Virtual hostnames must be valid FQDNs and compatible with current domain (or its"
+            + " aliases).");
+    final Domain domain =
+        provisioning.createDomain(
+            domainName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+              }
+            });
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtualHostname});
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new DumbModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(0, provisioning.getDomainByName(domainName).getVirtualHostname().length);
+  }
+
+  @Test
+  public void shouldAllowGlobalAdminChangeVirtualHostnameIfNotCompliantWithDomain()
+      throws ServiceException {
+    final String domainName = UUID.randomUUID() + ".zextras.io";
+    final String virtualHostname = "virtual.whatever.not.compliant";
+    final Domain domain =
+        provisioning.createDomain(
+            domainName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
+              }
+            });
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
+    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
+    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
+    final HashMap<String, Object> attrsToUpdate =
+        new HashMap<>() {
+          {
+            put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtualHostname});
+          }
+        };
+    modifyDomainRequest.setAttrs(attrsToUpdate);
+    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
+    assertEquals(virtualHostname, provisioning.getDomainByName(domainName).getVirtualHostname()[0]);
+  }
+
   /**
    * VirtualHostnames n = 1
-   *
-   * @throws ServiceException
    */
   @Test
   public void shouldAddVirtualHostnameIfCompliantWithDomain() throws ServiceException {
@@ -137,7 +228,7 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraDomainName, domainName);
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -156,8 +247,6 @@ public class ModifyDomainIT {
 
   /**
    * VirtualHostnames n > 1. Reason is we get a list, with n = 1 we get just a String.
-   *
-   * @throws ServiceException
    */
   @Test
   public void shouldAddMultipleVirtualHostnamesIfCompliantWithDomain() throws ServiceException {
@@ -172,7 +261,7 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraDomainName, domainName);
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final String[] vHostnames = {virtualHostname, virtualHostname2};
@@ -192,7 +281,7 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldAddMultipleVirtualHostnamesAndPublicServiceHostnameIfFQDNSEqualToDoamin()
+  public void shouldAddMultipleVirtualHostnamesAndPublicServiceHostnameIfFQDNSEqualToDomain()
       throws ServiceException {
     final String domainName = UUID.randomUUID() + ".zextras.io";
     final Domain domain =
@@ -203,7 +292,7 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraDomainName, domainName);
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final String[] vHostnames = {domainName};
@@ -224,36 +313,7 @@ public class ModifyDomainIT {
             .containsAll(Arrays.stream(vHostnames).collect(Collectors.toList())));
   }
 
-  @Test
-  public void shouldThrowServiceExceptionIfVirtualHostnameNotCompliantWithDomain()
-      throws ServiceException {
-    final String domainName = UUID.randomUUID() + ".zextras.io";
-    final String virtualHostname = "virtual.whatever.not.compliant";
-    expectedEx.expect(ServiceException.class);
-    expectedEx.expectMessage(
-        "Virtual hostnames must be valid FQDNs and compatible with current domain (or its"
-            + " aliases).");
-    final Domain domain =
-        provisioning.createDomain(
-            domainName,
-            new HashMap<>() {
-              {
-                put(ZAttrProvisioning.A_zimbraDomainName, domainName);
-              }
-            });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
-    final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
-    ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
-    final HashMap<String, Object> attrsToUpdate =
-        new HashMap<>() {
-          {
-            put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtualHostname});
-          }
-        };
-    modifyDomainRequest.setAttrs(attrsToUpdate);
-    new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
-    assertEquals(0, provisioning.getDomainByName(domainName).getVirtualHostname().length);
-  }
+
 
   @Test
   public void shouldThrowDomainNameImmutableWhenModifyingDomainName() throws ServiceException {
@@ -269,7 +329,7 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraDomainName, domainName);
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -284,8 +344,6 @@ public class ModifyDomainIT {
 
   /**
    * [CO-544] empty virtual hostnames should remove all virtual hostnames
-   *
-   * @throws ServiceException
    */
   @Test
   public void shouldRemoveVirtualHostnamesWhenVirtualHostnamesEmptyArray() throws ServiceException {
@@ -301,7 +359,7 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtual1, virtual2});
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
@@ -318,8 +376,6 @@ public class ModifyDomainIT {
 
   /**
    * [CO-544] when zimbraVirtualHostname not passed it should not remove existing hostnames
-   *
-   * @throws ServiceException
    */
   @Test
   public void shouldNotRemoveVirtualHostnamesWhenVirtualHostnamesNotPassed()
@@ -336,17 +392,23 @@ public class ModifyDomainIT {
                 put(ZAttrProvisioning.A_zimbraVirtualHostname, new String[] {virtual1, virtual2});
               }
             });
-    final Account adminAccount = createDelegatedAdminForDomain(domain);
+    final Account adminAccount = createAdminAccount(domain, ZAttrProvisioning.A_zimbraIsAdminAccount);
     final Map<String, Object> ctx = getSoapContextFromAccount(adminAccount);
     ModifyDomainRequest modifyDomainRequest = new ModifyDomainRequest(domain.getId());
     final HashMap<String, Object> attrsToUpdate =
-        new HashMap<>() {
-          {
-          }
-        };
+        new HashMap<>() {};
     modifyDomainRequest.setAttrs(attrsToUpdate);
     new ModifyDomain().handle(JaxbUtil.jaxbToElement(modifyDomainRequest), ctx);
     assertEquals(
         2, Arrays.stream(provisioning.getDomainByName(domainName).getVirtualHostname()).count());
+  }
+
+  //skip checking delegated admin rights
+  private static class DumbModifyDomain extends ModifyDomain {
+    @Override
+    protected AdminAccessControl checkDomainRight(ZimbraSoapContext zsc, Domain d, Object needed)
+        throws ServiceException {
+      return AdminAccessControl.getAdminAccessControl(zsc);
+    }
   }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -486,7 +486,7 @@ public class ModifyDomainIT {
     }
 
     @Override
-    protected boolean hasRight(AdminAccessControl adminAccessControl, Config config) {
+    protected boolean hasAdminRightAndCanModifyConfig(AdminAccessControl adminAccessControl, Config config) {
       return adminAccessControl.mAuthedAcct.getName().contains("delegated.admin.true");
     }
   }

--- a/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/ModifyDomainIT.java
@@ -73,7 +73,7 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldThrowExceptionForDelegatedAdminIfPublicServiceHostnameNotComplaintWithDomain()
+  public void shouldThrowExceptionForDelegatedAdminIfPublicServiceHostnameNotCompliantWithDomain()
       throws ServiceException {
     final String domainName = "demo.zextras.io";
     final Domain domain = provisioning.createDomain(
@@ -103,7 +103,7 @@ public class ModifyDomainIT {
   }
 
   @Test
-  public void shouldAllowGlobalAdminChangePublicServiceHostnameIfNotComplaintWithDomain()
+  public void shouldAllowGlobalAdminChangePublicServiceHostnameIfNotCompliantWithDomain()
       throws ServiceException {
     final String domainName = "demo.zextras.io";
     final Domain domain = provisioning.createDomain(


### PR DESCRIPTION
Now global admin and delegated admin with granted right `modifyGlobalConfig` could set an arbitrary value for zimbraPublicServiceHostname and zimbraVirtualHostname.