### PR TITLE
feat: [CO-756] Update defaults for proxy CSP header

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2945,6 +2945,19 @@ public class ZAttrProvisioning {
     public static final String A_carbonioPrefWebUiDarkMode = "carbonioPrefWebUiDarkMode";
 
     /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public static final String A_carbonioReverseProxyResponseCSPHeader = "carbonioReverseProxyResponseCSPHeader";
+
+    /**
      * Whether Carbonio can send analytics reports
      *
      * @since ZCS 9.0.0
@@ -15604,10 +15617,12 @@ public class ZAttrProvisioning {
     public static final String A_zimbraReverseProxyPortSearchBase = "zimbraReverseProxyPortSearchBase";
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @since ZCS 8.7.0,9.0.0
      */

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -10050,7 +10050,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="3133" name="carbonioReverseProxyResponseCSPHeader" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInfo,domainInherited" requiresRestart="nginxproxy" since="23.7.0">
-  <globalConfigValue>Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src  * blob: data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src  * blob: data:; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self';"</globalConfigValue>
+  <globalConfigValue>Content-Security-Policy: "default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';"</globalConfigValue>
   <desc>
     Content Security Policy headers to be added by the proxy. This is used along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
     to produce a complete set of Response Headers returned by the by the proxy.

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -8919,9 +8919,9 @@ TODO: delete them permanently from here
   <globalConfigValue>X-XSS-Protection: "1; mode=block"</globalConfigValue>
   <globalConfigValue>X-Frame-Options: "sameorigin"</globalConfigValue>
   <globalConfigValue>Expect-CT: max-age=86400</globalConfigValue>
-  <globalConfigValue>Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src  * blob: data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src  * blob: data:; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self';"</globalConfigValue>
   <desc>
-     Custom response headers to be added by the proxy. For example, can be used to add a HSTS header
+     Custom response headers to be added by the proxy. The carbonioReverseProxyResponseCSPHeader should be used along with this to
+     produce complete Proxy Response header. Usage: can be used to add a HSTS header
      that will enforce SSL usage on the client side. Note: the value
      MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo: "Bar1; Bar2").
   </desc>
@@ -10047,5 +10047,16 @@ TODO: delete them permanently from here
   <defaultCOSValue>FALSE</defaultCOSValue>
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the Team feature enabled for account or COS</desc>
+</attr>
+
+<attr id="3133" name="carbonioReverseProxyResponseCSPHeader" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInfo,domainInherited" requiresRestart="nginxproxy" since="23.7.0">
+  <globalConfigValue>Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src  * blob: data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src  * blob: data:; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self';"</globalConfigValue>
+  <desc>
+    Content Security Policy headers to be added by the proxy. This is used along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+    to produce a complete set of Response Headers returned by the by the proxy.
+    Usage: can be used to add a Content-Security-Policy header
+    that will enforce CSP rule on the client side. Note: the value
+    MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo: "Bar1; Bar2").
+  </desc>
 </attr>
 </attrs>

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -1513,6 +1513,103 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public String getCarbonioReverseProxyResponseCSPHeader() {
+        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param carbonioReverseProxyResponseCSPHeader new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public void setCarbonioReverseProxyResponseCSPHeader(String carbonioReverseProxyResponseCSPHeader) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, carbonioReverseProxyResponseCSPHeader);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param carbonioReverseProxyResponseCSPHeader new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public Map<String,Object> setCarbonioReverseProxyResponseCSPHeader(String carbonioReverseProxyResponseCSPHeader, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, carbonioReverseProxyResponseCSPHeader);
+        return attrs;
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public void unsetCarbonioReverseProxyResponseCSPHeader() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public Map<String,Object> unsetCarbonioReverseProxyResponseCSPHeader(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "");
+        return attrs;
+    }
+
+    /**
      * Whether Carbonio can send analytics reports
      *
      * @return carbonioSendAnalytics, or true if unset
@@ -61526,10 +61623,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @return zimbraReverseProxyResponseHeaders, or empty array if unset
      *
@@ -61537,14 +61636,16 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=1973)
     public String[] getReverseProxyResponseHeaders() {
-        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400","Content-Security-Policy: \"default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src  * blob: data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src  * blob: data:; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self';\""};
+        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400"};
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -61559,10 +61660,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new value
      * @param attrs existing map to populate, or null to create a new map
@@ -61578,10 +61681,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -61596,10 +61701,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new to add to existing values
      * @param attrs existing map to populate, or null to create a new map
@@ -61615,10 +61722,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -61633,10 +61742,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders existing value to remove
      * @param attrs existing map to populate, or null to create a new map
@@ -61652,10 +61763,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -61669,10 +61782,12 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1048,6 +1048,103 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public String getCarbonioReverseProxyResponseCSPHeader() {
+        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param carbonioReverseProxyResponseCSPHeader new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public void setCarbonioReverseProxyResponseCSPHeader(String carbonioReverseProxyResponseCSPHeader) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, carbonioReverseProxyResponseCSPHeader);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param carbonioReverseProxyResponseCSPHeader new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public Map<String,Object> setCarbonioReverseProxyResponseCSPHeader(String carbonioReverseProxyResponseCSPHeader, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, carbonioReverseProxyResponseCSPHeader);
+        return attrs;
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public void unsetCarbonioReverseProxyResponseCSPHeader() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Content Security Policy headers to be added by the proxy. This is used
+     * along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
+     * to produce a complete set of Response Headers returned by the by the
+     * proxy. Usage: can be used to add a Content-Security-Policy header that
+     * will enforce CSP rule on the client side. Note: the value MUST be the
+     * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.7.0
+     */
+    @ZAttr(id=3133)
+    public Map<String,Object> unsetCarbonioReverseProxyResponseCSPHeader(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "");
+        return attrs;
+    }
+
+    /**
      * Enable video server recording for Carbonio
      *
      * @return carbonioVideoServerRecordingEnabled, or false if unset
@@ -20509,10 +20606,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @return zimbraReverseProxyResponseHeaders, or empty array if unset
      *
@@ -20520,14 +20619,16 @@ public abstract class ZAttrDomain extends NamedEntry {
      */
     @ZAttr(id=1973)
     public String[] getReverseProxyResponseHeaders() {
-        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400","Content-Security-Policy: \"default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.zextras.tools; connect-src 'self' *.zextras.tools; img-src  * blob: data:; font-src 'self' fonts.gstatic.com; object-src 'self'; media-src  * blob: data:; child-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; form-action 'self'; frame-ancestors 'self';\""};
+        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraReverseProxyResponseHeaders, true, true); return value.length > 0 ? value : new String[] {"Strict-Transport-Security: \"max-age=31536000; includeSubDomains; preload\"","Permissions-Policy: \"geolocation=(self), microphone=(self)\"","Referrer-Policy: \"same-origin\"","X-Content-Type-Options: \"nosniff\"","X-Robots-Tag: \"noindex, nofollow\"","X-XSS-Protection: \"1; mode=block\"","X-Frame-Options: \"sameorigin\"","Expect-CT: max-age=86400"};
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -20542,10 +20643,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new value
      * @param attrs existing map to populate, or null to create a new map
