### PR TITLE
feat: [CO-824] add 127.0.0.1 to MailTrustedIP to prevent loss of OIP

### DIFF
--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -4744,6 +4744,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr id="1025" name="zimbraMailTrustedIP" type="string" cardinality="multi" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mailbox" since="5.0.17">
+  <globalConfigValue>127.0.0.1</globalConfigValue>
   <desc>
     In our web app, AJAX and standard html client, we have support for adding the HTTP
     client IP address as X-Originating-IP in an outbound message.  We also use

--- a/store/ldap/src/updates/attrs/1694605275.json
+++ b/store/ldap/src/updates/attrs/1694605275.json
@@ -1,0 +1,5 @@
+{
+  "zimbra_globalconfig": [
+    "zimbraMailTrustedIP"
+  ]
+}

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -32039,7 +32039,7 @@ public abstract class ZAttrConfig extends Entry {
      */
     @ZAttr(id=1025)
     public String[] getMailTrustedIP() {
-        return getMultiAttr(ZAttrProvisioning.A_zimbraMailTrustedIP, true, true);
+        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraMailTrustedIP, true, true); return value.length > 0 ? value : new String[] {"127.0.0.1"};
     }
 
     /**

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -18487,7 +18487,7 @@ public abstract class ZAttrServer extends NamedEntry {
      */
     @ZAttr(id=1025)
     public String[] getMailTrustedIP() {
-        return getMultiAttr(ZAttrProvisioning.A_zimbraMailTrustedIP, true, true);
+        String[] value = getMultiAttr(ZAttrProvisioning.A_zimbraMailTrustedIP, true, true); return value.length > 0 ? value : new String[] {"127.0.0.1"};
     }
 
     /**


### PR DESCRIPTION
**What has changed:**
- added 127.0.0.1 as default value in globalConf for zimbraMailTrustedIP
- provide migration