### PR TITLE
chore: bump dom4j to 2.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,7 @@
     <cxf.version>3.3.4</cxf.version>
     <nekohtml.version>1.9.22</nekohtml.version>
     <log4j.version>1.2.16</log4j.version>
-    <dom4j.version>2.1.1</dom4j.version>
+    <dom4j.version>2.1.3</dom4j.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <zkclient.version>0.11</zkclient.version>
     <hsqldb.version>2.2.9</hsqldb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,7 @@
     <cxf.version>3.3.4</cxf.version>
     <nekohtml.version>1.9.22</nekohtml.version>
     <log4j.version>1.2.16</log4j.version>
-    <dom4j.version>2.1.3</dom4j.version>
+    <dom4j.version>2.1.4</dom4j.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <zkclient.version>0.11</zkclient.version>
     <hsqldb.version>2.2.9</hsqldb.version>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -644,7 +644,7 @@
           <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
           </dependency>
           <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -644,7 +644,7 @@
           <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.3</version>
           </dependency>
           <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Check: https://mvnrepository.com/artifact/org.dom4j/dom4j
Fixes this vulnerability: https://github.com/Zextras/carbonio-mailbox/security/dependabot/94
Related PR: https://github.com/Zextras/carbonio-zcs-lib/pull/17