### PR TITLE
chore: 4.11.1

### DIFF
--- a/packages/appserver-db/PKGBUILD
+++ b/packages/appserver-db/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-appserver-db"
-pkgver="4.10.0"
+pkgver="4.11.1"
 pkgrel="1"
 pkgdesc="Carbonio Appserver DB Files"
 arch=('x86_64')


### PR DESCRIPTION
Noticed appserver-db PKGBUILD was not bumped