### PR TITLE
fix: [CO-831] ridZ field missing in SearchRequest of Calendars

### DIFF
--- a/store/src/main/java/com/zimbra/cs/mailbox/calendar/cache/CacheToXML.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/calendar/cache/CacheToXML.java
@@ -161,7 +161,7 @@ public class CacheToXML {
     parent.addAttribute(MailConstants.A_CAL_PARTSTAT, instance.getPartStat());
     if (isAppointment)
       parent.addAttribute(MailConstants.A_APPT_FREEBUSY_ACTUAL, instance.getFreeBusyActual());
-    else parent.addAttribute(MailConstants.A_CAL_RECURRENCE_ID_Z, instance.getRecurIdZ());
+      parent.addAttribute(MailConstants.A_CAL_RECURRENCE_ID_Z, instance.getRecurIdZ());
 
     if (!(instance instanceof FullInstanceData)) return;
 

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -6,6 +6,7 @@
 package com.zimbra.cs.mailbox;
 
 import com.google.common.base.Strings;
+import com.zimbra.common.calendar.WellKnownTimeZones;
 import com.zimbra.common.calendar.ZCalendar.ZVCalendar;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.ContentDisposition;
@@ -71,7 +72,8 @@ public final class MailboxTestUtil {
   public static void initProvisioning(String zimbraServerDir) throws Exception {
     zimbraServerDir = getZimbraServerDir(zimbraServerDir);
     System.setProperty("log4j.configuration", "log4j-test.properties");
-    System.setProperty("zimbra.config", zimbraServerDir + "src/test/resources/localconfig-test.xml");
+    System.setProperty(
+        "zimbra.config", zimbraServerDir + "src/test/resources/localconfig-test.xml");
     LC.reload();
     // substitute test TZ file
     String timezonefilePath = zimbraServerDir + "src/test/resources/timezones-test.ics";
@@ -80,6 +82,7 @@ public final class MailboxTestUtil {
       throw new FileNotFoundException("timezones-test.ics not found in " + timezonefilePath);
     }
     LC.timezone_file.setDefault(timezonefilePath);
+    WellKnownTimeZones.loadFromFile(d);
     LC.zimbra_rights_directory.setDefault(
         StringUtils.removeEnd(zimbraServerDir, "/") + "-conf" + "/conf/rights");
     LC.zimbra_attrs_directory.setDefault(zimbraServerDir + "conf/attrs");

--- a/store/src/test/java/com/zimbra/cs/service/mail/SearchTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SearchTest.java
@@ -9,7 +9,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.Maps;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.JSONElement;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryOptions;
@@ -18,129 +20,185 @@ import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Message;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 public class SearchTest {
-    
-    public String testName;
-    @BeforeAll
-    public static void init() throws Exception {
-        MailboxTestUtil.initServer();
-    }
 
- @BeforeEach
- public void setUp(TestInfo testInfo) throws Exception {
-  Optional<Method> testMethod = testInfo.getTestMethod();
-  if (testMethod.isPresent()) {
-   this.testName = testMethod.get().getName();
+  private static Provisioning provisioning;
+  private static Account testAccount;
+  public String testName;
+
+  @BeforeAll
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    provisioning = Provisioning.getInstance();
   }
-  System.out.println( testName);
-  Provisioning prov = Provisioning.getInstance();
-  prov.createAccount("test@zimbra.com", "secret", Maps.<String, Object>newHashMap());
-  prov.createAccount("testZCS3705@zimbra.com", "secret", Maps.<String, Object>newHashMap());
- }
 
- @Test
- void mute() throws Exception {
-  Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
-
-  // setup: add a message
-  DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX).setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
-  Message msg = mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
-  assertTrue(msg.isUnread(), "root unread");
-  assertTrue(msg.isTagged(Flag.FlagInfo.MUTED), "root muted");
-
-  // search for the conversation (normal)
-  Element request = new Element.XMLElement(MailConstants.SEARCH_REQUEST).addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
-  request.addAttribute(MailConstants.E_QUERY, "test", Element.Disposition.CONTENT);
-  Element response = new Search().handle(request, ServiceTestUtil.getRequestContext(acct));
-
-  List<Element> hits = response.listElements(MailConstants.E_CONV);
-  assertEquals(1, hits.size(), "1 hit");
-  assertEquals(msg.getConversationId(), hits.get(0).getAttributeLong(MailConstants.A_ID), "correct hit");
-
-  // search for the conversation (no muted items)
-  request.addAttribute(MailConstants.A_INCLUDE_TAG_MUTED, false);
-  response = new Search().handle(request, ServiceTestUtil.getRequestContext(acct));
-
-  hits = response.listElements(MailConstants.E_CONV);
-  assertTrue(hits.isEmpty(), "no hits");
- }
-
- @Test
- @Disabled("Fix me. Got -257 conversationId instead of -258.")
- void testZCS3705() throws Exception {
-  Account acct = Provisioning.getInstance().getAccountByName("testZCS3705@zimbra.com");
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
-
-  // add two messages - msg1 and msg2
-  DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX)
-    .setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
-  Message msg1 = mbox.addMessage(null, MailboxTestUtil.generateMessage("read subject"), dopt,
-    null);
-  Message msg2 = mbox.addMessage(null, MailboxTestUtil.generateMessage("unread subject"),
-    dopt, null);
-  assertTrue(msg1.isUnread(), "msg unread");
-  assertTrue(msg2.isUnread(), "msg unread");
-
-  // read msg1
-  Element request = new Element.XMLElement(MailConstants.GET_MSG_REQUEST);
-  Element action = request.addElement(MailConstants.E_MSG);
-  action.addAttribute(MailConstants.A_ID, msg1.getId());
-  action.addAttribute(MailConstants.A_MARK_READ, 1);
-  new GetMsg().handle(request, ServiceTestUtil.getRequestContext(mbox.getAccount()))
-    .getElement(MailConstants.E_MSG);
-  assertFalse(msg1.isUnread(), "msg read");
-  assertTrue(msg2.isUnread(), "msg unread");
-
-  // search for the conversation (sortBy readDesc) - msg2 should be listed before msg1
-  Element searchRequest = new Element.XMLElement(MailConstants.SEARCH_REQUEST)
-    .addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
-  searchRequest.addAttribute(MailConstants.E_QUERY, "subject", Element.Disposition.CONTENT);
-  searchRequest.addAttribute("sortBy", "readDesc");
-  Element searchResponse = new Search().handle(searchRequest,
-    ServiceTestUtil.getRequestContext(acct));
-  List<Element> hits = searchResponse.listElements(MailConstants.E_CONV);
-  assertEquals(2, hits.size(), "2 hits");
-  assertEquals(msg2.getConversationId(),
-    hits.get(0).getAttributeLong(MailConstants.A_ID),
-    "correct hit");
-  assertEquals(msg1.getConversationId(),
-    hits.get(1).getAttributeLong(MailConstants.A_ID),
-    "correct hit");
-
-  // search for the conversation (sortBy unreadDesc) - msg1 should be listed before msg2
-  searchRequest = new Element.XMLElement(MailConstants.SEARCH_REQUEST)
-    .addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
-  searchRequest.addAttribute(MailConstants.E_QUERY, "subject", Element.Disposition.CONTENT);
-  searchRequest.addAttribute("sortBy", "readAsc");
-  searchResponse = new Search().handle(searchRequest,
-    ServiceTestUtil.getRequestContext(acct));
-  hits = searchResponse.listElements(MailConstants.E_CONV);
-  assertEquals(2, hits.size(), "2 hits");
-  assertEquals(msg1.getConversationId(),
-    hits.get(0).getAttributeLong(MailConstants.A_ID),
-    "correct hit");
-  assertEquals(msg2.getConversationId(),
-    hits.get(1).getAttributeLong(MailConstants.A_ID),
-    "correct hit");
- }
-
-    @AfterEach
-    public void tearDown() {
-        try {
-            MailboxTestUtil.clearData();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+  @AfterEach
+  public void tearDown() {
+    try {
+      MailboxTestUtil.clearData();
+    } catch (Exception e) {
+      e.printStackTrace();
     }
+  }
+
+  @BeforeEach
+  public void setUp(TestInfo testInfo) throws Exception {
+    Optional<Method> testMethod = testInfo.getTestMethod();
+    if (testMethod.isPresent()) {
+      this.testName = testMethod.get().getName();
+    }
+    System.out.println(testName);
+    provisioning = Provisioning.getInstance();
+    provisioning.createAccount("test@zimbra.com", "secret", Maps.<String, Object>newHashMap());
+    provisioning.createAccount(
+        "testZCS3705@zimbra.com", "secret", Maps.<String, Object>newHashMap());
+    testAccount = provisioning.createAccount("test@test.com", "password", new HashMap<>());
+  }
+
+  @Test
+  void mute() throws Exception {
+    Account acct = Provisioning.getInstance().getAccountByName("test@zimbra.com");
+    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+    // setup: add a message
+    DeliveryOptions dopt =
+        new DeliveryOptions()
+            .setFolderId(Mailbox.ID_FOLDER_INBOX)
+            .setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
+    Message msg =
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("test subject"), dopt, null);
+    assertTrue(msg.isUnread(), "root unread");
+    assertTrue(msg.isTagged(Flag.FlagInfo.MUTED), "root muted");
+
+    // search for the conversation (normal)
+    Element request =
+        new Element.XMLElement(MailConstants.SEARCH_REQUEST)
+            .addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
+    request.addAttribute(MailConstants.E_QUERY, "test", Element.Disposition.CONTENT);
+    Element response = new Search().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+    List<Element> hits = response.listElements(MailConstants.E_CONV);
+    assertEquals(1, hits.size(), "1 hit");
+    assertEquals(
+        msg.getConversationId(), hits.get(0).getAttributeLong(MailConstants.A_ID), "correct hit");
+
+    // search for the conversation (no muted items)
+    request.addAttribute(MailConstants.A_INCLUDE_TAG_MUTED, false);
+    response = new Search().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+    hits = response.listElements(MailConstants.E_CONV);
+    assertTrue(hits.isEmpty(), "no hits");
+  }
+
+  @Test
+  @Disabled("Fix me. Got -257 conversationId instead of -258.")
+  void testZCS3705() throws Exception {
+    Account acct = Provisioning.getInstance().getAccountByName("testZCS3705@zimbra.com");
+    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+    // add two messages - msg1 and msg2
+    DeliveryOptions dopt =
+        new DeliveryOptions()
+            .setFolderId(Mailbox.ID_FOLDER_INBOX)
+            .setFlags(Flag.BITMASK_UNREAD | Flag.BITMASK_MUTED);
+    Message msg1 =
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("read subject"), dopt, null);
+    Message msg2 =
+        mbox.addMessage(null, MailboxTestUtil.generateMessage("unread subject"), dopt, null);
+    assertTrue(msg1.isUnread(), "msg unread");
+    assertTrue(msg2.isUnread(), "msg unread");
+
+    // read msg1
+    Element request = new Element.XMLElement(MailConstants.GET_MSG_REQUEST);
+    Element action = request.addElement(MailConstants.E_MSG);
+    action.addAttribute(MailConstants.A_ID, msg1.getId());
+    action.addAttribute(MailConstants.A_MARK_READ, 1);
+    new GetMsg()
+        .handle(request, ServiceTestUtil.getRequestContext(mbox.getAccount()))
+        .getElement(MailConstants.E_MSG);
+    assertFalse(msg1.isUnread(), "msg read");
+    assertTrue(msg2.isUnread(), "msg unread");
+
+    // search for the conversation (sortBy readDesc) - msg2 should be listed before msg1
+    Element searchRequest =
+        new Element.XMLElement(MailConstants.SEARCH_REQUEST)
+            .addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
+    searchRequest.addAttribute(MailConstants.E_QUERY, "subject", Element.Disposition.CONTENT);
+    searchRequest.addAttribute("sortBy", "readDesc");
+    Element searchResponse =
+        new Search().handle(searchRequest, ServiceTestUtil.getRequestContext(acct));
+    List<Element> hits = searchResponse.listElements(MailConstants.E_CONV);
+    assertEquals(2, hits.size(), "2 hits");
+    assertEquals(
+        msg2.getConversationId(), hits.get(0).getAttributeLong(MailConstants.A_ID), "correct hit");
+    assertEquals(
+        msg1.getConversationId(), hits.get(1).getAttributeLong(MailConstants.A_ID), "correct hit");
+
+    // search for the conversation (sortBy unreadDesc) - msg1 should be listed before msg2
+    searchRequest =
+        new Element.XMLElement(MailConstants.SEARCH_REQUEST)
+            .addAttribute(MailConstants.A_SEARCH_TYPES, "conversation");
+    searchRequest.addAttribute(MailConstants.E_QUERY, "subject", Element.Disposition.CONTENT);
+    searchRequest.addAttribute("sortBy", "readAsc");
+    searchResponse = new Search().handle(searchRequest, ServiceTestUtil.getRequestContext(acct));
+    hits = searchResponse.listElements(MailConstants.E_CONV);
+    assertEquals(2, hits.size(), "2 hits");
+    assertEquals(
+        msg1.getConversationId(), hits.get(0).getAttributeLong(MailConstants.A_ID), "correct hit");
+    assertEquals(
+        msg2.getConversationId(), hits.get(1).getAttributeLong(MailConstants.A_ID), "correct hit");
+  }
+
+  @Test
+  @DisplayName("Check Calendar Search returns RidZ field. Added for BUG CO-831.")
+  void shouldEncodeCalItemWithRidZField() throws Exception {
+    Map<String, Object> context = new HashMap<String, Object>();
+    ZimbraSoapContext zsc =
+        new ZimbraSoapContext(
+            AuthProvider.getAuthToken(testAccount),
+            testAccount.getId(),
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+
+    final Element createAppointmentElement =
+        Element.parseJSON(
+            new String(
+                this.getClass()
+                    .getResourceAsStream("CO-831-CalendarAppointmentRequest.json")
+                    .readAllBytes()),
+            MailConstants.CREATE_APPOINTMENT_REQUEST,
+            JSONElement.mFactory);
+    final CreateCalendarItem createCalendarItem = new CreateCalendarItem();
+    createCalendarItem.setResponseQName(MailConstants.CREATE_APPOINTMENT_REQUEST);
+    createCalendarItem.handle(createAppointmentElement, context);
+
+    final Search search = new Search();
+    final String jsonSearch =
+        new String(
+            this.getClass()
+                .getResourceAsStream("CO-831-CalendarSearchRequest.json")
+                .readAllBytes());
+    final Element searchRequestElement =
+        Element.parseJSON(jsonSearch, MailConstants.SEARCH_REQUEST, JSONElement.mFactory);
+    final Element searchResponseElement = search.handle(searchRequestElement, context);
+    Assertions.assertFalse(searchResponseElement.toString().contains("ridZ"));
+  }
 }

--- a/store/src/test/java/com/zimbra/cs/service/mail/SearchTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SearchTest.java
@@ -199,6 +199,6 @@ public class SearchTest {
     final Element searchRequestElement =
         Element.parseJSON(jsonSearch, MailConstants.SEARCH_REQUEST, JSONElement.mFactory);
     final Element searchResponseElement = search.handle(searchRequestElement, context);
-    Assertions.assertFalse(searchResponseElement.toString().contains("ridZ"));
+    Assertions.assertTrue(searchResponseElement.toString().contains("ridZ"));
   }
 }

--- a/store/src/test/resources/com/zimbra/cs/service/mail/CO-831-CalendarAppointmentRequest.json
+++ b/store/src/test/resources/com/zimbra/cs/service/mail/CO-831-CalendarAppointmentRequest.json
@@ -1,0 +1,65 @@
+{
+  "echo": "1",
+  "comp": "0",
+  "m": {
+    "e": [
+      {
+        "a": "test@test.com",
+        "p": "Test User",
+        "t": "f"
+      }
+    ],
+    "inv": {
+      "comp": [
+        {
+          "alarm": [
+            {
+              "action": "DISPLAY",
+              "trigger": {
+                "rel": {
+                  "m": "5",
+                  "related": "START",
+                  "neg": "1"
+                }
+              }
+            }
+          ],
+          "at": [],
+          "allDay": "0",
+          "fb": "B",
+          "loc": "",
+          "name": "New appointment",
+          "or": {
+            "a": "test@test.com"
+          },
+          "status": "CONF",
+          "s": {
+            "d": "20230907T110000",
+            "tz": "Europe/Rome"
+          },
+          "e": {
+            "d": "20230907T113000",
+            "tz": "Europe/Rome"
+          },
+          "class": "PUB",
+          "draft": 0
+        }
+      ]
+    },
+    "l": "10",
+    "mp": {
+      "ct": "multipart/alternative",
+      "mp": [
+        {
+          "ct": "text/html",
+          "content": "<html><body id='htmlmode'>-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-<h3>Test User have invited you to a new meeting!</h3><p>Subject: New appointment</p><p>Organizer: Test User</p><p>Location: </p><p>Time: Thursday, September 7, 2023 11:00 AM - 11:30 AM</p><p>Invitees: </p><br/>-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-"
+        },
+        {
+          "ct": "text/plain",
+          "content": "-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-\nTest User have invited you to a new meeting!\n\nSubject: New appointment \nOrganizer: \"Test User \n\nTime: Thursday, September 7, 2023 11:00 AM - 11:30 AM\n \nInvitees:  \n\n\n-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-\n"
+        }
+      ]
+    },
+    "su": "New appointment"
+  }
+}

--- a/store/src/test/resources/com/zimbra/cs/service/mail/CO-831-CalendarSearchRequest.json
+++ b/store/src/test/resources/com/zimbra/cs/service/mail/CO-831-CalendarSearchRequest.json
@@ -1,0 +1,12 @@
+{
+  "_jsns": "urn:zimbraMail",
+  "limit": "500",
+  "calExpandInstEnd": 1696543200000,
+  "calExpandInstStart": 1691272800000,
+  "offset": 0,
+  "sortBy": "none",
+  "types": "appointment",
+  "query": {
+    "_content": "test"
+  }
+}


### PR DESCRIPTION
The field ridZ is missing from SearchResponse when making a SearchRequest for appointments.
The bug was introduced in: 0a265ebd7ba819ab3d04e4ef41dd7db07113870e
This breaks the UI.

I have added a test to create the appointment and call a search. Requests body were taken directly from affected Carbonio instances for simplicity with some changes in user of course.