### PR TITLE
feat: [CO-807] update mailboxd_java_options for JDK17

### DIFF
--- a/common/src/main/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/main/java/com/zimbra/common/localconfig/LC.java
@@ -1312,8 +1312,6 @@ public final class LC {
   public static final KnownKey public_share_advertising_scope =
       KnownKey.newKey(PUBLIC_SHARE_VISIBILITY.samePrimaryDomain.toString());
 
-  ;
-
   // Triton integration
   public static final KnownKey triton_store_url = KnownKey.newKey("");
   public static final KnownKey triton_hash_type = KnownKey.newKey("SHA0");

--- a/common/src/main/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/main/java/com/zimbra/common/localconfig/LC.java
@@ -504,7 +504,9 @@ public final class LC {
               + " -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions"
               + " -XX:G1NewSizePercent=15 -XX:G1MaxNewSizePercent=45 -XX:-OmitStackTraceInFastThrow"
               + " -verbose:gc"
-              + " -Xlog:gc*=info,safepoint=info:file=/opt/zextras/log/gc.log:time:filecount=20,filesize=10m");
+              + " -Xlog:gc*=info,safepoint=info:file=/opt/zextras/log/gc.log:time:filecount=20,filesize=10m"
+              + " -Djava.security.egd=file:/dev/./urandom --add-opens"
+              + " java.base/java.lang=ALL-UNNAMED");
 
   @Supported
   public static final KnownKey mailboxd_pidfile =
