### PR TITLE
chore: remove MailTrustedIP migration

### DIFF
--- a/store/ldap/src/updates/attrs/1694605275.json
+++ b/store/ldap/src/updates/attrs/1694605275.json
@@ -1,5 +1,0 @@
-{
-  "zimbra_globalconfig": [
-    "zimbraMailTrustedIP"
-  ]
-}


### PR DESCRIPTION
**What has changed:**
- removed the migration but the default value in new install will still set.

migration was added in [CO-824]

[CO-824]: https://zextras.atlassian.net/browse/CO-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