### PR TITLE
fix: maven pom version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,6 @@
 def mvnCmd(String cmd) {
     def profile = ''
-    def revisionModifier = '-SNAPSHOT'
     if (env.BRANCH_NAME == 'main' ) {
-        revisionModifier = ''
         profile = '-Pprod'
     }
     else if (env.BRANCH_NAME == 'devel' ) {

--- a/pom.xml
+++ b/pom.xml
@@ -882,8 +882,7 @@
     <error_prone_annotations.version>2.3.2</error_prone_annotations.version>
     <jersey.version>1.11</jersey.version>
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
-    <modifier>-SNAPSHOT</modifier>
-    <revision>23.11.0${modifier}</revision>
+    <revision>23.11.0</revision>
     <mockserver.version>5.13.0</mockserver.version>
   </properties>
   <version>${revision}</version>


### PR DESCRIPTION
- remove modifier for now, maven not able to handle it
The issue is the pom is published with 23.11.0modifier (modifier is not replaced)