### PR TITLE
chore: pre-commit exclude generated files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: 'attrs.xml'
+exclude: (?:(?!ZAttr.*\.java$|attrs\.xml|rights\-*\.xml$).)*$
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.3.0


### PR DESCRIPTION
**What has changed:**

config now excludes the following file patterns from being processed by pre-commit hooks:

- exclude ZAttr*.java
- exclude attrs.xml
- exclude rights-*.xml