### PR TITLE
chore: remove old junit

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -176,12 +176,6 @@
       <artifactId>zm-native</artifactId>
       <groupId>zextras</groupId>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
* there was a junit dependency with RELEASE version not resolvable by ivy