@@ -20561,10 +20664,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new to add to existing values
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -20579,10 +20684,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders new to add to existing values
      * @param attrs existing map to populate, or null to create a new map
@@ -20598,10 +20705,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders existing value to remove
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -20616,10 +20725,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param zimbraReverseProxyResponseHeaders existing value to remove
      * @param attrs existing map to populate, or null to create a new map
@@ -20635,10 +20746,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -20652,10 +20765,12 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Custom response headers to be added by the proxy. For example, can be
-     * used to add a HSTS header that will enforce SSL usage on the client
-     * side. Note: the value MUST be the entire header line (e.g. X-Foo: Bar,
-     * X-Zoo: &quot;Bar1; Bar2&quot;).
+     * Custom response headers to be added by the proxy. The
+     * carbonioReverseProxyResponseCSPHeader should be used along with this
+     * to produce complete Proxy Response header. Usage: can be used to add a
+     * HSTS header that will enforce SSL usage on the client side. Note: the
+     * value MUST be the entire header line (e.g. X-Foo: Bar, X-Zoo:
+     * &quot;Bar1; Bar2&quot;).
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/DomainAttrExceptionItem.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/DomainAttrExceptionItem.java
@@ -1,7 +1,7 @@
 package com.zimbra.cs.util.proxyconfgen;
 
 /**
- * The visit of LdapProvisioning can't throw the exception out. Therefore uses this special item to
+ * The visit of LdapProvisioning can't throw the exception out. Therefore, uses this special item to
  * indicate exception.
  *
  * @author jiankuan
@@ -11,7 +11,7 @@ class DomainAttrExceptionItem extends DomainAttrItem {
   ProxyConfException exception;
 
   public DomainAttrExceptionItem(ProxyConfException e) {
-    super(null, null, null, null, null, null, null, null);
+    super(null, null, null, null, null, null, null, null, null);
     this.exception = e;
   }
 }

--- a/store/src/main/java/com/zimbra/cs/util/proxyconfgen/DomainAttrItem.java
+++ b/store/src/main/java/com/zimbra/cs/util/proxyconfgen/DomainAttrItem.java
@@ -16,6 +16,7 @@ class DomainAttrItem {
   String clientCertMode;
   String clientCertCa;
   String[] rspHeaders;
+  String cspHeader;
 
   public DomainAttrItem(
       String dn,
@@ -25,7 +26,8 @@ class DomainAttrItem {
       String spk,
       String ccm,
       String cca,
-      String[] rhdr) {
+      String[] rhdr,
+      String csp) {
     this.domainName = dn;
     this.virtualHostname = vhn;
     this.virtualIPAddress = vip;
@@ -34,5 +36,6 @@ class DomainAttrItem {
     this.clientCertMode = ccm;
     this.clientCertCa = cca;
     this.rspHeaders = rhdr;
+    this.cspHeader = csp;
   }
 }


### PR DESCRIPTION
**What has changed:**
- CSP header can be set separately.
- ProxyConfGen util will combine the 'Custom response headers' with 'CSP header' to produce complete Response header set.
- Updated CSP policy according to our requirements.

**Other PRs:**
- https://github.com/zextras/carbonio-ldap-utilities/pull/51