### PR TITLE
chore: [CO-723] fix code smells in generated code (Attribute classes)

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -17,11 +17,12 @@ public class ZAttrProvisioning {
 
   ///// BEGIN-AUTO-GEN-REPLACE
 
-    public static enum AccountCalendarUserType {
+    public enum AccountCalendarUserType {
         USER("USER"),
         RESOURCE("RESOURCE");
-        private String mValue;
-        private AccountCalendarUserType(String value) { mValue = value; }
+        private final String mValue;
+        AccountCalendarUserType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AccountCalendarUserType fromString(String s) throws ServiceException {
             for (AccountCalendarUserType value : values()) {
@@ -33,15 +34,16 @@ public class ZAttrProvisioning {
         public boolean isRESOURCE() { return this == RESOURCE;}
     }
 
-    public static enum AccountStatus {
+    public enum AccountStatus {
         active("active"),
         maintenance("maintenance"),
         locked("locked"),
         closed("closed"),
         lockout("lockout"),
         pending("pending");
-        private String mValue;
-        private AccountStatus(String value) { mValue = value; }
+        private final String mValue;
+        AccountStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AccountStatus fromString(String s) throws ServiceException {
             for (AccountStatus value : values()) {
@@ -57,11 +59,12 @@ public class ZAttrProvisioning {
         public boolean isPending() { return this == pending;}
     }
 
-    public static enum AdminAccessControlMech {
+    public enum AdminAccessControlMech {
         acl("acl"),
         global("global");
-        private String mValue;
-        private AdminAccessControlMech(String value) { mValue = value; }
+        private final String mValue;
+        AdminAccessControlMech(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AdminAccessControlMech fromString(String s) throws ServiceException {
             for (AdminAccessControlMech value : values()) {
@@ -73,13 +76,14 @@ public class ZAttrProvisioning {
         public boolean isGlobal() { return this == global;}
     }
 
-    public static enum AmavisFinalSpamDestiny {
+    public enum AmavisFinalSpamDestiny {
         D_PASS("D_PASS"),
         D_BOUNCE("D_BOUNCE"),
         D_REJECT("D_REJECT"),
         D_DISCARD("D_DISCARD");
-        private String mValue;
-        private AmavisFinalSpamDestiny(String value) { mValue = value; }
+        private final String mValue;
+        AmavisFinalSpamDestiny(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AmavisFinalSpamDestiny fromString(String s) throws ServiceException {
             for (AmavisFinalSpamDestiny value : values()) {
@@ -93,13 +97,14 @@ public class ZAttrProvisioning {
         public boolean isD_DISCARD() { return this == D_DISCARD;}
     }
 
-    public static enum AutoProvAuthMech {
+    public enum AutoProvAuthMech {
         LDAP("LDAP"),
         PREAUTH("PREAUTH"),
         KRB5("KRB5"),
         SPNEGO("SPNEGO");
-        private String mValue;
-        private AutoProvAuthMech(String value) { mValue = value; }
+        private final String mValue;
+        AutoProvAuthMech(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AutoProvAuthMech fromString(String s) throws ServiceException {
             for (AutoProvAuthMech value : values()) {
@@ -113,12 +118,13 @@ public class ZAttrProvisioning {
         public boolean isSPNEGO() { return this == SPNEGO;}
     }
 
-    public static enum AutoProvMode {
+    public enum AutoProvMode {
         EAGER("EAGER"),
         LAZY("LAZY"),
         MANUAL("MANUAL");
-        private String mValue;
-        private AutoProvMode(String value) { mValue = value; }
+        private final String mValue;
+        AutoProvMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static AutoProvMode fromString(String s) throws ServiceException {
             for (AutoProvMode value : values()) {
@@ -131,11 +137,12 @@ public class ZAttrProvisioning {
         public boolean isMANUAL() { return this == MANUAL;}
     }
 
-    public static enum BackupMode {
+    public enum BackupMode {
         Standard("Standard"),
         Auto_Grouped("Auto-Grouped");
-        private String mValue;
-        private BackupMode(String value) { mValue = value; }
+        private final String mValue;
+        BackupMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static BackupMode fromString(String s) throws ServiceException {
             for (BackupMode value : values()) {
@@ -147,11 +154,12 @@ public class ZAttrProvisioning {
         public boolean isAuto_Grouped() { return this == Auto_Grouped;}
     }
 
-    public static enum CalendarCompatibilityMode {
+    public enum CalendarCompatibilityMode {
         standard("standard"),
         exchange("exchange");
-        private String mValue;
-        private CalendarCompatibilityMode(String value) { mValue = value; }
+        private final String mValue;
+        CalendarCompatibilityMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static CalendarCompatibilityMode fromString(String s) throws ServiceException {
             for (CalendarCompatibilityMode value : values()) {
@@ -163,11 +171,12 @@ public class ZAttrProvisioning {
         public boolean isExchange() { return this == exchange;}
     }
 
-    public static enum CalResType {
+    public enum CalResType {
         Location("Location"),
         Equipment("Equipment");
-        private String mValue;
-        private CalResType(String value) { mValue = value; }
+        private final String mValue;
+        CalResType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static CalResType fromString(String s) throws ServiceException {
             for (CalResType value : values()) {
@@ -179,11 +188,12 @@ public class ZAttrProvisioning {
         public boolean isEquipment() { return this == Equipment;}
     }
 
-    public static enum CBPolicydBypassMode {
+    public enum CBPolicydBypassMode {
         tempfail("tempfail"),
         pass("pass");
-        private String mValue;
-        private CBPolicydBypassMode(String value) { mValue = value; }
+        private final String mValue;
+        CBPolicydBypassMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static CBPolicydBypassMode fromString(String s) throws ServiceException {
             for (CBPolicydBypassMode value : values()) {
@@ -195,12 +205,13 @@ public class ZAttrProvisioning {
         public boolean isPass() { return this == pass;}
     }
 
-    public static enum ClusterType {
+    public enum ClusterType {
         none("none"),
         RedHat("RedHat"),
         Veritas("Veritas");
-        private String mValue;
-        private ClusterType(String value) { mValue = value; }
+        private final String mValue;
+        ClusterType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ClusterType fromString(String s) throws ServiceException {
             for (ClusterType value : values()) {
@@ -213,13 +224,14 @@ public class ZAttrProvisioning {
         public boolean isVeritas() { return this == Veritas;}
     }
 
-    public static enum DataSourceAuthMechanism {
+    public enum DataSourceAuthMechanism {
         PLAIN("PLAIN"),
         GSSAPI("GSSAPI"),
         CRAM_MD5("CRAM-MD5"),
         XOAUTH2("XOAUTH2");
-        private String mValue;
-        private DataSourceAuthMechanism(String value) { mValue = value; }
+        private final String mValue;
+        DataSourceAuthMechanism(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DataSourceAuthMechanism fromString(String s) throws ServiceException {
             for (DataSourceAuthMechanism value : values()) {
@@ -233,13 +245,14 @@ public class ZAttrProvisioning {
         public boolean isXOAUTH2() { return this == XOAUTH2;}
     }
 
-    public static enum DataSourceConnectionType {
+    public enum DataSourceConnectionType {
         cleartext("cleartext"),
         ssl("ssl"),
         tls("tls"),
         tls_if_available("tls_if_available");
-        private String mValue;
-        private DataSourceConnectionType(String value) { mValue = value; }
+        private final String mValue;
+        DataSourceConnectionType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DataSourceConnectionType fromString(String s) throws ServiceException {
             for (DataSourceConnectionType value : values()) {
@@ -253,11 +266,12 @@ public class ZAttrProvisioning {
         public boolean isTls_if_available() { return this == tls_if_available;}
     }
 
-    public static enum DataSourceSmtpConnectionType {
+    public enum DataSourceSmtpConnectionType {
         cleartext("cleartext"),
         ssl("ssl");
-        private String mValue;
-        private DataSourceSmtpConnectionType(String value) { mValue = value; }
+        private final String mValue;
+        DataSourceSmtpConnectionType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DataSourceSmtpConnectionType fromString(String s) throws ServiceException {
             for (DataSourceSmtpConnectionType value : values()) {
@@ -269,12 +283,13 @@ public class ZAttrProvisioning {
         public boolean isSsl() { return this == ssl;}
     }
 
-    public static enum DistributionListSubscriptionPolicy {
+    public enum DistributionListSubscriptionPolicy {
         ACCEPT("ACCEPT"),
         REJECT("REJECT"),
         APPROVAL("APPROVAL");
-        private String mValue;
-        private DistributionListSubscriptionPolicy(String value) { mValue = value; }
+        private final String mValue;
+        DistributionListSubscriptionPolicy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DistributionListSubscriptionPolicy fromString(String s) throws ServiceException {
             for (DistributionListSubscriptionPolicy value : values()) {
@@ -287,12 +302,13 @@ public class ZAttrProvisioning {
         public boolean isAPPROVAL() { return this == APPROVAL;}
     }
 
-    public static enum DistributionListUnsubscriptionPolicy {
+    public enum DistributionListUnsubscriptionPolicy {
         ACCEPT("ACCEPT"),
         REJECT("REJECT"),
         APPROVAL("APPROVAL");
-        private String mValue;
-        private DistributionListUnsubscriptionPolicy(String value) { mValue = value; }
+        private final String mValue;
+        DistributionListUnsubscriptionPolicy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DistributionListUnsubscriptionPolicy fromString(String s) throws ServiceException {
             for (DistributionListUnsubscriptionPolicy value : values()) {
@@ -305,12 +321,13 @@ public class ZAttrProvisioning {
         public boolean isAPPROVAL() { return this == APPROVAL;}
     }
 
-    public static enum DomainAggregateQuotaPolicy {
+    public enum DomainAggregateQuotaPolicy {
         ALLOWSENDRECEIVE("ALLOWSENDRECEIVE"),
         BLOCKSEND("BLOCKSEND"),
         BLOCKSENDRECEIVE("BLOCKSENDRECEIVE");
-        private String mValue;
-        private DomainAggregateQuotaPolicy(String value) { mValue = value; }
+        private final String mValue;
+        DomainAggregateQuotaPolicy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DomainAggregateQuotaPolicy fromString(String s) throws ServiceException {
             for (DomainAggregateQuotaPolicy value : values()) {
@@ -323,15 +340,16 @@ public class ZAttrProvisioning {
         public boolean isBLOCKSENDRECEIVE() { return this == BLOCKSENDRECEIVE;}
     }
 
-    public static enum DomainStatus {
+    public enum DomainStatus {
         active("active"),
         maintenance("maintenance"),
         locked("locked"),
         closed("closed"),
         suspended("suspended"),
         shutdown("shutdown");
-        private String mValue;
-        private DomainStatus(String value) { mValue = value; }
+        private final String mValue;
+        DomainStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DomainStatus fromString(String s) throws ServiceException {
             for (DomainStatus value : values()) {
@@ -347,11 +365,12 @@ public class ZAttrProvisioning {
         public boolean isShutdown() { return this == shutdown;}
     }
 
-    public static enum DomainType {
+    public enum DomainType {
         local("local"),
         alias("alias");
-        private String mValue;
-        private DomainType(String value) { mValue = value; }
+        private final String mValue;
+        DomainType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static DomainType fromString(String s) throws ServiceException {
             for (DomainType value : values()) {
@@ -363,13 +382,14 @@ public class ZAttrProvisioning {
         public boolean isAlias() { return this == alias;}
     }
 
-    public static enum FeatureAddressVerificationStatus {
+    public enum FeatureAddressVerificationStatus {
         verified("verified"),
         pending("pending"),
         failed("failed"),
         expired("expired");
-        private String mValue;
-        private FeatureAddressVerificationStatus(String value) { mValue = value; }
+        private final String mValue;
+        FeatureAddressVerificationStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static FeatureAddressVerificationStatus fromString(String s) throws ServiceException {
             for (FeatureAddressVerificationStatus value : values()) {
@@ -383,12 +403,13 @@ public class ZAttrProvisioning {
         public boolean isExpired() { return this == expired;}
     }
 
-    public static enum FeatureResetPasswordStatus {
+    public enum FeatureResetPasswordStatus {
         enabled("enabled"),
         suspended("suspended"),
         disabled("disabled");
-        private String mValue;
-        private FeatureResetPasswordStatus(String value) { mValue = value; }
+        private final String mValue;
+        FeatureResetPasswordStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static FeatureResetPasswordStatus fromString(String s) throws ServiceException {
             for (FeatureResetPasswordStatus value : values()) {
@@ -401,13 +422,14 @@ public class ZAttrProvisioning {
         public boolean isDisabled() { return this == disabled;}
     }
 
-    public static enum FeatureSocialFiltersEnabled {
+    public enum FeatureSocialFiltersEnabled {
         SocialCast("SocialCast"),
         LinkedIn("LinkedIn"),
         Twitter("Twitter"),
         Facebook("Facebook");
-        private String mValue;
-        private FeatureSocialFiltersEnabled(String value) { mValue = value; }
+        private final String mValue;
+        FeatureSocialFiltersEnabled(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static FeatureSocialFiltersEnabled fromString(String s) throws ServiceException {
             for (FeatureSocialFiltersEnabled value : values()) {
@@ -421,11 +443,12 @@ public class ZAttrProvisioning {
         public boolean isFacebook() { return this == Facebook;}
     }
 
-    public static enum FreebusyExchangeAuthScheme {
+    public enum FreebusyExchangeAuthScheme {
         basic("basic"),
         form("form");
-        private String mValue;
-        private FreebusyExchangeAuthScheme(String value) { mValue = value; }
+        private final String mValue;
+        FreebusyExchangeAuthScheme(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static FreebusyExchangeAuthScheme fromString(String s) throws ServiceException {
             for (FreebusyExchangeAuthScheme value : values()) {
@@ -437,11 +460,12 @@ public class ZAttrProvisioning {
         public boolean isForm() { return this == form;}
     }
 
-    public static enum FreebusyExchangeServerType {
+    public enum FreebusyExchangeServerType {
         webdav("webdav"),
         ews("ews");
-        private String mValue;
-        private FreebusyExchangeServerType(String value) { mValue = value; }
+        private final String mValue;
+        FreebusyExchangeServerType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static FreebusyExchangeServerType fromString(String s) throws ServiceException {
             for (FreebusyExchangeServerType value : values()) {
@@ -453,12 +477,13 @@ public class ZAttrProvisioning {
         public boolean isEws() { return this == ews;}
     }
 
-    public static enum GalLdapAuthMech {
+    public enum GalLdapAuthMech {
         none("none"),
         simple("simple"),
         kerberos5("kerberos5");
-        private String mValue;
-        private GalLdapAuthMech(String value) { mValue = value; }
+        private final String mValue;
+        GalLdapAuthMech(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalLdapAuthMech fromString(String s) throws ServiceException {
             for (GalLdapAuthMech value : values()) {
@@ -471,12 +496,13 @@ public class ZAttrProvisioning {
         public boolean isKerberos5() { return this == kerberos5;}
     }
 
-    public static enum GalMode {
+    public enum GalMode {
         zimbra("zimbra"),
         both("both"),
         ldap("ldap");
-        private String mValue;
-        private GalMode(String value) { mValue = value; }
+        private final String mValue;
+        GalMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalMode fromString(String s) throws ServiceException {
             for (GalMode value : values()) {
@@ -489,11 +515,12 @@ public class ZAttrProvisioning {
         public boolean isLdap() { return this == ldap;}
     }
 
-    public static enum GalStatus {
+    public enum GalStatus {
         enabled("enabled"),
         disabled("disabled");
-        private String mValue;
-        private GalStatus(String value) { mValue = value; }
+        private final String mValue;
+        GalStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalStatus fromString(String s) throws ServiceException {
             for (GalStatus value : values()) {
@@ -505,12 +532,13 @@ public class ZAttrProvisioning {
         public boolean isDisabled() { return this == disabled;}
     }
 
-    public static enum GalSyncLdapAuthMech {
+    public enum GalSyncLdapAuthMech {
         none("none"),
         simple("simple"),
         kerberos5("kerberos5");
-        private String mValue;
-        private GalSyncLdapAuthMech(String value) { mValue = value; }
+        private final String mValue;
+        GalSyncLdapAuthMech(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalSyncLdapAuthMech fromString(String s) throws ServiceException {
             for (GalSyncLdapAuthMech value : values()) {
@@ -523,11 +551,12 @@ public class ZAttrProvisioning {
         public boolean isKerberos5() { return this == kerberos5;}
     }
 
-    public static enum GalTokenizeAutoCompleteKey {
+    public enum GalTokenizeAutoCompleteKey {
         and("and"),
         or("or");
-        private String mValue;
-        private GalTokenizeAutoCompleteKey(String value) { mValue = value; }
+        private final String mValue;
+        GalTokenizeAutoCompleteKey(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalTokenizeAutoCompleteKey fromString(String s) throws ServiceException {
             for (GalTokenizeAutoCompleteKey value : values()) {
@@ -539,11 +568,12 @@ public class ZAttrProvisioning {
         public boolean isOr() { return this == or;}
     }
 
-    public static enum GalTokenizeSearchKey {
+    public enum GalTokenizeSearchKey {
         and("and"),
         or("or");
-        private String mValue;
-        private GalTokenizeSearchKey(String value) { mValue = value; }
+        private final String mValue;
+        GalTokenizeSearchKey(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalTokenizeSearchKey fromString(String s) throws ServiceException {
             for (GalTokenizeSearchKey value : values()) {
@@ -555,11 +585,12 @@ public class ZAttrProvisioning {
         public boolean isOr() { return this == or;}
     }
 
-    public static enum GalType {
+    public enum GalType {
         zimbra("zimbra"),
         ldap("ldap");
-        private String mValue;
-        private GalType(String value) { mValue = value; }
+        private final String mValue;
+        GalType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static GalType fromString(String s) throws ServiceException {
             for (GalType value : values()) {
@@ -571,12 +602,13 @@ public class ZAttrProvisioning {
         public boolean isLdap() { return this == ldap;}
     }
 
-    public static enum IPMode {
+    public enum IPMode {
         ipv4("ipv4"),
         ipv6("ipv6"),
         both("both");
-        private String mValue;
-        private IPMode(String value) { mValue = value; }
+        private final String mValue;
+        IPMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static IPMode fromString(String s) throws ServiceException {
             for (IPMode value : values()) {
@@ -589,14 +621,15 @@ public class ZAttrProvisioning {
         public boolean isBoth() { return this == both;}
     }
 
-    public static enum MailMode {
+    public enum MailMode {
         http("http"),
         https("https"),
         both("both"),
         mixed("mixed"),
         redirect("redirect");
-        private String mValue;
-        private MailMode(String value) { mValue = value; }
+        private final String mValue;
+        MailMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MailMode fromString(String s) throws ServiceException {
             for (MailMode value : values()) {
@@ -611,12 +644,13 @@ public class ZAttrProvisioning {
         public boolean isRedirect() { return this == redirect;}
     }
 
-    public static enum MailReferMode {
+    public enum MailReferMode {
         always("always"),
         wronghost("wronghost"),
         reverse_proxied("reverse-proxied");
-        private String mValue;
-        private MailReferMode(String value) { mValue = value; }
+        private final String mValue;
+        MailReferMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MailReferMode fromString(String s) throws ServiceException {
             for (MailReferMode value : values()) {
@@ -629,12 +663,13 @@ public class ZAttrProvisioning {
         public boolean isReverse_proxied() { return this == reverse_proxied;}
     }
 
-    public static enum MailSSLClientCertMode {
+    public enum MailSSLClientCertMode {
         Disabled("Disabled"),
         NeedClientAuth("NeedClientAuth"),
         WantClientAuth("WantClientAuth");
-        private String mValue;
-        private MailSSLClientCertMode(String value) { mValue = value; }
+        private final String mValue;
+        MailSSLClientCertMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MailSSLClientCertMode fromString(String s) throws ServiceException {
             for (MailSSLClientCertMode value : values()) {
@@ -647,11 +682,12 @@ public class ZAttrProvisioning {
         public boolean isWantClientAuth() { return this == WantClientAuth;}
     }
 
-    public static enum MailStatus {
+    public enum MailStatus {
         enabled("enabled"),
         disabled("disabled");
-        private String mValue;
-        private MailStatus(String value) { mValue = value; }
+        private final String mValue;
+        MailStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MailStatus fromString(String s) throws ServiceException {
             for (MailStatus value : values()) {
@@ -663,14 +699,15 @@ public class ZAttrProvisioning {
         public boolean isDisabled() { return this == disabled;}
     }
 
-    public static enum MailThreadingAlgorithm {
+    public enum MailThreadingAlgorithm {
         subject("subject"),
         subjrefs("subjrefs"),
         references("references"),
         strict("strict"),
         none("none");
-        private String mValue;
-        private MailThreadingAlgorithm(String value) { mValue = value; }
+        private final String mValue;
+        MailThreadingAlgorithm(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MailThreadingAlgorithm fromString(String s) throws ServiceException {
             for (MailThreadingAlgorithm value : values()) {
@@ -685,13 +722,14 @@ public class ZAttrProvisioning {
         public boolean isNone() { return this == none;}
     }
 
-    public static enum MobileGatewayProxyImapConnectionType {
+    public enum MobileGatewayProxyImapConnectionType {
         cleartext("cleartext"),
         ssl("ssl"),
         tls("tls"),
         tls_if_available("tls_if_available");
-        private String mValue;
-        private MobileGatewayProxyImapConnectionType(String value) { mValue = value; }
+        private final String mValue;
+        MobileGatewayProxyImapConnectionType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MobileGatewayProxyImapConnectionType fromString(String s) throws ServiceException {
             for (MobileGatewayProxyImapConnectionType value : values()) {
@@ -705,11 +743,12 @@ public class ZAttrProvisioning {
         public boolean isTls_if_available() { return this == tls_if_available;}
     }
 
-    public static enum MobileGatewayProxySmtpConnectionType {
+    public enum MobileGatewayProxySmtpConnectionType {
         cleartext("cleartext"),
         ssl("ssl");
-        private String mValue;
-        private MobileGatewayProxySmtpConnectionType(String value) { mValue = value; }
+        private final String mValue;
+        MobileGatewayProxySmtpConnectionType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MobileGatewayProxySmtpConnectionType fromString(String s) throws ServiceException {
             for (MobileGatewayProxySmtpConnectionType value : values()) {
@@ -721,11 +760,12 @@ public class ZAttrProvisioning {
         public boolean isSsl() { return this == ssl;}
     }
 
-    public static enum MtaAlwaysAddMissingHeaders {
+    public enum MtaAlwaysAddMissingHeaders {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaAlwaysAddMissingHeaders(String value) { mValue = value; }
+        private final String mValue;
+        MtaAlwaysAddMissingHeaders(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaAlwaysAddMissingHeaders fromString(String s) throws ServiceException {
             for (MtaAlwaysAddMissingHeaders value : values()) {
@@ -737,11 +777,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaBrokenSaslAuthClients {
+    public enum MtaBrokenSaslAuthClients {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaBrokenSaslAuthClients(String value) { mValue = value; }
+        private final String mValue;
+        MtaBrokenSaslAuthClients(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaBrokenSaslAuthClients fromString(String s) throws ServiceException {
             for (MtaBrokenSaslAuthClients value : values()) {
@@ -753,11 +794,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaLmtpHostLookup {
+    public enum MtaLmtpHostLookup {
         dns("dns"),
         native_("native");
-        private String mValue;
-        private MtaLmtpHostLookup(String value) { mValue = value; }
+        private final String mValue;
+        MtaLmtpHostLookup(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaLmtpHostLookup fromString(String s) throws ServiceException {
             for (MtaLmtpHostLookup value : values()) {
@@ -769,14 +811,15 @@ public class ZAttrProvisioning {
         public boolean isNative_() { return this == native_;}
     }
 
-    public static enum MtaLmtpTlsCiphers {
+    public enum MtaLmtpTlsCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaLmtpTlsCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaLmtpTlsCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaLmtpTlsCiphers fromString(String s) throws ServiceException {
             for (MtaLmtpTlsCiphers value : values()) {
@@ -791,14 +834,15 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaLmtpTlsMandatoryCiphers {
+    public enum MtaLmtpTlsMandatoryCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaLmtpTlsMandatoryCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaLmtpTlsMandatoryCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaLmtpTlsMandatoryCiphers fromString(String s) throws ServiceException {
             for (MtaLmtpTlsMandatoryCiphers value : values()) {
@@ -813,7 +857,7 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaLmtpTlsSecurityLevel {
+    public enum MtaLmtpTlsSecurityLevel {
         none("none"),
         may("may"),
         encrypt("encrypt"),
@@ -822,8 +866,9 @@ public class ZAttrProvisioning {
         fingerprint("fingerprint"),
         verify("verify"),
         secure("secure");
-        private String mValue;
-        private MtaLmtpTlsSecurityLevel(String value) { mValue = value; }
+        private final String mValue;
+        MtaLmtpTlsSecurityLevel(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaLmtpTlsSecurityLevel fromString(String s) throws ServiceException {
             for (MtaLmtpTlsSecurityLevel value : values()) {
@@ -841,13 +886,14 @@ public class ZAttrProvisioning {
         public boolean isSecure() { return this == secure;}
     }
 
-    public static enum MtaMilterDefaultAction {
+    public enum MtaMilterDefaultAction {
         accept("accept"),
         reject("reject"),
         tempfail("tempfail"),
         quarantine("quarantine");
-        private String mValue;
-        private MtaMilterDefaultAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaMilterDefaultAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaMilterDefaultAction fromString(String s) throws ServiceException {
             for (MtaMilterDefaultAction value : values()) {
@@ -861,7 +907,7 @@ public class ZAttrProvisioning {
         public boolean isQuarantine() { return this == quarantine;}
     }
 
-    public static enum MtaNotifyClasses {
+    public enum MtaNotifyClasses {
         bounce("bounce"),
         _bounce("2bounce"),
         data("data"),
@@ -870,8 +916,9 @@ public class ZAttrProvisioning {
         protocol("protocol"),
         resource("resource"),
         software("software");
-        private String mValue;
-        private MtaNotifyClasses(String value) { mValue = value; }
+        private final String mValue;
+        MtaNotifyClasses(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaNotifyClasses fromString(String s) throws ServiceException {
             for (MtaNotifyClasses value : values()) {
@@ -889,12 +936,13 @@ public class ZAttrProvisioning {
         public boolean isSoftware() { return this == software;}
     }
 
-    public static enum MtaPostscreenBareNewlineAction {
+    public enum MtaPostscreenBareNewlineAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenBareNewlineAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenBareNewlineAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenBareNewlineAction fromString(String s) throws ServiceException {
             for (MtaPostscreenBareNewlineAction value : values()) {
@@ -907,11 +955,12 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenBareNewlineEnable {
+    public enum MtaPostscreenBareNewlineEnable {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaPostscreenBareNewlineEnable(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenBareNewlineEnable(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenBareNewlineEnable fromString(String s) throws ServiceException {
             for (MtaPostscreenBareNewlineEnable value : values()) {
@@ -923,12 +972,13 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaPostscreenBlacklistAction {
+    public enum MtaPostscreenBlacklistAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenBlacklistAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenBlacklistAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenBlacklistAction fromString(String s) throws ServiceException {
             for (MtaPostscreenBlacklistAction value : values()) {
@@ -941,12 +991,13 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenDnsblAction {
+    public enum MtaPostscreenDnsblAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenDnsblAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenDnsblAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenDnsblAction fromString(String s) throws ServiceException {
             for (MtaPostscreenDnsblAction value : values()) {
@@ -959,12 +1010,13 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenGreetAction {
+    public enum MtaPostscreenGreetAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenGreetAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenGreetAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenGreetAction fromString(String s) throws ServiceException {
             for (MtaPostscreenGreetAction value : values()) {
@@ -977,12 +1029,13 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenNonSmtpCommandAction {
+    public enum MtaPostscreenNonSmtpCommandAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenNonSmtpCommandAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenNonSmtpCommandAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenNonSmtpCommandAction fromString(String s) throws ServiceException {
             for (MtaPostscreenNonSmtpCommandAction value : values()) {
@@ -995,11 +1048,12 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenNonSmtpCommandEnable {
+    public enum MtaPostscreenNonSmtpCommandEnable {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaPostscreenNonSmtpCommandEnable(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenNonSmtpCommandEnable(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenNonSmtpCommandEnable fromString(String s) throws ServiceException {
             for (MtaPostscreenNonSmtpCommandEnable value : values()) {
@@ -1011,12 +1065,13 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaPostscreenPipeliningAction {
+    public enum MtaPostscreenPipeliningAction {
         ignore("ignore"),
         enforce("enforce"),
         drop("drop");
-        private String mValue;
-        private MtaPostscreenPipeliningAction(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenPipeliningAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenPipeliningAction fromString(String s) throws ServiceException {
             for (MtaPostscreenPipeliningAction value : values()) {
@@ -1029,11 +1084,12 @@ public class ZAttrProvisioning {
         public boolean isDrop() { return this == drop;}
     }
 
-    public static enum MtaPostscreenPipeliningEnable {
+    public enum MtaPostscreenPipeliningEnable {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaPostscreenPipeliningEnable(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenPipeliningEnable(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenPipeliningEnable fromString(String s) throws ServiceException {
             for (MtaPostscreenPipeliningEnable value : values()) {
@@ -1045,10 +1101,11 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaPostscreenUpstreamProxyProtocol {
+    public enum MtaPostscreenUpstreamProxyProtocol {
         haproxy("haproxy");
-        private String mValue;
-        private MtaPostscreenUpstreamProxyProtocol(String value) { mValue = value; }
+        private final String mValue;
+        MtaPostscreenUpstreamProxyProtocol(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPostscreenUpstreamProxyProtocol fromString(String s) throws ServiceException {
             for (MtaPostscreenUpstreamProxyProtocol value : values()) {
@@ -1059,15 +1116,16 @@ public class ZAttrProvisioning {
         public boolean isHaproxy() { return this == haproxy;}
     }
 
-    public static enum MtaPropagateUnmatchedExtensions {
+    public enum MtaPropagateUnmatchedExtensions {
         canonical("canonical"),
         virtual("virtual"),
         alias("alias"),
         forward("forward"),
         include("include"),
         generic("generic");
-        private String mValue;
-        private MtaPropagateUnmatchedExtensions(String value) { mValue = value; }
+        private final String mValue;
+        MtaPropagateUnmatchedExtensions(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaPropagateUnmatchedExtensions fromString(String s) throws ServiceException {
             for (MtaPropagateUnmatchedExtensions value : values()) {
@@ -1083,11 +1141,12 @@ public class ZAttrProvisioning {
         public boolean isGeneric() { return this == generic;}
     }
 
-    public static enum MtaSaslAuthEnable {
+    public enum MtaSaslAuthEnable {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSaslAuthEnable(String value) { mValue = value; }
+        private final String mValue;
+        MtaSaslAuthEnable(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSaslAuthEnable fromString(String s) throws ServiceException {
             for (MtaSaslAuthEnable value : values()) {
@@ -1099,11 +1158,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpCnameOverridesServername {
+    public enum MtaSmtpCnameOverridesServername {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpCnameOverridesServername(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpCnameOverridesServername(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpCnameOverridesServername fromString(String s) throws ServiceException {
             for (MtaSmtpCnameOverridesServername value : values()) {
@@ -1115,11 +1175,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdClientPortLogging {
+    public enum MtaSmtpdClientPortLogging {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdClientPortLogging(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdClientPortLogging(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdClientPortLogging fromString(String s) throws ServiceException {
             for (MtaSmtpdClientPortLogging value : values()) {
@@ -1131,11 +1192,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdHeloRequired {
+    public enum MtaSmtpdHeloRequired {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdHeloRequired(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdHeloRequired(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdHeloRequired fromString(String s) throws ServiceException {
             for (MtaSmtpdHeloRequired value : values()) {
@@ -1147,12 +1209,13 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpDnsSupportLevel {
+    public enum MtaSmtpDnsSupportLevel {
         disabled("disabled"),
         enabled("enabled"),
         dnssec("dnssec");
-        private String mValue;
-        private MtaSmtpDnsSupportLevel(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpDnsSupportLevel(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpDnsSupportLevel fromString(String s) throws ServiceException {
             for (MtaSmtpDnsSupportLevel value : values()) {
@@ -1165,11 +1228,12 @@ public class ZAttrProvisioning {
         public boolean isDnssec() { return this == dnssec;}
     }
 
-    public static enum MtaSmtpdRejectUnlistedRecipient {
+    public enum MtaSmtpdRejectUnlistedRecipient {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdRejectUnlistedRecipient(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdRejectUnlistedRecipient(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdRejectUnlistedRecipient fromString(String s) throws ServiceException {
             for (MtaSmtpdRejectUnlistedRecipient value : values()) {
@@ -1181,11 +1245,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdRejectUnlistedSender {
+    public enum MtaSmtpdRejectUnlistedSender {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdRejectUnlistedSender(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdRejectUnlistedSender(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdRejectUnlistedSender fromString(String s) throws ServiceException {
             for (MtaSmtpdRejectUnlistedSender value : values()) {
@@ -1197,11 +1262,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdSaslAuthenticatedHeader {
+    public enum MtaSmtpdSaslAuthenticatedHeader {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdSaslAuthenticatedHeader(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdSaslAuthenticatedHeader(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdSaslAuthenticatedHeader fromString(String s) throws ServiceException {
             for (MtaSmtpdSaslAuthenticatedHeader value : values()) {
@@ -1213,14 +1279,15 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdSaslSecurityOptions {
+    public enum MtaSmtpdSaslSecurityOptions {
         noplaintext("noplaintext"),
         noactive("noactive"),
         nodictionary("nodictionary"),
         noanonymous("noanonymous"),
         mutual_auth("mutual_auth");
-        private String mValue;
-        private MtaSmtpdSaslSecurityOptions(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdSaslSecurityOptions(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdSaslSecurityOptions fromString(String s) throws ServiceException {
             for (MtaSmtpdSaslSecurityOptions value : values()) {
@@ -1235,11 +1302,12 @@ public class ZAttrProvisioning {
         public boolean isMutual_auth() { return this == mutual_auth;}
     }
 
-    public static enum MtaSmtpdTlsAskCcert {
+    public enum MtaSmtpdTlsAskCcert {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdTlsAskCcert(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdTlsAskCcert(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdTlsAskCcert fromString(String s) throws ServiceException {
             for (MtaSmtpdTlsAskCcert value : values()) {
@@ -1251,14 +1319,15 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpdTlsCiphers {
+    public enum MtaSmtpdTlsCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaSmtpdTlsCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdTlsCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdTlsCiphers fromString(String s) throws ServiceException {
             for (MtaSmtpdTlsCiphers value : values()) {
@@ -1273,14 +1342,15 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaSmtpdTlsMandatoryCiphers {
+    public enum MtaSmtpdTlsMandatoryCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaSmtpdTlsMandatoryCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdTlsMandatoryCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdTlsMandatoryCiphers fromString(String s) throws ServiceException {
             for (MtaSmtpdTlsMandatoryCiphers value : values()) {
@@ -1295,11 +1365,12 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaSmtpdTlsReceivedHeader {
+    public enum MtaSmtpdTlsReceivedHeader {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpdTlsReceivedHeader(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpdTlsReceivedHeader(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpdTlsReceivedHeader fromString(String s) throws ServiceException {
             for (MtaSmtpdTlsReceivedHeader value : values()) {
@@ -1311,11 +1382,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpSaslAuthEnable {
+    public enum MtaSmtpSaslAuthEnable {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaSmtpSaslAuthEnable(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpSaslAuthEnable(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpSaslAuthEnable fromString(String s) throws ServiceException {
             for (MtaSmtpSaslAuthEnable value : values()) {
@@ -1327,14 +1399,15 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaSmtpSaslSecurityOptions {
+    public enum MtaSmtpSaslSecurityOptions {
         noplaintext("noplaintext"),
         noactive("noactive"),
         nodictionary("nodictionary"),
         noanonymous("noanonymous"),
         mutual_auth("mutual_auth");
-        private String mValue;
-        private MtaSmtpSaslSecurityOptions(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpSaslSecurityOptions(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpSaslSecurityOptions fromString(String s) throws ServiceException {
             for (MtaSmtpSaslSecurityOptions value : values()) {
@@ -1349,14 +1422,15 @@ public class ZAttrProvisioning {
         public boolean isMutual_auth() { return this == mutual_auth;}
     }
 
-    public static enum MtaSmtpTlsCiphers {
+    public enum MtaSmtpTlsCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaSmtpTlsCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpTlsCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpTlsCiphers fromString(String s) throws ServiceException {
             for (MtaSmtpTlsCiphers value : values()) {
@@ -1371,12 +1445,13 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaSmtpTlsDaneInsecureMXPolicy {
+    public enum MtaSmtpTlsDaneInsecureMXPolicy {
         may("may"),
         encrypt("encrypt"),
         dane("dane");
-        private String mValue;
-        private MtaSmtpTlsDaneInsecureMXPolicy(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpTlsDaneInsecureMXPolicy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpTlsDaneInsecureMXPolicy fromString(String s) throws ServiceException {
             for (MtaSmtpTlsDaneInsecureMXPolicy value : values()) {
@@ -1389,14 +1464,15 @@ public class ZAttrProvisioning {
         public boolean isDane() { return this == dane;}
     }
 
-    public static enum MtaSmtpTlsMandatoryCiphers {
+    public enum MtaSmtpTlsMandatoryCiphers {
         export("export"),
         low("low"),
         medium("medium"),
         high("high"),
         null_("null");
-        private String mValue;
-        private MtaSmtpTlsMandatoryCiphers(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpTlsMandatoryCiphers(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpTlsMandatoryCiphers fromString(String s) throws ServiceException {
             for (MtaSmtpTlsMandatoryCiphers value : values()) {
@@ -1411,7 +1487,7 @@ public class ZAttrProvisioning {
         public boolean isNull_() { return this == null_;}
     }
 
-    public static enum MtaSmtpTlsSecurityLevel {
+    public enum MtaSmtpTlsSecurityLevel {
         none("none"),
         may("may"),
         encrypt("encrypt"),
@@ -1420,8 +1496,9 @@ public class ZAttrProvisioning {
         fingerprint("fingerprint"),
         verify("verify"),
         secure("secure");
-        private String mValue;
-        private MtaSmtpTlsSecurityLevel(String value) { mValue = value; }
+        private final String mValue;
+        MtaSmtpTlsSecurityLevel(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaSmtpTlsSecurityLevel fromString(String s) throws ServiceException {
             for (MtaSmtpTlsSecurityLevel value : values()) {
@@ -1439,11 +1516,12 @@ public class ZAttrProvisioning {
         public boolean isSecure() { return this == secure;}
     }
 
-    public static enum MtaTlsAppendDefaultCA {
+    public enum MtaTlsAppendDefaultCA {
         yes("yes"),
         no("no");
-        private String mValue;
-        private MtaTlsAppendDefaultCA(String value) { mValue = value; }
+        private final String mValue;
+        MtaTlsAppendDefaultCA(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaTlsAppendDefaultCA fromString(String s) throws ServiceException {
             for (MtaTlsAppendDefaultCA value : values()) {
@@ -1455,11 +1533,12 @@ public class ZAttrProvisioning {
         public boolean isNo() { return this == no;}
     }
 
-    public static enum MtaTlsSecurityLevel {
+    public enum MtaTlsSecurityLevel {
         may("may"),
         none("none");
-        private String mValue;
-        private MtaTlsSecurityLevel(String value) { mValue = value; }
+        private final String mValue;
+        MtaTlsSecurityLevel(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static MtaTlsSecurityLevel fromString(String s) throws ServiceException {
             for (MtaTlsSecurityLevel value : values()) {
@@ -1471,15 +1550,16 @@ public class ZAttrProvisioning {
         public boolean isNone() { return this == none;}
     }
 
-    public static enum PasswordLockoutSuppressionProtocols {
+    public enum PasswordLockoutSuppressionProtocols {
         zsync("zsync"),
         imap("imap"),
         pop3("pop3"),
         http_basic("http_basic"),
         http_dav("http_dav"),
         soap("soap");
-        private String mValue;
-        private PasswordLockoutSuppressionProtocols(String value) { mValue = value; }
+        private final String mValue;
+        PasswordLockoutSuppressionProtocols(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PasswordLockoutSuppressionProtocols fromString(String s) throws ServiceException {
             for (PasswordLockoutSuppressionProtocols value : values()) {
@@ -1495,12 +1575,13 @@ public class ZAttrProvisioning {
         public boolean isSoap() { return this == soap;}
     }
 
-    public static enum PrefCalendarAllowedTargetsForInviteDeniedAutoReply {
+    public enum PrefCalendarAllowedTargetsForInviteDeniedAutoReply {
         internal("internal"),
         sameDomain("sameDomain"),
         all("all");
-        private String mValue;
-        private PrefCalendarAllowedTargetsForInviteDeniedAutoReply(String value) { mValue = value; }
+        private final String mValue;
+        PrefCalendarAllowedTargetsForInviteDeniedAutoReply(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefCalendarAllowedTargetsForInviteDeniedAutoReply fromString(String s) throws ServiceException {
             for (PrefCalendarAllowedTargetsForInviteDeniedAutoReply value : values()) {
@@ -1513,11 +1594,12 @@ public class ZAttrProvisioning {
         public boolean isAll() { return this == all;}
     }
 
-    public static enum PrefCalendarApptVisibility {
+    public enum PrefCalendarApptVisibility {
         public_("public"),
         private_("private");
-        private String mValue;
-        private PrefCalendarApptVisibility(String value) { mValue = value; }
+        private final String mValue;
+        PrefCalendarApptVisibility(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefCalendarApptVisibility fromString(String s) throws ServiceException {
             for (PrefCalendarApptVisibility value : values()) {
@@ -1529,15 +1611,16 @@ public class ZAttrProvisioning {
         public boolean isPrivate_() { return this == private_;}
     }
 
-    public static enum PrefCalendarInitialView {
+    public enum PrefCalendarInitialView {
         day("day"),
         week("week"),
         workWeek("workWeek"),
         month("month"),
         list("list"),
         year("year");
-        private String mValue;
-        private PrefCalendarInitialView(String value) { mValue = value; }
+        private final String mValue;
+        PrefCalendarInitialView(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefCalendarInitialView fromString(String s) throws ServiceException {
             for (PrefCalendarInitialView value : values()) {
@@ -1553,12 +1636,13 @@ public class ZAttrProvisioning {
         public boolean isYear() { return this == year;}
     }
 
-    public static enum PrefClientType {
+    public enum PrefClientType {
         standard("standard"),
         advanced("advanced"),
         modern("modern");
-        private String mValue;
-        private PrefClientType(String value) { mValue = value; }
+        private final String mValue;
+        PrefClientType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefClientType fromString(String s) throws ServiceException {
             for (PrefClientType value : values()) {
@@ -1571,11 +1655,12 @@ public class ZAttrProvisioning {
         public boolean isModern() { return this == modern;}
     }
 
-    public static enum PrefComposeDirection {
+    public enum PrefComposeDirection {
         LTR("LTR"),
         RTL("RTL");
-        private String mValue;
-        private PrefComposeDirection(String value) { mValue = value; }
+        private final String mValue;
+        PrefComposeDirection(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefComposeDirection fromString(String s) throws ServiceException {
             for (PrefComposeDirection value : values()) {
@@ -1587,11 +1672,12 @@ public class ZAttrProvisioning {
         public boolean isRTL() { return this == RTL;}
     }
 
-    public static enum PrefComposeFormat {
+    public enum PrefComposeFormat {
         text("text"),
         html("html");
-        private String mValue;
-        private PrefComposeFormat(String value) { mValue = value; }
+        private final String mValue;
+        PrefComposeFormat(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefComposeFormat fromString(String s) throws ServiceException {
             for (PrefComposeFormat value : values()) {
@@ -1603,11 +1689,12 @@ public class ZAttrProvisioning {
         public boolean isHtml() { return this == html;}
     }
 
-    public static enum PrefConversationOrder {
+    public enum PrefConversationOrder {
         dateDesc("dateDesc"),
         dateAsc("dateAsc");
-        private String mValue;
-        private PrefConversationOrder(String value) { mValue = value; }
+        private final String mValue;
+        PrefConversationOrder(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefConversationOrder fromString(String s) throws ServiceException {
             for (PrefConversationOrder value : values()) {
@@ -1619,12 +1706,13 @@ public class ZAttrProvisioning {
         public boolean isDateAsc() { return this == dateAsc;}
     }
 
-    public static enum PrefConvReadingPaneLocation {
+    public enum PrefConvReadingPaneLocation {
         bottom("bottom"),
         right("right"),
         off("off");
-        private String mValue;
-        private PrefConvReadingPaneLocation(String value) { mValue = value; }
+        private final String mValue;
+        PrefConvReadingPaneLocation(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefConvReadingPaneLocation fromString(String s) throws ServiceException {
             for (PrefConvReadingPaneLocation value : values()) {
@@ -1637,12 +1725,13 @@ public class ZAttrProvisioning {
         public boolean isOff() { return this == off;}
     }
 
-    public static enum PrefDedupeMessagesSentToSelf {
+    public enum PrefDedupeMessagesSentToSelf {
         dedupeNone("dedupeNone"),
         secondCopyifOnToOrCC("secondCopyifOnToOrCC"),
         dedupeAll("dedupeAll");
-        private String mValue;
-        private PrefDedupeMessagesSentToSelf(String value) { mValue = value; }
+        private final String mValue;
+        PrefDedupeMessagesSentToSelf(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefDedupeMessagesSentToSelf fromString(String s) throws ServiceException {
             for (PrefDedupeMessagesSentToSelf value : values()) {
@@ -1655,13 +1744,14 @@ public class ZAttrProvisioning {
         public boolean isDedupeAll() { return this == dedupeAll;}
     }
 
-    public static enum PrefDelegatedSendSaveTarget {
+    public enum PrefDelegatedSendSaveTarget {
         owner("owner"),
         sender("sender"),
         both("both"),
         none("none");
-        private String mValue;
-        private PrefDelegatedSendSaveTarget(String value) { mValue = value; }
+        private final String mValue;
+        PrefDelegatedSendSaveTarget(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefDelegatedSendSaveTarget fromString(String s) throws ServiceException {
             for (PrefDelegatedSendSaveTarget value : values()) {
@@ -1675,13 +1765,14 @@ public class ZAttrProvisioning {
         public boolean isNone() { return this == none;}
     }
 
-    public static enum PrefExternalSendersType {
+    public enum PrefExternalSendersType {
         ALL("ALL"),
         ALLNOTINAB("ALLNOTINAB"),
         INAB("INAB"),
         INSD("INSD");
-        private String mValue;
-        private PrefExternalSendersType(String value) { mValue = value; }
+        private final String mValue;
+        PrefExternalSendersType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefExternalSendersType fromString(String s) throws ServiceException {
             for (PrefExternalSendersType value : values()) {
@@ -1695,15 +1786,16 @@ public class ZAttrProvisioning {
         public boolean isINSD() { return this == INSD;}
     }
 
-    public static enum PrefForwardIncludeOriginalText {
+    public enum PrefForwardIncludeOriginalText {
         includeAsAttachment("includeAsAttachment"),
         includeBody("includeBody"),
         includeBodyWithPrefix("includeBodyWithPrefix"),
         includeBodyAndHeadersWithPrefix("includeBodyAndHeadersWithPrefix"),
         includeBodyAndHeaders("includeBodyAndHeaders"),
         includeBodyOnly("includeBodyOnly");
-        private String mValue;
-        private PrefForwardIncludeOriginalText(String value) { mValue = value; }
+        private final String mValue;
+        PrefForwardIncludeOriginalText(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefForwardIncludeOriginalText fromString(String s) throws ServiceException {
             for (PrefForwardIncludeOriginalText value : values()) {
@@ -1719,12 +1811,13 @@ public class ZAttrProvisioning {
         public boolean isIncludeBodyOnly() { return this == includeBodyOnly;}
     }
 
-    public static enum PrefForwardReplyFormat {
+    public enum PrefForwardReplyFormat {
         text("text"),
         html("html"),
         same("same");
-        private String mValue;
-        private PrefForwardReplyFormat(String value) { mValue = value; }
+        private final String mValue;
+        PrefForwardReplyFormat(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefForwardReplyFormat fromString(String s) throws ServiceException {
             for (PrefForwardReplyFormat value : values()) {
@@ -1737,11 +1830,12 @@ public class ZAttrProvisioning {
         public boolean isSame() { return this == same;}
     }
 
-    public static enum PrefFromAddressType {
+    public enum PrefFromAddressType {
         sendAs("sendAs"),
         sendOnBehalfOf("sendOnBehalfOf");
-        private String mValue;
-        private PrefFromAddressType(String value) { mValue = value; }
+        private final String mValue;
+        PrefFromAddressType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefFromAddressType fromString(String s) throws ServiceException {
             for (PrefFromAddressType value : values()) {
@@ -1753,11 +1847,12 @@ public class ZAttrProvisioning {
         public boolean isSendOnBehalfOf() { return this == sendOnBehalfOf;}
     }
 
-    public static enum PrefGetMailAction {
+    public enum PrefGetMailAction {
         default_("default"),
         update("update");
-        private String mValue;
-        private PrefGetMailAction(String value) { mValue = value; }
+        private final String mValue;
+        PrefGetMailAction(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefGetMailAction fromString(String s) throws ServiceException {
             for (PrefGetMailAction value : values()) {
@@ -1769,11 +1864,12 @@ public class ZAttrProvisioning {
         public boolean isUpdate() { return this == update;}
     }
 
-    public static enum PrefGroupMailBy {
+    public enum PrefGroupMailBy {
         conversation("conversation"),
         message("message");
-        private String mValue;
-        private PrefGroupMailBy(String value) { mValue = value; }
+        private final String mValue;
+        PrefGroupMailBy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefGroupMailBy fromString(String s) throws ServiceException {
             for (PrefGroupMailBy value : values()) {
@@ -1785,12 +1881,13 @@ public class ZAttrProvisioning {
         public boolean isMessage() { return this == message;}
     }
 
-    public static enum PrefMailSelectAfterDelete {
+    public enum PrefMailSelectAfterDelete {
         next("next"),
         previous("previous"),
         adaptive("adaptive");
-        private String mValue;
-        private PrefMailSelectAfterDelete(String value) { mValue = value; }
+        private final String mValue;
+        PrefMailSelectAfterDelete(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefMailSelectAfterDelete fromString(String s) throws ServiceException {
             for (PrefMailSelectAfterDelete value : values()) {
@@ -1803,12 +1900,13 @@ public class ZAttrProvisioning {
         public boolean isAdaptive() { return this == adaptive;}
     }
 
-    public static enum PrefMailSendReadReceipts {
+    public enum PrefMailSendReadReceipts {
         always("always"),
         never("never"),
         prompt("prompt");
-        private String mValue;
-        private PrefMailSendReadReceipts(String value) { mValue = value; }
+        private final String mValue;
+        PrefMailSendReadReceipts(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefMailSendReadReceipts fromString(String s) throws ServiceException {
             for (PrefMailSendReadReceipts value : values()) {
@@ -1821,11 +1919,12 @@ public class ZAttrProvisioning {
         public boolean isPrompt() { return this == prompt;}
     }
 
-    public static enum PrefMailSignatureStyle {
+    public enum PrefMailSignatureStyle {
         outlook("outlook"),
         internet("internet");
-        private String mValue;
-        private PrefMailSignatureStyle(String value) { mValue = value; }
+        private final String mValue;
+        PrefMailSignatureStyle(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefMailSignatureStyle fromString(String s) throws ServiceException {
             for (PrefMailSignatureStyle value : values()) {
@@ -1837,11 +1936,12 @@ public class ZAttrProvisioning {
         public boolean isInternet() { return this == internet;}
     }
 
-    public static enum PrefOutOfOfficeFreeBusyStatus {
+    public enum PrefOutOfOfficeFreeBusyStatus {
         BUSY("BUSY"),
         OUTOFOFFICE("OUTOFOFFICE");
-        private String mValue;
-        private PrefOutOfOfficeFreeBusyStatus(String value) { mValue = value; }
+        private final String mValue;
+        PrefOutOfOfficeFreeBusyStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefOutOfOfficeFreeBusyStatus fromString(String s) throws ServiceException {
             for (PrefOutOfOfficeFreeBusyStatus value : values()) {
@@ -1853,11 +1953,12 @@ public class ZAttrProvisioning {
         public boolean isOUTOFOFFICE() { return this == OUTOFOFFICE;}
     }
 
-    public static enum PrefPasswordRecoveryAddressStatus {
+    public enum PrefPasswordRecoveryAddressStatus {
         verified("verified"),
         pending("pending");
-        private String mValue;
-        private PrefPasswordRecoveryAddressStatus(String value) { mValue = value; }
+        private final String mValue;
+        PrefPasswordRecoveryAddressStatus(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefPasswordRecoveryAddressStatus fromString(String s) throws ServiceException {
             for (PrefPasswordRecoveryAddressStatus value : values()) {
@@ -1869,13 +1970,14 @@ public class ZAttrProvisioning {
         public boolean isPending() { return this == pending;}
     }
 
-    public static enum PrefPop3DeleteOption {
+    public enum PrefPop3DeleteOption {
         keep("keep"),
         read("read"),
         trash("trash"),
         delete("delete");
-        private String mValue;
-        private PrefPop3DeleteOption(String value) { mValue = value; }
+        private final String mValue;
+        PrefPop3DeleteOption(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefPop3DeleteOption fromString(String s) throws ServiceException {
             for (PrefPop3DeleteOption value : values()) {
@@ -1889,12 +1991,13 @@ public class ZAttrProvisioning {
         public boolean isDelete() { return this == delete;}
     }
 
-    public static enum PrefReadingPaneLocation {
+    public enum PrefReadingPaneLocation {
         bottom("bottom"),
         right("right"),
         off("off");
-        private String mValue;
-        private PrefReadingPaneLocation(String value) { mValue = value; }
+        private final String mValue;
+        PrefReadingPaneLocation(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefReadingPaneLocation fromString(String s) throws ServiceException {
             for (PrefReadingPaneLocation value : values()) {
@@ -1907,7 +2010,7 @@ public class ZAttrProvisioning {
         public boolean isOff() { return this == off;}
     }
 
-    public static enum PrefReplyIncludeOriginalText {
+    public enum PrefReplyIncludeOriginalText {
         includeAsAttachment("includeAsAttachment"),
         includeBody("includeBody"),
         includeBodyWithPrefix("includeBodyWithPrefix"),
@@ -1919,8 +2022,9 @@ public class ZAttrProvisioning {
         includeSmartAndHeaders("includeSmartAndHeaders"),
         includeSmartAndHeadersWithPrefix("includeSmartAndHeadersWithPrefix"),
         includeBodyOnly("includeBodyOnly");
-        private String mValue;
-        private PrefReplyIncludeOriginalText(String value) { mValue = value; }
+        private final String mValue;
+        PrefReplyIncludeOriginalText(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefReplyIncludeOriginalText fromString(String s) throws ServiceException {
             for (PrefReplyIncludeOriginalText value : values()) {
@@ -1941,15 +2045,16 @@ public class ZAttrProvisioning {
         public boolean isIncludeBodyOnly() { return this == includeBodyOnly;}
     }
 
-    public static enum PrefTasksFilterBy {
+    public enum PrefTasksFilterBy {
         NOTSTARTED("NOTSTARTED"),
         COMPLETED("COMPLETED"),
         INPROGRESS("INPROGRESS"),
         WAITING("WAITING"),
         DEFERRED("DEFERRED"),
         TODO("TODO");
-        private String mValue;
-        private PrefTasksFilterBy(String value) { mValue = value; }
+        private final String mValue;
+        PrefTasksFilterBy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefTasksFilterBy fromString(String s) throws ServiceException {
             for (PrefTasksFilterBy value : values()) {
@@ -1965,12 +2070,13 @@ public class ZAttrProvisioning {
         public boolean isTODO() { return this == TODO;}
     }
 
-    public static enum PrefTasksReadingPaneLocation {
+    public enum PrefTasksReadingPaneLocation {
         bottom("bottom"),
         right("right"),
         off("off");
-        private String mValue;
-        private PrefTasksReadingPaneLocation(String value) { mValue = value; }
+        private final String mValue;
+        PrefTasksReadingPaneLocation(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static PrefTasksReadingPaneLocation fromString(String s) throws ServiceException {
             for (PrefTasksReadingPaneLocation value : values()) {
@@ -1983,10 +2089,11 @@ public class ZAttrProvisioning {
         public boolean isOff() { return this == off;}
     }
 
-    public static enum Product {
+    public enum Product {
         ZCS("ZCS");
-        private String mValue;
-        private Product(String value) { mValue = value; }
+        private final String mValue;
+        Product(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static Product fromString(String s) throws ServiceException {
             for (Product value : values()) {
@@ -1997,11 +2104,12 @@ public class ZAttrProvisioning {
         public boolean isZCS() { return this == ZCS;}
     }
 
-    public static enum ReverseProxyAcceptMutex {
+    public enum ReverseProxyAcceptMutex {
         on("on"),
         off("off");
-        private String mValue;
-        private ReverseProxyAcceptMutex(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyAcceptMutex(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyAcceptMutex fromString(String s) throws ServiceException {
             for (ReverseProxyAcceptMutex value : values()) {
@@ -2013,12 +2121,13 @@ public class ZAttrProvisioning {
         public boolean isOff() { return this == off;}
     }
 
-    public static enum ReverseProxyClientCertMode {
+    public enum ReverseProxyClientCertMode {
         on("on"),
         off("off"),
         optional("optional");
-        private String mValue;
-        private ReverseProxyClientCertMode(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyClientCertMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyClientCertMode fromString(String s) throws ServiceException {
             for (ReverseProxyClientCertMode value : values()) {
@@ -2031,11 +2140,12 @@ public class ZAttrProvisioning {
         public boolean isOptional() { return this == optional;}
     }
 
-    public static enum ReverseProxyExactServerVersionCheck {
+    public enum ReverseProxyExactServerVersionCheck {
         on("on"),
         off("off");
-        private String mValue;
-        private ReverseProxyExactServerVersionCheck(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyExactServerVersionCheck(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyExactServerVersionCheck fromString(String s) throws ServiceException {
             for (ReverseProxyExactServerVersionCheck value : values()) {
@@ -2047,12 +2157,13 @@ public class ZAttrProvisioning {
         public boolean isOff() { return this == off;}
     }
 
-    public static enum ReverseProxyImapStartTlsMode {
+    public enum ReverseProxyImapStartTlsMode {
         on("on"),
         off("off"),
         only("only");
-        private String mValue;
-        private ReverseProxyImapStartTlsMode(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyImapStartTlsMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyImapStartTlsMode fromString(String s) throws ServiceException {
             for (ReverseProxyImapStartTlsMode value : values()) {
@@ -2065,7 +2176,7 @@ public class ZAttrProvisioning {
         public boolean isOnly() { return this == only;}
     }
 
-    public static enum ReverseProxyLogLevel {
+    public enum ReverseProxyLogLevel {
         debug("debug"),
         info("info"),
         notice("notice"),
@@ -2076,8 +2187,9 @@ public class ZAttrProvisioning {
         debug_mail("debug_mail"),
         debug_core("debug_core"),
         debug_zimbra("debug_zimbra");
-        private String mValue;
-        private ReverseProxyLogLevel(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyLogLevel(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyLogLevel fromString(String s) throws ServiceException {
             for (ReverseProxyLogLevel value : values()) {
@@ -2097,11 +2209,12 @@ public class ZAttrProvisioning {
         public boolean isDebug_zimbra() { return this == debug_zimbra;}
     }
 
-    public static enum ReverseProxyMailMode {
+    public enum ReverseProxyMailMode {
         https("https"),
         redirect("redirect");
-        private String mValue;
-        private ReverseProxyMailMode(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyMailMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyMailMode fromString(String s) throws ServiceException {
             for (ReverseProxyMailMode value : values()) {
@@ -2113,12 +2226,13 @@ public class ZAttrProvisioning {
         public boolean isRedirect() { return this == redirect;}
     }
 
-    public static enum ReverseProxyPop3StartTlsMode {
+    public enum ReverseProxyPop3StartTlsMode {
         on("on"),
         off("off"),
         only("only");
-        private String mValue;
-        private ReverseProxyPop3StartTlsMode(String value) { mValue = value; }
+        private final String mValue;
+        ReverseProxyPop3StartTlsMode(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ReverseProxyPop3StartTlsMode fromString(String s) throws ServiceException {
             for (ReverseProxyPop3StartTlsMode value : values()) {
@@ -2131,12 +2245,13 @@ public class ZAttrProvisioning {
         public boolean isOnly() { return this == only;}
     }
 
-    public static enum ScheduledTaskRetryPolicy {
+    public enum ScheduledTaskRetryPolicy {
         constant("constant"),
         linear("linear"),
         exponential("exponential");
-        private String mValue;
-        private ScheduledTaskRetryPolicy(String value) { mValue = value; }
+        private final String mValue;
+        ScheduledTaskRetryPolicy(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ScheduledTaskRetryPolicy fromString(String s) throws ServiceException {
             for (ScheduledTaskRetryPolicy value : values()) {
@@ -2149,12 +2264,13 @@ public class ZAttrProvisioning {
         public boolean isExponential() { return this == exponential;}
     }
 
-    public static enum ShareNotificationMtaConnectionType {
+    public enum ShareNotificationMtaConnectionType {
         CLEARTEXT("CLEARTEXT"),
         SSL("SSL"),
         STARTTLS("STARTTLS");
-        private String mValue;
-        private ShareNotificationMtaConnectionType(String value) { mValue = value; }
+        private final String mValue;
+        ShareNotificationMtaConnectionType(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static ShareNotificationMtaConnectionType fromString(String s) throws ServiceException {
             for (ShareNotificationMtaConnectionType value : values()) {
@@ -2167,12 +2283,13 @@ public class ZAttrProvisioning {
         public boolean isSTARTTLS() { return this == STARTTLS;}
     }
 
-    public static enum TwoFactorAuthHashAlgorithm {
+    public enum TwoFactorAuthHashAlgorithm {
         SHA1("SHA1"),
         SHA256("SHA256"),
         SHA512("SHA512");
-        private String mValue;
-        private TwoFactorAuthHashAlgorithm(String value) { mValue = value; }
+        private final String mValue;
+        TwoFactorAuthHashAlgorithm(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static TwoFactorAuthHashAlgorithm fromString(String s) throws ServiceException {
             for (TwoFactorAuthHashAlgorithm value : values()) {
@@ -2185,11 +2302,12 @@ public class ZAttrProvisioning {
         public boolean isSHA512() { return this == SHA512;}
     }
 
-    public static enum TwoFactorAuthScratchCodeEncoding {
+    public enum TwoFactorAuthScratchCodeEncoding {
         BASE32("BASE32"),
         BASE64("BASE64");
-        private String mValue;
-        private TwoFactorAuthScratchCodeEncoding(String value) { mValue = value; }
+        private final String mValue;
+        TwoFactorAuthScratchCodeEncoding(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static TwoFactorAuthScratchCodeEncoding fromString(String s) throws ServiceException {
             for (TwoFactorAuthScratchCodeEncoding value : values()) {
@@ -2201,11 +2319,12 @@ public class ZAttrProvisioning {
         public boolean isBASE64() { return this == BASE64;}
     }
 
-    public static enum TwoFactorAuthSecretEncoding {
+    public enum TwoFactorAuthSecretEncoding {
         BASE32("BASE32"),
         BASE64("BASE64");
-        private String mValue;
-        private TwoFactorAuthSecretEncoding(String value) { mValue = value; }
+        private final String mValue;
+        TwoFactorAuthSecretEncoding(String value) { mValue = value; }
+        @Override
         public String toString() { return mValue; }
         public static TwoFactorAuthSecretEncoding fromString(String s) throws ServiceException {
             for (TwoFactorAuthSecretEncoding value : values()) {
@@ -2219,243 +2338,243 @@ public class ZAttrProvisioning {
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisAddrExtensionBadHeader = "amavisAddrExtensionBadHeader";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisAddrExtensionBanned = "amavisAddrExtensionBanned";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisAddrExtensionSpam = "amavisAddrExtensionSpam";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisAddrExtensionVirus = "amavisAddrExtensionVirus";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisArchiveQuarantineTo = "amavisArchiveQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBadHeaderAdmin = "amavisBadHeaderAdmin";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBadHeaderLover = "amavisBadHeaderLover";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBadHeaderQuarantineTo = "amavisBadHeaderQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBannedAdmin = "amavisBannedAdmin";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBannedFilesLover = "amavisBannedFilesLover";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBannedQuarantineTo = "amavisBannedQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBannedRuleNames = "amavisBannedRuleNames";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBlacklistSender = "amavisBlacklistSender";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBypassBannedChecks = "amavisBypassBannedChecks";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBypassHeaderChecks = "amavisBypassHeaderChecks";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBypassSpamChecks = "amavisBypassSpamChecks";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisBypassVirusChecks = "amavisBypassVirusChecks";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisCleanQuarantineTo = "amavisCleanQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisDisclaimerOptions = "amavisDisclaimerOptions";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisForwardMethod = "amavisForwardMethod";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisLocal = "amavisLocal";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisMessageSizeLimit = "amavisMessageSizeLimit";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisNewVirusAdmin = "amavisNewVirusAdmin";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSaUserConf = "amavisSaUserConf";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSaUserName = "amavisSaUserName";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamAdmin = "amavisSpamAdmin";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamDsnCutoffLevel = "amavisSpamDsnCutoffLevel";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamKillLevel = "amavisSpamKillLevel";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamLover = "amavisSpamLover";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamModifiesSubj = "amavisSpamModifiesSubj";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamQuarantineCutoffLevel = "amavisSpamQuarantineCutoffLevel";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamQuarantineTo = "amavisSpamQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamSubjectTag = "amavisSpamSubjectTag";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamSubjectTag2 = "amavisSpamSubjectTag2";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamSubjectTag3 = "amavisSpamSubjectTag3";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamTag2Level = "amavisSpamTag2Level";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamTag3Level = "amavisSpamTag3Level";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisSpamTagLevel = "amavisSpamTagLevel";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisUncheckedLover = "amavisUncheckedLover";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisUncheckedQuarantineTo = "amavisUncheckedQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisVirusAdmin = "amavisVirusAdmin";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisVirusLover = "amavisVirusLover";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisVirusQuarantineTo = "amavisVirusQuarantineTo";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisWarnBadHeaderRecip = "amavisWarnBadHeaderRecip";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisWarnBannedRecip = "amavisWarnBannedRecip";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisWarnVirusRecip = "amavisWarnVirusRecip";
 
     /**
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_amavisWhitelistSender = "amavisWhitelistSender";
 
     /**
      * RFC2256: ISO-3166 country 2-letter code
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_c = "c";
 
     /**
@@ -2799,199 +2918,199 @@ public class ZAttrProvisioning {
     /**
      * RFC2256: common name(s) for which the entity is known by
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_cn = "cn";
 
     /**
      * RFC1274: friendly country name
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_co = "co";
 
     /**
      * From Microsoft Schema
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_company = "company";
 
     /**
      * RFC2256: descriptive information
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_description = "description";
 
     /**
      * RFC2256: destination indicator
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_destinationIndicator = "destinationIndicator";
 
     /**
      * RFC2798: preferred name to be used when displaying entries
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_displayName = "displayName";
 
     /**
      * RFC2256: Facsimile (Fax) Telephone Number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_facsimileTelephoneNumber = "facsimileTelephoneNumber";
 
     /**
      * RFC2256: first name(s) for which the entity is known by
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_givenName = "givenName";
 
     /**
      * RFC2256: first name(s) for which the entity is known by
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_gn = "gn";
 
     /**
      * RFC1274: home telephone number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_homePhone = "homePhone";
 
     /**
      * RFC2256: initials of some or all of names, but not the surname(s).
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_initials = "initials";
 
     /**
      * RFC2256: international ISDN number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_internationaliSDNNumber = "internationaliSDNNumber";
 
     /**
      * RFC2256: locality which this object resides in
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_l = "l";
 
     /**
      * RFC1274: RFC822 Mailbox
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_mail = "mail";
 
     /**
      * Identifies an URL associated with each member of a group
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_memberURL = "memberURL";
 
     /**
      * RFC1274: mobile telephone number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_mobile = "mobile";
 
     /**
      * RFC2256: organization this object belongs to
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_o = "o";
 
     /**
      * RFC2256: object classes of the entity
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_objectClass = "objectClass";
 
     /**
      * RFC2256: organizational unit this object belongs to
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_ou = "ou";
 
     /**
      * RFC1274: pager telephone number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_pager = "pager";
 
     /**
      * &#039;RFC2256: Physical Delivery Office Name
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_physicalDeliveryOfficeName = "physicalDeliveryOfficeName";
 
     /**
      * RFC2256: postal address
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_postalAddress = "postalAddress";
 
     /**
      * RFC2256: postal code
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_postalCode = "postalCode";
 
     /**
      * RFC2256: Post Office Box
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_postOfficeBox = "postOfficeBox";
 
     /**
      * RFC2256: preferred delivery method
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_preferredDeliveryMethod = "preferredDeliveryMethod";
 
     /**
      * RFC2256: registered postal address
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_registeredAddress = "registeredAddress";
 
     /**
      * RFC2256: last (family) name(s) for which the entity is known by
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_sn = "sn";
 
     /**
      * RFC2256: state or province which this object resides in
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_st = "st";
 
     /**
      * RFC2256: street address of this object
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_street = "street";
 
     /**
      * RFC2256: street address of this object
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_streetAddress = "streetAddress";
 
     /**
      * RFC2256: Telephone Number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_telephoneNumber = "telephoneNumber";
 
     /**
      * RFC2256: Teletex Terminal Identifier
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_teletexTerminalIdentifier = "teletexTerminalIdentifier";
 
     /**
      * RFC2256: Telex Number
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_telexNumber = "telexNumber";
 
     /**
@@ -3005,37 +3124,37 @@ public class ZAttrProvisioning {
     /**
      * RFC2256: title associated with the entity
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_title = "title";
 
     /**
      * RFC1274: user identifier
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_uid = "uid";
 
     /**
      * RFC2256: X.509 user certificate
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_userCertificate = "userCertificate";
 
     /**
      * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_userPassword = "userPassword";
 
     /**
      * RFC2798: PKCS#7 SignedData used to support S/MIME
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_userSMIMECertificate = "userSMIMECertificate";
 
     /**
      * RFC2256: X.121 Address
      */
-    @ZAttr(id=-1)
+    @ZAttr()
     public static final String A_x121Address = "x121Address";
 
     /**

--- a/store/src/main/java/com/zimbra/cs/account/AttributeManagerUtil.java
+++ b/store/src/main/java/com/zimbra/cs/account/AttributeManagerUtil.java
@@ -115,7 +115,7 @@ public class AttributeManagerUtil {
     String enumName = enumName(ai);
 
     result.append(String.format("%n"));
-    result.append(String.format("    public static enum %s {%n", enumName));
+    result.append(String.format("    public enum %s {%n", enumName));
     Set<Map.Entry<String, String>> set = values.entrySet();
     int i = 1;
     for (Map.Entry<String, String> entry : set) {
@@ -126,9 +126,9 @@ public class AttributeManagerUtil {
       i++;
     }
 
-    result.append(String.format("        private String mValue;%n"));
-    result.append(
-        String.format("        private %s(String value) { mValue = value; }%n", enumName));
+    result.append(String.format("        private final String mValue;%n"));
+    result.append(String.format("        %s(String value) { mValue = value; }%n", enumName));
+    result.append(String.format("        @Override%n"));
     result.append(String.format("        public String toString() { return mValue; }%n"));
     result.append(
         String.format(
@@ -781,12 +781,6 @@ public class AttributeManagerUtil {
   }
 
   private static CommandLine parseArgs(String[] args) {
-    //    StringBuilder gotCL = new StringBuilder("cmdline: ");
-    //    for (String arg : args) {
-    //      gotCL.append("'").append(arg).append("' ");
-    //    }
-    // mLog.info(gotCL);
-
     CommandLineParser parser = new GnuParser();
     CommandLine commandLine = null;
     try {
@@ -1710,27 +1704,36 @@ public class AttributeManagerUtil {
     }
 
     for (String a : list) {
-      AttributeInfo ai = getAttrs().get(a.toLowerCase());
-      if (ai == null) {
+      AttributeInfo attributeInfo = getAttrs().get(a.toLowerCase());
+      if (attributeInfo == null) {
         continue;
       }
 
       result.append("\n    /**\n");
-      if (ai.getDescription() != null) {
+      if (attributeInfo.getDescription() != null) {
         result.append(
-            FileGenUtil.wrapComments(StringUtil.escapeHtml(ai.getDescription()), 70, "     * "));
+            FileGenUtil.wrapComments(
+                StringUtil.escapeHtml(attributeInfo.getDescription()), 70, "     * "));
         result.append("\n");
       }
-      if (ai.getSince() != null) {
+      if (attributeInfo.getSince() != null) {
         result.append("     *\n");
-        result.append(String.format("     * @since ZCS %s%n", versionListAsString(ai.getSince())));
+        result.append(
+            String.format("     * @since ZCS %s%n", versionListAsString(attributeInfo.getSince())));
       }
       result.append("     */\n");
-      result.append(String.format("    @ZAttr(id=%d)%n", ai.getId()));
+
+      // avoid setting id if its default one. i,e -1
+      if (attributeInfo.getId() == -1) {
+        result.append(String.format("    @ZAttr()%n"));
+      } else {
+        result.append(String.format("    @ZAttr(id=%d)%n", attributeInfo.getId()));
+      }
 
       result.append(
           String.format(
-              "    public static final String A_%s = \"%s\";%n", ai.getName(), ai.getName()));
+              "    public static final String A_%s = \"%s\";%n",
+              attributeInfo.getName(), attributeInfo.getName()));
     }
 
     FileGenUtil.replaceJavaFile(javaFile, result.toString());


### PR DESCRIPTION
**Note:** This is part 2 of contineous optimization of AttributeManagerUtil, changes in part 1 were merged by this PR  [here](https://github.com/Zextras/carbonio-mailbox/pull/230) 

**What has changed:**

- remove static from enums as they are static by default
- mark methods override where required
- remove bogus access modifiers from enum constructors
- avoid redundant default parameter assignment for some fields
- minor code cleanup

**Tests:**
- smoke test on dev env
- generated ldiff files with new code has no diffs with old one