### PR TITLE
chore: update the package verions to match the expected one

### DIFF
--- a/packages/appserver-store-libs/PKGBUILD
+++ b/packages/appserver-store-libs/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "ubuntu"
 )
 pkgname="carbonio-appserver-store-libs"
-pkgver="4.0.10"
+pkgver="4.0.11"
 pkgrel="1"
 pkgdesc="Replace Carbonio store libs"
 pkgdesclong=(

--- a/packages/common-core-libs/PKGBUILD
+++ b/packages/common-core-libs/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "ubuntu"
 )
 pkgname="carbonio-common-core-libs"
-pkgver="4.0.10"
+pkgver="4.0.11"
 pkgrel="1"
 pkgdesc="Replace Carbonio core libs"
 pkgdesclong=(


### PR DESCRIPTION
- carbonio-appserver-store-libs
- carbonio-common-core-libs

4.0.10 was put mistakenly while merging carbonio-zcs-lib in mailbox. 
This change will make above mentioned mailbox pakcages install latest changes for us everywhere.