### PR TITLE
fix: [CO-803] Fix NPE while exporting user data in tgz format

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -567,7 +567,7 @@ public abstract class ArchiveFormatter extends Formatter {
       throws ServiceException {
 
     String ext = null, name = null;
-    StringBuilder extra = null;
+    StringBuilder extra = new StringBuilder();
     Integer fid = mi.getFolderId();
     String fldr;
     InputStream is = null;


### PR DESCRIPTION
**What has changed:**

- StringBuilder object used to accumulate some "extra" user data is initialized instead of being assigned to null avoiding NPE in successive calls.