### PR TITLE
fix: [CO-740] check retention policy before setting

### DIFF
--- a/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9351,7 +9351,7 @@ public class Mailbox implements MailboxStore {
       if (keepPolicy.isEmpty() && purgePolicy.isEmpty()) {
         throw ServiceException.INVALID_REQUEST("No keep or purge policy specified.", null);
       }
-      if (!keepPolicy.isEmpty() && !purgePolicy.isEmpty() ) {
+      if (!keepPolicy.isEmpty() && !purgePolicy.isEmpty()) {
         throw ServiceException.INVALID_REQUEST("Cannot specify both keep and purge policy.", null);
       }
 

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailboxTest.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailboxTest.java
@@ -737,23 +737,24 @@ public final class MailboxTest {
 
   @Test
   public void setRetentionPolicy_shouldFail_whenBothPoliciesAreProvided() throws ServiceException {
-    Mailbox mbox = MailboxManager.getInstance()
-        .getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
-    Folder folder = mbox.createFolder(null, "/bothPolicies",
-        new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
+    Folder folder =
+        mbox.createFolder(
+            null,
+            "/bothPolicies",
+            new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
 
-    List<Policy> keep = List.of(
-        Policy.newUserPolicy("1m"));
+    List<Policy> keep = List.of(Policy.newUserPolicy("1m"));
 
-    List<Policy> purge = List.of(
-        Policy.newUserPolicy("1m"));
+    List<Policy> purge = List.of(Policy.newUserPolicy("1m"));
 
     RetentionPolicy retentionPolicy = new RetentionPolicy(keep, purge);
 
     try {
       mbox.setRetentionPolicy(null, folder.getId(), MailItem.Type.FOLDER, retentionPolicy);
-    }catch (Exception e) {
+    } catch (Exception e) {
       String expectedErrorMessage = "invalid request: Cannot specify both keep and purge policy.";
       Assert.assertEquals(expectedErrorMessage, e.getMessage());
     }
@@ -761,17 +762,20 @@ public final class MailboxTest {
 
   @Test
   public void setRetentionPolicy_shouldFail_whenNoPoliciesAreProvided() throws ServiceException {
-    Mailbox mbox = MailboxManager.getInstance()
-        .getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
-    Folder folder = mbox.createFolder(null, "/nullPolicies",
-        new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
+    Folder folder =
+        mbox.createFolder(
+            null,
+            "/nullPolicies",
+            new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
 
     RetentionPolicy retentionPolicy = new RetentionPolicy(null, null);
 
     try {
       mbox.setRetentionPolicy(null, folder.getId(), MailItem.Type.FOLDER, retentionPolicy);
-    }catch (Exception e) {
+    } catch (Exception e) {
       String expectedErrorMessage = "invalid request: No keep or purge policy specified.";
       Assert.assertEquals(expectedErrorMessage, e.getMessage());
     }

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailboxTest.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailboxTest.java
@@ -747,7 +747,6 @@ public final class MailboxTest {
             new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
 
     List<Policy> keep = List.of(Policy.newUserPolicy("1m"));
-
     List<Policy> purge = List.of(Policy.newUserPolicy("1m"));
 
     RetentionPolicy retentionPolicy = new RetentionPolicy(keep, purge);
@@ -778,6 +777,41 @@ public final class MailboxTest {
     } catch (Exception e) {
       String expectedErrorMessage = "invalid request: No keep or purge policy specified.";
       Assert.assertEquals(expectedErrorMessage, e.getMessage());
+    }
+  }
+
+  @Test
+  public void validateIndividualRetentionPolicy_shouldFail_whenMultipleUserPoliciesArePassed()
+      throws ServiceException {
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+    List<Policy> policies = new ArrayList<>();
+    policies.add(Policy.newUserPolicy("1m"));
+    policies.add(Policy.newUserPolicy("1m"));
+
+    try {
+      mbox.validateIndividualRetentionPolicy(policies);
+    } catch (ServiceException e) {
+      String expectedErrorMessage =
+          "invalid request: Cannot set more than one user retention policy per folder.";
+      Assert.assertEquals(expectedErrorMessage, e.getMessage());
+    }
+  }
+
+  @Test
+  public void validateIndividualRetentionPolicy_shouldNotFail_whenSingleUserPoliciesArePassed()
+      throws ServiceException {
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+
+    List<Policy> policies = new ArrayList<>();
+    policies.add(Policy.newUserPolicy("1m"));
+
+    try {
+      mbox.validateIndividualRetentionPolicy(policies);
+    } catch (ServiceException e) {
+      Assert.fail("Should not fail due to service exception " + e.getMessage());
     }
   }
 

--- a/store/src/test/java/com/zimbra/cs/redolog/op/SetRetentionPolicyTest.java
+++ b/store/src/test/java/com/zimbra/cs/redolog/op/SetRetentionPolicyTest.java
@@ -7,13 +7,6 @@ package com.zimbra.cs.redolog.op;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.HashMap;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Folder;
@@ -24,81 +17,81 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Tag;
 import com.zimbra.soap.mail.type.Policy;
 import com.zimbra.soap.mail.type.RetentionPolicy;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class SetRetentionPolicyTest {
 
-    @BeforeClass
-    public static void init() throws Exception {
-        MailboxTestUtil.initServer();
-        Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-    }
+  @BeforeClass
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    Provisioning prov = Provisioning.getInstance();
+    prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+  }
 
-    @Before
-    public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
-    }
+  @Before
+  public void setUp() throws Exception {
+    MailboxTestUtil.clearData();
+  }
 
-    /**
-     * Verifies serializing, deserializing, and replaying for folder.
-     */
-    @Test
-    public void redoFolder() throws Exception {
-        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  /** Verifies serializing, deserializing, and replaying for folder. */
+  @Test
+  public void redoFolder() throws Exception {
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
-        // Create folder.
-        Folder folder = mbox.createFolder(null, "/redo", new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
-        assertEquals(0, folder.getRetentionPolicy().getKeepPolicy().size());
-        assertEquals(0, folder.getRetentionPolicy().getPurgePolicy().size());
+    // Create folder.
+    Folder folder =
+        mbox.createFolder(
+            null, "/redo", new Folder.FolderOptions().setDefaultView(MailItem.Type.MESSAGE));
+    assertEquals(0, folder.getRetentionPolicy().getKeepPolicy().size());
+    assertEquals(0, folder.getRetentionPolicy().getPurgePolicy().size());
 
-        // Create RedoableOp.
-        RetentionPolicy rp = new RetentionPolicy(
-            Arrays.asList(Policy.newSystemPolicy("123")),
-            Arrays.asList(Policy.newUserPolicy("45m")));
-        SetRetentionPolicy redoPlayer = new SetRetentionPolicy(mbox.getId(), MailItem.Type.FOLDER, folder.getId(), rp);
+    // Create RedoableOp.
+    RetentionPolicy rp = new RetentionPolicy(null, Arrays.asList(Policy.newUserPolicy("45m")));
+    SetRetentionPolicy redoPlayer =
+        new SetRetentionPolicy(mbox.getId(), MailItem.Type.FOLDER, folder.getId(), rp);
 
-        // Serialize, deserialize, and redo.
-        byte[] data = redoPlayer.testSerialize();
-        redoPlayer = new SetRetentionPolicy();
-        redoPlayer.setMailboxId(mbox.getId());
-        redoPlayer.testDeserialize(data);
-        redoPlayer.redo();
-        folder = mbox.getFolderById(null, folder.getId());
-        assertEquals(1, folder.getRetentionPolicy().getKeepPolicy().size());
-        assertEquals(1, folder.getRetentionPolicy().getPurgePolicy().size());
-        assertEquals("45m", folder.getRetentionPolicy().getPurgePolicy().get(0).getLifetime());
-        assertEquals("123", folder.getRetentionPolicy().getKeepPolicy().get(0).getId());
-    }
+    // Serialize, deserialize, and redo.
+    byte[] data = redoPlayer.testSerialize();
+    redoPlayer = new SetRetentionPolicy();
+    redoPlayer.setMailboxId(mbox.getId());
+    redoPlayer.testDeserialize(data);
+    redoPlayer.redo();
+    folder = mbox.getFolderById(null, folder.getId());
+    assertEquals(1, folder.getRetentionPolicy().getPurgePolicy().size());
+    assertEquals("45m", folder.getRetentionPolicy().getPurgePolicy().get(0).getLifetime());
+  }
 
-    /**
-     * Verifies serializing, deserializing, and replaying for tag.
-     */
-    @Test
-    public void redoTag() throws Exception {
-        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  /** Verifies serializing, deserializing, and replaying for tag. */
+  @Test
+  public void redoTag() throws Exception {
+    Mailbox mbox =
+        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
-        // Create folder.
-        Tag tag = mbox.createTag(null, "tag", (byte) 0);
-        assertEquals(0, tag.getRetentionPolicy().getKeepPolicy().size());
-        assertEquals(0, tag.getRetentionPolicy().getPurgePolicy().size());
+    // Create folder.
+    Tag tag = mbox.createTag(null, "tag", (byte) 0);
+    assertEquals(0, tag.getRetentionPolicy().getKeepPolicy().size());
+    assertEquals(0, tag.getRetentionPolicy().getPurgePolicy().size());
 
-        // Create RedoableOp.
-        RetentionPolicy rp = new RetentionPolicy(
-            Arrays.asList(Policy.newSystemPolicy("123")),
-            Arrays.asList(Policy.newUserPolicy("45m")));
-        SetRetentionPolicy redoPlayer = new SetRetentionPolicy(mbox.getId(), MailItem.Type.TAG, tag.getId(), rp);
+    // Create RedoableOp.
+    RetentionPolicy rp = new RetentionPolicy(List.of(Policy.newSystemPolicy("123")), null);
+    SetRetentionPolicy redoPlayer =
+        new SetRetentionPolicy(mbox.getId(), MailItem.Type.TAG, tag.getId(), rp);
 
-        // Serialize, deserialize, and redo.
-        byte[] data = redoPlayer.testSerialize();
-        redoPlayer = new SetRetentionPolicy();
-        redoPlayer.setMailboxId(mbox.getId());
-        redoPlayer.testDeserialize(data);
-        redoPlayer.redo();
+    // Serialize, deserialize, and redo.
+    byte[] data = redoPlayer.testSerialize();
+    redoPlayer = new SetRetentionPolicy();
+    redoPlayer.setMailboxId(mbox.getId());
+    redoPlayer.testDeserialize(data);
+    redoPlayer.redo();
 
-        tag = mbox.getTagById(null, tag.getId());
-        assertEquals(1, tag.getRetentionPolicy().getKeepPolicy().size());
-        assertEquals(1, tag.getRetentionPolicy().getPurgePolicy().size());
-        assertEquals("45m", tag.getRetentionPolicy().getPurgePolicy().get(0).getLifetime());
-        assertEquals("123", tag.getRetentionPolicy().getKeepPolicy().get(0).getId());
-    }
+    tag = mbox.getTagById(null, tag.getId());
+    assertEquals(1, tag.getRetentionPolicy().getKeepPolicy().size());
+    assertEquals("123", tag.getRetentionPolicy().getKeepPolicy().get(0).getId());
+  }
 }


### PR DESCRIPTION
**What has changed:**
- Setting retention policy fails if both(keep and purge) policies are specified
- Setting retention policy fails if no policy is specified
- Unit test covering both cases