### PR TITLE
feat: [CO-825] add attribute to manage ClamAv ReadTimeout

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2871,6 +2871,15 @@ public class ZAttrProvisioning {
     public static final String A_carbonioClamAVDatabaseCustomURL = "carbonioClamAVDatabaseCustomURL";
 
     /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public static final String A_carbonioClamAVReadTimeout = "carbonioClamAVReadTimeout";
+
+    /**
      * Whether the Chat App usages enabled for account or COS
      *
      * @since ZCS 23.1.0

--- a/store/conf/attrs/attrs.xml
+++ b/store/conf/attrs/attrs.xml
@@ -10118,4 +10118,9 @@ TODO: delete them permanently from here
 <attr id="3139" name="carbonioAdminUILogoutURL" type="string" max="256" cardinality="single" optionalIn="globalConfig,domain" flags="domainInfo,domainAdminModifiable" requiresRestart="nginxproxy" since="23.10.0">
   <desc>Logout URL for Carbonio Admin web client to send the user to upon explicit logging out</desc>
 </attr>
+
+<attr id="3140" name="carbonioClamAVReadTimeout" type="integer" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited" requiresRestart="mta,antivirus" since="23.11.0">
+  <globalConfigValue>900</globalConfigValue>
+  <desc>Waiting for data from a client socket connected to ClamAV will timeout after this time (seconds)</desc>
+</attr>
 </attrs>

--- a/store/ldap/src/updates/attrs/1697206170.json
+++ b/store/ldap/src/updates/attrs/1697206170.json
@@ -1,0 +1,5 @@
+{
+  "zimbra_globalconfig": [
+    "carbonioClamAVReadTimeout"
+  ]
+}

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -1375,6 +1375,83 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @return carbonioClamAVReadTimeout, or 900 if unset
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public int getCarbonioClamAVReadTimeout() {
+        return getIntAttr(ZAttrProvisioning.A_carbonioClamAVReadTimeout, 900, true);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param carbonioClamAVReadTimeout new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public void setCarbonioClamAVReadTimeout(int carbonioClamAVReadTimeout) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, Integer.toString(carbonioClamAVReadTimeout));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param carbonioClamAVReadTimeout new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public Map<String,Object> setCarbonioClamAVReadTimeout(int carbonioClamAVReadTimeout, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, Integer.toString(carbonioClamAVReadTimeout));
+        return attrs;
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public void unsetCarbonioClamAVReadTimeout() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public Map<String,Object> unsetCarbonioClamAVReadTimeout(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, "");
+        return attrs;
+    }
+
+    /**
      * Logo URL for domain
      *
      * @return carbonioLogoUrl, or "https://www.zextras.com" if unset

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -227,6 +227,83 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @return carbonioClamAVReadTimeout, or 900 if unset
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public int getCarbonioClamAVReadTimeout() {
+        return getIntAttr(ZAttrProvisioning.A_carbonioClamAVReadTimeout, 900, true);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param carbonioClamAVReadTimeout new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public void setCarbonioClamAVReadTimeout(int carbonioClamAVReadTimeout) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, Integer.toString(carbonioClamAVReadTimeout));
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param carbonioClamAVReadTimeout new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public Map<String,Object> setCarbonioClamAVReadTimeout(int carbonioClamAVReadTimeout, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, Integer.toString(carbonioClamAVReadTimeout));
+        return attrs;
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public void unsetCarbonioClamAVReadTimeout() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * Waiting for data from a client socket connected to ClamAV will timeout
+     * after this time (seconds)
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 23.11.0
+     */
+    @ZAttr(id=3140)
+    public Map<String,Object> unsetCarbonioClamAVReadTimeout(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioClamAVReadTimeout, "");
+        return attrs;
+    }
+
+    /**
      * RFC2256: common name(s) for which the entity is known by
      *
      * @return cn, or null if unset


### PR DESCRIPTION
**What has changed:**
- added `carbonioClamAVReadTimeout` to manage ClamAv socket read timeout in seconds. Attribute is optional in globalConf and server. Is supposed to be used in clamd.conf template.

**Related PRs:**
- https://github.com/zextras/carbonio-mta/pull/8
- https://github.com/zextras/carbonio-ldap-utilities/pull/58
- https://github.com/zextras/carbonio-amavis/pull/7