### PR TITLE
chore: always skip deps check except main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 def mvnCmd(String cmd) {
-  sh 'mvn -B -s settings-jenkins.xml ' + cmd
+    def extraOptions = ''
+    if (env.BRANCH_NAME == 'main') {
+        extraOptions = '-Ddependency-check.skip=false'
+    }
+  sh 'mvn -B -s settings-jenkins.xml ' + extraOptions + ' ' + cmd
 }
 pipeline {
     agent {
@@ -35,7 +39,6 @@ pipeline {
         }
         stage('Build') {
             steps {
-
                 mvnCmd("$BUILD_PROPERTIES_PARAMS -DskipTests=true clean install")
 
                 sh 'mkdir staging'

--- a/pom.xml
+++ b/pom.xml
@@ -916,6 +916,8 @@
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <revision>23.9.0-SNAPSHOT</revision>
     <mockserver.version>5.13.0</mockserver.version>
+    <!-- Skip Dependency check by default -->
+    <dependency-check.skip>true</dependency-check.skip>
   </properties>
   <version>${revision}</version>
   <profiles>


### PR DESCRIPTION
The idea is to run dependency check only on main branch.

By default maven will skip it (see pom.xml)
The property will be set to true only when in main