### PR TITLE
chore: IN-620: use syft and dependency-track platform for SBOM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 def mvnCmd(String cmd) {
     def extraOptions = ''
-    if (env.BRANCH_NAME == 'main') {
-        extraOptions = '-Ddependency-check.skip=false'
-    }
-  sh 'mvn -B -s settings-jenkins.xml ' + extraOptions + ' ' + cmd
+    sh 'mvn -B -s settings-jenkins.xml ' + extraOptions + ' ' + cmd
 }
 pipeline {
     agent {
@@ -35,6 +32,23 @@ pipeline {
                 withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
                   sh "cp ${SETTINGS_PATH} settings-jenkins.xml"
                 }
+            }
+        }
+        stage("Generate SBOM and submit"){
+            when {
+                anyOf {
+                    branch 'main'
+                }
+            }
+            steps{
+                sh '''
+                    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b .
+                    ./syft . -o cyclonedx-json=sbom.cyclonedx.json
+                '''
+                dependencyTrackPublisher artifact: 'sbom.cyclonedx.json',
+                    synchronous: false,
+                    projectName: 'carbonio-mailbox',
+                    projectVersion: 'rc'
             }
         }
         stage('Build') {
@@ -71,7 +85,7 @@ pipeline {
                 }
             steps {
                 withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                    mvnCmd("$BUILD_PROPERTIES_PARAMS -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html sonar:sonar")
+                    mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar")
                 }
             }
         }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -78,10 +78,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -197,10 +197,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
       <!-- Analyze dependencies -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -15,10 +15,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -868,8 +868,6 @@
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <revision>23.9.0</revision>
     <mockserver.version>5.13.0</mockserver.version>
-    <!-- Skip Dependency check by default -->
-    <dependency-check.skip>true</dependency-check.skip>
   </properties>
   <version>${revision}</version>
   <profiles>
@@ -952,22 +950,6 @@
           <artifactId>maven-antrun-plugin</artifactId>
           <groupId>org.apache.maven.plugins</groupId>
           <version>3.1.0</version>
-        </plugin>
-        <!-- Dependency Checker -->
-        <plugin>
-          <groupId>org.owasp</groupId>
-          <artifactId>dependency-check-maven</artifactId>
-          <version>8.2.1</version>
-          <configuration>
-            <outputDirectory>${dependency.check.report.dir}</outputDirectory>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>aggregate</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <!-- Testing -->
         <plugin>
@@ -1166,10 +1148,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -108,10 +108,6 @@
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/store-conf/pom.xml
+++ b/store-conf/pom.xml
@@ -7,10 +7,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>

--- a/store-extra-runtime-dependencies/pom.xml
+++ b/store-extra-runtime-dependencies/pom.xml
@@ -165,10 +165,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -502,10 +502,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
       <!-- This is a hack: some code is generated from same module, so we compile, generate code,
         compile again, run tests, etc. TODO: find a way to move generator classes on another module -->
       <plugin>


### PR DESCRIPTION
here  reported version is statically set as 'rc'.
Scanning is done on main branch as requested in our meetings (see the ticket for details).
Waiting for suggestion for a better version number usage (maybe retrieved from the pom.xml?)