### PR TITLE
chore: upgrade pre-commit to new common rules

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+default: true
+MD013:
+  line_length: 120
+  code_blocks: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,49 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: (ZAttr.*\.java$|attrs\.xml|rights(-[a-zA-Z]+)?\.xml)
+exclude: (ZAttr.*\.java$|attrs\.xml|rights(-[a-zA-Z]+)?\.xml|mvnw|package-lock.json|go.sum)
 repos:
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
-      hooks:
-        - id: trailing-whitespace
-        - id: end-of-file-fixer
-        - id: check-yaml
-        - id: check-added-large-files
-        - id: check-toml
-        - id: mixed-line-ending
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-xml
+      - id: check-toml
+      - id: mixed-line-ending
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=2048]
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.22
     hooks:
       - id: shellcheck
+  - repo: https://github.com/IamTheFij/docker-pre-commit
+    rev: v3.0.1
+    hooks:
+      - id: docker-compose-check
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.9.0
     hooks:
       - id: pretty-format-java
         args: [--autofix]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.35.0
     hooks:
       - id: markdownlint
       - id: markdownlint-fix
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []
   - repo: https://github.com/jorisroovers/gitlint
     rev:  v0.17.0
     hooks:
       - id: gitlint
+#  - repo: https://github.com/fsfe/reuse-tool
+#    rev: v1.1.2
+#    hooks:
+#      - id: reuse


### PR DESCRIPTION
Basically with @federicorispo and @nomanAli95 on behalf of the backend tribe we decided new common rules for `pre-commit` hooks. With this PR, we update the mailbox to these new rules (a document is being prepared with pre-defined templates to copy from, this is basically one of them)

I didn't activate reuse because it runs on all the codebase and makes the build fail. We have to fix our headers before being able to activate it!