### PR TITLE
feat: [COR-975] define domain admin rights

### DIFF
--- a/store-conf/conf/rights/rights-domainadmin.xml
+++ b/store-conf/conf/rights/rights-domainadmin.xml
@@ -711,6 +711,9 @@
     <r n="domainAdminCalendarResourceRights"/>
     <r n="domainAdminDistributionListRights"/>
     <r n="domainAdminDomainRights"/>
+    <r n="set.domain.zimbraPublicServiceHostname"/>
+    <r n="set.domain.zimbraVirtualHostname"/>
+    <r n="set.domain.zimbraSSLCertificate"/>
     
     <!-- not generated, put here manually -->
     <r n="listAlias"/>

--- a/store-conf/conf/rights/rights-domainadmin.xml
+++ b/store-conf/conf/rights/rights-domainadmin.xml
@@ -714,7 +714,8 @@
     <r n="set.domain.zimbraPublicServiceHostname"/>
     <r n="set.domain.zimbraVirtualHostname"/>
     <r n="set.domain.zimbraSSLCertificate"/>
-    
+    <r n="set.domain.zimbraSSLPrivateKey"/>
+
     <!-- not generated, put here manually -->
     <r n="listAlias"/>
   </rights>

--- a/store-conf/conf/rights/rights-domainadmin.xml-template
+++ b/store-conf/conf/rights/rights-domainadmin.xml-template
@@ -177,6 +177,9 @@ ${DOMAIN_ATTRS}
     <r n="domainAdminCalendarResourceRights"/>
     <r n="domainAdminDistributionListRights"/>
     <r n="domainAdminDomainRights"/>
+    <r n="set.domain.zimbraPublicServiceHostname"/>
+    <r n="set.domain.zimbraVirtualHostname"/>
+    <r n="set.domain.zimbraSSLCertificate"/>
     
     <!-- not generated, put here manually -->
     <r n="listAlias"/>

--- a/store-conf/conf/rights/rights-domainadmin.xml-template
+++ b/store-conf/conf/rights/rights-domainadmin.xml-template
@@ -180,7 +180,8 @@ ${DOMAIN_ATTRS}
     <r n="set.domain.zimbraPublicServiceHostname"/>
     <r n="set.domain.zimbraVirtualHostname"/>
     <r n="set.domain.zimbraSSLCertificate"/>
-    
+    <r n="set.domain.zimbraSSLPrivateKey"/>
+
     <!-- not generated, put here manually -->
     <r n="listAlias"/>
   </rights>


### PR DESCRIPTION
- set zimbraSSL certificate and private key right on domainAdminRights

Instead of adding these rights to the InitDomain json call it makes more sense to define domainAdminRights as a combo with all the needed rights to avoid confusion.