@@ -1294,12 +1296,6 @@ public final class LC {
 
   @Supported public static final KnownKey zimbra_listeners_maxsize = KnownKey.newKey(5);
 
-  public enum PUBLIC_SHARE_VISIBILITY {
-    samePrimaryDomain,
-    all,
-    none
-  };
-
   /**
    * Added for Bug 99825 which relates to the security implications of public shares being visible
    * to users in different domains. If nothing else, it provided a means for harvesting details of
@@ -1316,22 +1312,19 @@ public final class LC {
   public static final KnownKey public_share_advertising_scope =
       KnownKey.newKey(PUBLIC_SHARE_VISIBILITY.samePrimaryDomain.toString());
 
+  ;
+
   // Triton integration
   public static final KnownKey triton_store_url = KnownKey.newKey("");
   public static final KnownKey triton_hash_type = KnownKey.newKey("SHA0");
   public static final KnownKey triton_upload_buffer_size = KnownKey.newKey(25000);
-
   public static final KnownKey uncompressed_cache_min_lifetime =
       KnownKey.newKey(Constants.MILLIS_PER_MINUTE);
-
   public static final KnownKey check_dl_membership_enabled = KnownKey.newKey(true);
-
   public static final KnownKey conversation_ignore_maillist_prefix = KnownKey.newKey(true);
-
   // EWS web service
   public static final KnownKey ews_service_wsdl_location =
       KnownKey.newKey("/opt/zextras/lib/ext/zimbraews/");
-
   public static final KnownKey zimbra_ews_autodiscover_use_service_url = KnownKey.newKey(false);
 
   @Supported
@@ -1346,56 +1339,41 @@ public final class LC {
 
   // Remote IMAP
   @Reloadable public static final KnownKey imap_always_use_remote_store = KnownKey.newKey(false);
-
   // owasp handler
   public static final KnownKey zimbra_use_owasp_html_sanitizer = KnownKey.newKey(true);
-
   // file content type blacklist
   public static final KnownKey zimbra_file_content_type_blacklist =
       KnownKey.newKey("application/x-ms*");
-
   public static final KnownKey enable_delegated_admin_ldap_access = KnownKey.newKey(true);
-
   // alias login
   public static final KnownKey alias_login_enabled = KnownKey.newKey(true);
-
   // Feed Manager comma-separated blacklist. addresses can be CIDR notation, or single ip. no
   // wild-cards (default blacklist private networks)
   public static final KnownKey zimbra_feed_manager_blacklist =
       KnownKey.newKey("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fd00::/8");
-
   // Feed Manager comma-separated whitelist (exceptions to the blacklist). addresses can be CIDR
   // notation, or single ip. no wild-cards
   public static final KnownKey zimbra_feed_manager_whitelist = KnownKey.newKey("");
-
   // Zimbra valid class list to de-serialize
   public static final KnownKey zimbra_deserialize_classes = KnownKey.newKey("");
-
   // XML 1.0 invalid characters regex pattern
   public static final KnownKey xml_invalid_chars_regex =
       KnownKey.newKey("\\&\\#(?:x([0-9a-fA-F]+)|([0-9]+))\\;");
-
   // to switch to Tika com.zimbra.cs.convert.TikaExtractionClient
   public static final KnownKey attachment_extraction_client_class =
       KnownKey.newKey("com.zimbra.cs.convert.LegacyConverterClient");
-
   // list file for blocking common passwords
   public static final KnownKey common_passwords_txt =
       KnownKey.newKey("${zimbra_home}/conf/common-passwords.txt");
-
   // imap folder pagination size
   public static final KnownKey zimbra_imap_folder_pagination_size = KnownKey.newKey(2000);
-
   // imap folder pagination enabled
   public static final KnownKey zimbra_imap_folder_pagination_enabled = KnownKey.newKey(false);
-
   // imap different message size than postfix mta ( useful for import )
   public static final KnownKey imap_max_message_size = KnownKey.newKey(null);
-
   // unsubscribe folder creation enabled
   public static final KnownKey zimbra_feature_safe_unsubscribe_folder_enabled =
       KnownKey.newKey(false);
-
   // wsdl use public service hostname
   public static final KnownKey wsdl_use_public_service_hostname = KnownKey.newKey(true);
 
@@ -1428,25 +1406,6 @@ public final class LC {
       }
     }
   }
-
-  /**
-   * Used to apply the reloadable flag to a KnownKey in LC
-   *
-   * @author jpowers
-   */
-  @Target({ElementType.FIELD})
-  @Retention(RetentionPolicy.RUNTIME)
-  public @interface Reloadable {}
-
-  /**
-   * This annotation represents a supported local config setting. To make a new setting show up in
-   * the zmlocalconfig -i command, use this annotation
-   *
-   * @author jpowers
-   */
-  @Target({ElementType.FIELD})
-  @Retention(RetentionPolicy.RUNTIME)
-  public @interface Supported {}
 
   public static PUBLIC_SHARE_VISIBILITY getPublicShareAdvertisingScope() {
     String value = LC.public_share_advertising_scope.value();
@@ -1490,4 +1449,29 @@ public final class LC {
     // This method is there to guarantee static initializer of this
     // class is run.
   }
+
+  public enum PUBLIC_SHARE_VISIBILITY {
+    samePrimaryDomain,
+    all,
+    none
+  }
+
+  /**
+   * Used to apply the reloadable flag to a KnownKey in LC
+   *
+   * @author jpowers
+   */
+  @Target({ElementType.FIELD})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Reloadable {}
+
+  /**
+   * This annotation represents a supported local config setting. To make a new setting show up in
+   * the zmlocalconfig -i command, use this annotation
+   *
+   * @author jpowers
+   */
+  @Target({ElementType.FIELD})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Supported {}
 }

--- a/packages/common-appserver-conf/PKGBUILD
+++ b/packages/common-appserver-conf/PKGBUILD
@@ -202,3 +202,61 @@ package() {
   install -D "store-conf/conf/rights/user-rights.xml" \
     "${pkgdir}/opt/zextras/conf/rights/user-rights.xml"
 }
+
+postinst:apt() {
+  # Update LC mailboxd_java_options for JDK17 on post-upgrade
+  if [ "$1" = "configure" ] && [ ! -z "$2" ]; then
+    echo -n "*Updating mailboxd_java_options for JDK17..."
+    java_options=$(su - zextras -c "/opt/zextras/bin/zmlocalconfig -m nokey mailboxd_java_options 2> /dev/null")
+    new_java_options="$java_options"
+    needs_update=false
+    if ! echo "$java_options" | grep -q -e '-Djava.security.egd'; then
+        new_java_options="$new_java_options -Djava.security.egd=file:/dev/./urandom"
+        needs_update=true
+    fi
+    if ! echo "$java_options" | grep -q -e '--add-opens\ java.base/java.lang=ALL-UNNAMED'; then
+        new_java_options="$new_java_options --add-opens java.base/java.lang=ALL-UNNAMED"
+        needs_update=true
+    fi
+    if $needs_update; then
+        new_java_options="$(echo "$new_java_options" | sed -e 's/^[[:space:]]*//')"
+        su - zextras -c "/opt/zextras/bin/zmlocalconfig -f -e mailboxd_java_options='$new_java_options' 2> /dev/null"
+        if [ "$?" -eq 0 ]; then
+            echo "done."
+        else
+            echo "failed."
+        fi
+    else
+        echo "already up-to-date."
+    fi
+  fi
+}
+
+postinst:yum() {
+  # Update LC mailboxd_java_options for JDK17 on post-upgrade
+  if [ "$1" -eq 2 ]; then
+    echo -n "*Updating mailboxd_java_options for JDK17..."
+    java_options=$(su - zextras -c "/opt/zextras/bin/zmlocalconfig -m nokey mailboxd_java_options 2> /dev/null")
+    new_java_options="$java_options"
+    needs_update=false
+    if ! echo "$java_options" | grep -q -e '-Djava.security.egd'; then
+        new_java_options="$new_java_options -Djava.security.egd=file:/dev/./urandom"
+        needs_update=true
+    fi
+    if ! echo "$java_options" | grep -q -e '--add-opens\ java.base/java.lang=ALL-UNNAMED'; then
+        new_java_options="$new_java_options --add-opens java.base/java.lang=ALL-UNNAMED"
+        needs_update=true
+    fi
+    if $needs_update; then
+        new_java_options="$(echo "$new_java_options" | sed -e 's/^[[:space:]]*//')"
+        su - zextras -c "/opt/zextras/bin/zmlocalconfig -f -e mailboxd_java_options='$new_java_options' 2> /dev/null"
+        if [ "$?" -eq 0 ]; then
+            echo "done."
+        else
+            echo "failed."
+        fi
+    else
+        echo "already up-to-date."
+    fi
+  fi
+}


### PR DESCRIPTION
**What has changed:**
- update `mailboxd_java_options` in `LC.java` to allow reflection access at runtime **(this ships update in fresh installs)**
- update `mailboxd_java_options` in `LC.java` adding `java.security.egd` to use `file:/dev/./urandom` as SecureRandom source
- post-upgrade scripts were added to carbonio-common-appserver-conf package to handle the update of `mailboxd_java_options` **(this ships update on existing installs)**