### PR TITLE
feat: [CO-729] Redirect as default globalConf value for reverseProxyMailMode

### DIFF
--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -3337,6 +3337,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="685" name="zimbraReverseProxyMailMode" type="enum" value="https,redirect" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="nginxproxy" since="5.0.7">
+  <globalConfigValue>redirect</globalConfigValue>
   <desc>whether to run proxy in HTTPS or redirect mode. See also related attributes zimbraMailProxyPort and zimbraMailSSLProxyPort</desc>
 </attr>
 

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -55831,13 +55831,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [https, redirect]
      *
-     * @return zimbraReverseProxyMailMode, or null if unset and/or has invalid value
+     * @return zimbraReverseProxyMailMode, or ZAttrProvisioning.ReverseProxyMailMode.redirect if unset and/or has invalid value
      *
      * @since ZCS 5.0.7
      */
     @ZAttr(id=685)
     public ZAttrProvisioning.ReverseProxyMailMode getReverseProxyMailMode() {
-        try { String v = getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, true, true); return v == null ? null : ZAttrProvisioning.ReverseProxyMailMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
+        try { String v = getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, true, true); return v == null ? ZAttrProvisioning.ReverseProxyMailMode.redirect : ZAttrProvisioning.ReverseProxyMailMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.ReverseProxyMailMode.redirect; }
     }
 
     /**
@@ -55846,13 +55846,13 @@ public abstract class ZAttrConfig extends Entry {
      *
      * <p>Valid values: [https, redirect]
      *
-     * @return zimbraReverseProxyMailMode, or null if unset
+     * @return zimbraReverseProxyMailMode, or "redirect" if unset
      *
      * @since ZCS 5.0.7
      */
     @ZAttr(id=685)
     public String getReverseProxyMailModeAsString() {
-        return getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, null, true);
+        return getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, "redirect", true);
     }
 
     /**

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -38390,13 +38390,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [https, redirect]
      *
-     * @return zimbraReverseProxyMailMode, or null if unset and/or has invalid value
+     * @return zimbraReverseProxyMailMode, or ZAttrProvisioning.ReverseProxyMailMode.redirect if unset and/or has invalid value
      *
      * @since ZCS 5.0.7
      */
     @ZAttr(id=685)
     public ZAttrProvisioning.ReverseProxyMailMode getReverseProxyMailMode() {
-        try { String v = getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, true, true); return v == null ? null : ZAttrProvisioning.ReverseProxyMailMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return null; }
+        try { String v = getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, true, true); return v == null ? ZAttrProvisioning.ReverseProxyMailMode.redirect : ZAttrProvisioning.ReverseProxyMailMode.fromString(v); } catch(com.zimbra.common.service.ServiceException e) { return ZAttrProvisioning.ReverseProxyMailMode.redirect; }
     }
 
     /**
@@ -38405,13 +38405,13 @@ public abstract class ZAttrServer extends NamedEntry {
      *
      * <p>Valid values: [https, redirect]
      *
-     * @return zimbraReverseProxyMailMode, or null if unset
+     * @return zimbraReverseProxyMailMode, or "redirect" if unset
      *
      * @since ZCS 5.0.7
      */
     @ZAttr(id=685)
     public String getReverseProxyMailModeAsString() {
-        return getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, null, true);
+        return getAttr(ZAttrProvisioning.A_zimbraReverseProxyMailMode, "redirect", true);
     }
 
     /**


### PR DESCRIPTION
**What has changed:**
- deault globalConf value for reverseProxyMailMode as 'redirect'

**Other PRs:**
- https://github.com/Zextras/carbonio-ldap-utilities/pull/49

See, CO-729 for context.