### PR TITLE
fix(CO-728): use commons-io 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>io.vavr</groupId>


### PR DESCRIPTION
FilesClient is built on top commons-io 2.11.0. Mailbox ships 1.4, resulting in a runtime error (method not found).

- [ ] This requires alignment of zcs-lib. I made all dependencies aligned to mailbox: https://github.com/Zextras/carbonio-zcs-lib/pull/19

Tested on a VM along with packages of zcs-lib.