### PR TITLE
fix: log4j.properties: remove undefined references to EWS logger

### DIFF
--- a/store-conf/conf/log4j.properties.production
+++ b/store-conf/conf/log4j.properties.production
@@ -113,7 +113,7 @@ log4j.additivity.zimbra.activity=false
 log4j.logger.zimbra.activity=INFO,ACTIVITY
 log4j.logger.zimbra.searchstat=INFO,SEARCHSTAT
 log4j.additivity.zimbra.ews=false
-log4j.logger.zimbra.ews=INFO,EWS
+log4j.logger.zimbra.ews=INFO
 
 log4j.logger.zimbra=INFO
 log4j.logger.zimbra.op=WARN


### PR DESCRIPTION
This will fix error messages within `/opt/zextras/log/zmmailboxd.out`
```
[3.545s][info][gc] GC(2) Pause Young (Concurrent Start) (Metadata GC Threshold) 87M->56M(3942M) 9.255ms
[3.546s][info][gc] GC(3) Concurrent Mark Cycle
[3.574s][info][gc] GC(3) Pause Remark 58M->58M(3942M) 3.069ms
[3.583s][info][gc] GC(3) Pause Cleanup 58M->58M(3942M) 0.245ms
[3.590s][info][gc] GC(3) Concurrent Mark Cycle 44.796ms
log4j:ERROR Could not find value for key log4j.appender.EWS
log4j:ERROR Could not instantiate appender named "EWS".
log4j:ERROR Could not find value for key log4j.appender.EWS
log4j:ERROR Could not instantiate appender named "EWS".
log4j:ERROR Could not find value for key log4j.appender.EWS
log4j:ERROR Could not instantiate appender named "EWS".
[4.429s][info][gc] GC(4) Pause Young (Prepare Mixed) (Metadata GC Threshold) 122M->62M(3942M) 10.285ms
```