### PR TITLE
chore: [CO-739] limit LE certificate management for delegated admins

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
@@ -60,11 +60,11 @@ public class IssueCert extends AdminDocumentHandler {
                     ServiceException.INVALID_REQUEST(
                         "Domain with id " + domainId + " could not be found.", null));
 
-    final AdminAccessControl admin =
+    final AdminAccessControl adminAccessControl =
         checkDomainRight(zsc, domain, AdminRights.R_setDomainAdminDomainAttrs);
-    final String adminMail = admin.mAuthedAcct.getMail();
+    final String adminMail = adminAccessControl.mAuthedAcct.getMail();
 
-    final String chain =
+    final String chainType =
         request.getAttribute(AdminConstants.A_CHAIN_TYPE, AdminConstants.DEFAULT_CHAIN);
 
     final String domainName =
@@ -107,7 +107,7 @@ public class IssueCert extends AdminDocumentHandler {
         certbot.createCommand(
             RemoteCommands.CERTBOT_CERTONLY,
             adminMail,
-            chain,
+            chainType,
             domainName,
             publicServiceHostname,
             virtualHostNames);

--- a/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
@@ -36,6 +36,9 @@ public class IssueCert extends AdminDocumentHandler {
    * command, asynchronously executes it, creates response element, notifies global and domain
    * recipients about the result of remote execution.
    *
+   * <p>Note: Executes certbot command only on ONE (first found) proxy even if there are multiple
+   * proxy in the infrastructure.
+   *
    * @param request {@link Element} representation of {@link
    *     com.zimbra.soap.admin.message.IssueCertRequest}
    * @param context request context
@@ -87,8 +90,6 @@ public class IssueCert extends AdminDocumentHandler {
                     ServiceException.FAILURE(
                         "Domain " + domainName + " must have at least one VirtualHostName."));
 
-    // First release will work only on ONE proxy even if there are multiple proxy in the
-    // infrastructure.
     final Server proxyServer =
         prov.getAllServers().stream()
             .filter(Server::hasProxyService)

--- a/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/IssueCert.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 public class IssueCert extends AdminDocumentHandler {
 
   public static final String RESPONSE =
-      "The System is processing your certificate generation request. It will send the result to the"
-          + " Global and Domain notification recipients if they are set.";
+      "The System is processing your certificate generation request.\n"
+          + "It will send the result to the Global and Domain notification recipients.";
 
   /**
    * Handles the request. Searches a domain by id, checks admin rights (accessible to global and

--- a/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
@@ -38,12 +38,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 public class IssueCertTest {
-  private static final MockedStatic<RemoteManager> staticRemoteManager
-      = mockStatic(RemoteManager.class);
-  private static final MockedStatic<RemoteCertbot> staticRemoteCertbot
-      = mockStatic(RemoteCertbot.class);
-  private static final MockedStatic<CertificateNotificationManager> staticNotificationManager
-      = mockStatic(CertificateNotificationManager.class);
+  private static final MockedStatic<RemoteManager> staticRemoteManager =
+      mockStatic(RemoteManager.class);
+  private static final MockedStatic<RemoteCertbot> staticRemoteCertbot =
+      mockStatic(RemoteCertbot.class);
+  private static final MockedStatic<CertificateNotificationManager> staticNotificationManager =
+      mockStatic(CertificateNotificationManager.class);
 
   private final Map<String, Object> context = new HashMap<>();
   private final Map<String, Object> domainAttributes = new HashMap<>();
@@ -56,8 +56,8 @@ public class IssueCertTest {
 
   private final RemoteManager remoteManager = mock(RemoteManager.class);
   private final RemoteCertbot remoteCertbot = mock(RemoteCertbot.class);
-  private final CertificateNotificationManager notificationManager
-      = mock(CertificateNotificationManager.class);
+  private final CertificateNotificationManager notificationManager =
+      mock(CertificateNotificationManager.class);
 
   private final IssueCert handler = new IssueCert();
   private final XMLElement request = new XMLElement(ISSUE_CERT_REQUEST);
@@ -73,17 +73,16 @@ public class IssueCertTest {
 
     RightManager.getInstance();
 
-    String domainId = "domainId";
-    String password = "testPwd";
+    final String domainId = "domainId";
+    final String password = "testPwd";
 
-    Account account =
+    final Account account =
         provisioning.createAccount(
             mail,
             password,
             new HashMap<>() {
               {
                 put(ZAttrProvisioning.A_zimbraIsAdminAccount, "TRUE");
-                put(ZAttrProvisioning.A_zimbraIsDelegatedAdminAccount, "TRUE");
                 put(ZAttrProvisioning.A_mail, mail);
               }
             });
@@ -91,11 +90,12 @@ public class IssueCertTest {
     domainAttributes.put(ZAttrProvisioning.A_zimbraDomainName, domainName);
     domainAttributes.put(ZAttrProvisioning.A_zimbraId, domainId);
 
-    this.zsc =  new ZimbraSoapContext(
-        AuthProvider.getAuthToken(account, true),
-        account.getId(),
-        SoapProtocol.Soap12,
-        SoapProtocol.Soap12);
+    this.zsc =
+        new ZimbraSoapContext(
+            AuthProvider.getAuthToken(account, true),
+            account.getId(),
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
     this.context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
 
     this.request.addNonUniqueElement(A_DOMAIN).addText(domainId);
@@ -117,80 +117,99 @@ public class IssueCertTest {
     staticNotificationManager.close();
   }
 
- @Test
- void shouldSupplyAsyncAndReturnResponse() throws Exception {
-  domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-  domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+  @Test
+  void shouldSupplyAsyncAndReturnResponse() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
 
-  Domain expectedDomain = provisioning.createDomain(domainName, domainAttributes);
+    final Domain expectedDomain = provisioning.createDomain(domainName, domainAttributes);
 
-  final String serverName = "serverName";
-  final Server server =
-    provisioning.createServer(
-      serverName,
-      new HashMap<>() {
-       {
-        put(ZAttrProvisioning.A_cn, serverName);
-        put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
-       }
-      });
+    final String serverName = "serverName";
+    final Server server =
+        provisioning.createServer(
+            serverName,
+            new HashMap<>() {
+              {
+                put(ZAttrProvisioning.A_cn, serverName);
+                put(ZAttrProvisioning.A_zimbraServiceEnabled, Provisioning.SERVICE_PROXY);
+              }
+            });
 
-  staticRemoteManager.when(() -> RemoteManager.getRemoteManager(server))
-    .thenReturn(remoteManager);
-  staticRemoteCertbot.when(() -> RemoteCertbot.getRemoteCertbot(remoteManager))
-    .thenReturn(remoteCertbot);
+    staticRemoteManager
+        .when(() -> RemoteManager.getRemoteManager(server))
+        .thenReturn(remoteManager);
+    staticRemoteCertbot
+        .when(() -> RemoteCertbot.getRemoteCertbot(remoteManager))
+        .thenReturn(remoteCertbot);
 
-  Mailbox expectMailbox = getRequestedMailbox(zsc);
-  staticNotificationManager.when(() -> CertificateNotificationManager
-    .getCertificateNotificationManager(expectMailbox, expectedDomain))
-    .thenReturn(notificationManager);
+    final Mailbox expectMailbox = getRequestedMailbox(zsc);
+    staticNotificationManager
+        .when(
+            () ->
+                CertificateNotificationManager.getCertificateNotificationManager(
+                    expectMailbox, expectedDomain))
+        .thenReturn(notificationManager);
 
-  String expectedCommand = "certbot certonly --agree-tos --email admin@example.com"
-    + " -n --keep --webroot -w /opt/zextras "
-    + "--cert-name example.com "
-    + "-d public.example.com -d virtual.example.com";
+    final String expectedCommand =
+        "certbot certonly --agree-tos --email admin@example.com"
+            + " -n --keep --webroot -w /opt/zextras "
+            + "--cert-name example.com "
+            + "-d public.example.com -d virtual.example.com";
 
-  when(remoteCertbot.createCommand(
-    RemoteCommands.CERTBOT_CERTONLY,
-    mail,
-    AdminConstants.DEFAULT_CHAIN,
-    domainName,
-    publicServiceHostName,
-    expectedDomain.getVirtualHostname())).thenReturn(expectedCommand);
+    when(remoteCertbot.createCommand(
+            RemoteCommands.CERTBOT_CERTONLY,
+            mail,
+            AdminConstants.DEFAULT_CHAIN,
+            domainName,
+            publicServiceHostName,
+            expectedDomain.getVirtualHostname()))
+        .thenReturn(expectedCommand);
 
-  final Element response = handler.handle(request, context);
-  final Element message = response.getElement(E_MESSAGE);
+    final Element response = handler.handle(request, context);
+    final Element message = response.getElement(E_MESSAGE);
 
-  assertEquals(domainName, message.getAttribute(A_DOMAIN));
-  assertEquals(IssueCert.RESPONSE, message.getText());
+    assertEquals(domainName, message.getAttribute(A_DOMAIN));
+    assertEquals(IssueCert.RESPONSE, message.getText());
 
-  verify(remoteCertbot).supplyAsync(notificationManager, expectedCommand);
- }
+    verify(remoteCertbot).supplyAsync(notificationManager, expectedCommand);
+  }
 
- @Test
- void shouldReturnInvalidIfNoSuchDomain() {
-   assertThrows(ServiceException.class, () -> handler.handle(request, context), "Domain with id domainId could not be found.");
- }
+  @Test
+  void shouldReturnInvalidIfNoSuchDomain() {
+    assertThrows(
+        ServiceException.class,
+        () -> handler.handle(request, context),
+        "Domain with id domainId could not be found.");
+  }
 
- @Test
- void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
-  domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-  provisioning.createDomain(domainName, domainAttributes);
-  assertThrows(ServiceException.class, () -> handler.handle(request, context),"must have PublicServiceHostname");
- }
+  @Test
+  void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+    provisioning.createDomain(domainName, domainAttributes);
+    assertThrows(
+        ServiceException.class,
+        () -> handler.handle(request, context),
+        "must have PublicServiceHostname");
+  }
 
- @Test
- void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
-  domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-  provisioning.createDomain(domainName, domainAttributes);
-  assertThrows(ServiceException.class, () -> handler.handle(request, context),"must have at least one VirtualHostName.");
- }
+  @Test
+  void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+    provisioning.createDomain(domainName, domainAttributes);
+    assertThrows(
+        ServiceException.class,
+        () -> handler.handle(request, context),
+        "must have at least one VirtualHostName.");
+  }
 
- @Test
- void shouldReturnFailureIfNoServerWithProxy() throws Exception {
-  domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
-  domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
-  provisioning.createDomain(domainName, domainAttributes);
-  assertThrows(ServiceException.class, () -> handler.handle(request, context),"Issuing LetsEncrypt certificate command requires carbonio-proxy.");
- }
+  @Test
+  void shouldReturnFailureIfNoServerWithProxy() throws Exception {
+    domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
+    domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
+    provisioning.createDomain(domainName, domainAttributes);
+    assertThrows(
+        ServiceException.class,
+        () -> handler.handle(request, context),
+        "Issuing LetsEncrypt certificate command requires carbonio-proxy.");
+  }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/IssueCertTest.java
@@ -118,7 +118,7 @@ public class IssueCertTest {
   }
 
   @Test
-  void shouldSupplyAsyncAndReturnResponse() throws Exception {
+  void handleShouldSupplyAsyncAndReturnResponse() throws Exception {
     domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
     domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
 
@@ -175,41 +175,45 @@ public class IssueCertTest {
   }
 
   @Test
-  void shouldReturnInvalidIfNoSuchDomain() {
-    assertThrows(
-        ServiceException.class,
-        () -> handler.handle(request, context),
-        "Domain with id domainId could not be found.");
+  void handleShouldThrowServiceExceptionWhenNoSuchDomain() {
+    final ServiceException exception =
+        assertThrows(ServiceException.class, () -> handler.handle(request, context));
+    assertEquals(
+        "invalid request: Domain with id domainId could not be found.", exception.getMessage());
   }
 
   @Test
-  void shouldReturnInvalidIfNoPublicServiceHostName() throws Exception {
+  void handleShouldThrowServiceExceptionWhenNoPublicServiceHostName() throws Exception {
     domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
     provisioning.createDomain(domainName, domainAttributes);
-    assertThrows(
-        ServiceException.class,
-        () -> handler.handle(request, context),
-        "must have PublicServiceHostname");
+    final ServiceException exception =
+        assertThrows(ServiceException.class, () -> handler.handle(request, context));
+    assertEquals(
+        "system failure: Domain example.com must have PublicServiceHostname.",
+        exception.getMessage());
   }
 
   @Test
-  void shouldReturnInvalidIfNoVirtualHostName() throws Exception {
+  void handleShouldThrowServiceExceptionWhenNoVirtualHostName() throws Exception {
     domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
     provisioning.createDomain(domainName, domainAttributes);
-    assertThrows(
-        ServiceException.class,
-        () -> handler.handle(request, context),
-        "must have at least one VirtualHostName.");
+    final ServiceException exception =
+        assertThrows(ServiceException.class, () -> handler.handle(request, context));
+    assertEquals(
+        "system failure: Domain example.com must have at least one VirtualHostName.",
+        exception.getMessage());
   }
 
   @Test
-  void shouldReturnFailureIfNoServerWithProxy() throws Exception {
+  void handleShouldThrowServiceExceptionWhenNoServerWithProxyIsAvailable() throws Exception {
     domainAttributes.put(ZAttrProvisioning.A_zimbraPublicServiceHostname, publicServiceHostName);
     domainAttributes.put(ZAttrProvisioning.A_zimbraVirtualHostname, virtualHostName);
     provisioning.createDomain(domainName, domainAttributes);
-    assertThrows(
-        ServiceException.class,
-        () -> handler.handle(request, context),
-        "Issuing LetsEncrypt certificate command requires carbonio-proxy.");
+    final ServiceException exception =
+        assertThrows(ServiceException.class, () -> handler.handle(request, context));
+    assertEquals(
+        "system failure: Issuing LetsEncrypt certificate command requires carbonio-proxy. Make sure"
+            + " carbonio-proxy is installed, up and running.",
+        exception.getMessage());
   }
 }


### PR DESCRIPTION
**What has changed:**

issueCert api will be available for global admins, domain admins (on their domains) and delegated admin with setDomainAdminDomainAttrs right (instead of getDomain right).

