### PR TITLE
chore: improve build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ and their roles:
 - **store**: WAR package that defines the service. It also includes core functionalities like SOAP
 APIs, LDAP, Krb5, IMAP, POP3 and CLI functions
 
+## Generating Rights and ZAttr classes
+Whenever you make changes to [store/conf/attrs/attrs.xml](store/conf/attrs/attrs.xml)
+you can generate rights and ZAttr* classes by running:
+> mvn antrun:run@generate-zattr-rights
+
+## Generating SOAP DOCS
+> mvn antrun:run@generate-soap-docs
+
 ## Building Carbonio Mailbox from source
 
 ### 1. Build using local mvn command

--- a/soap/ant-generate-soap-docs.xml
+++ b/soap/ant-generate-soap-docs.xml
@@ -42,14 +42,14 @@
     </java>
   </target>
 
-  <target name="wsdl-file" depends="generate-schema" description="Generates WSDL file">
+  <target name="generate-wsdl" depends="generate-schema" description="Generates WSDL file">
     <mkdir dir="${xml.schema.dir}" />
     <java classname="com.zimbra.soap.util.WsdlGenerator" classpathref="class.path" fork="true" failonerror="true">
       <arg line="-output.dir ${xml.schema.dir}" />
     </java>
   </target>
 
-  <target name="generate-soap-api-doc" depends="wsdl-file">
+  <target name="generate-soap-api-doc" depends="generate-wsdl">
 
     <path id="soapdocs.doclet.class.path">
       <pathelement location="${build.classes.dir}"/>

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -165,7 +165,25 @@
               <goal>run</goal>
             </goals>
             <id>generate-soap-docs</id>
+          </execution>
+          <execution>
+            <configuration>
+              <target>
+                <property name="compile_classpath" refid="maven.compile.classpath"/>
+                <property name="runtime_classpath" refid="maven.runtime.classpath"/>
+                <property name="test_classpath" refid="maven.test.classpath"/>
+                <taskdef classpathref="maven.plugin.classpath"
+                  resource="net/sf/antcontrib/antlib.xml"/>
+                <ant antfile="${basedir}/ant-generate-soap-docs.xml">
+                  <target name="generate-wsdl"/>
+                </ant>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
             <phase>prepare-package</phase>
+            <id>generate-wsdl</id>
           </execution>
         </executions>
         <groupId>org.apache.maven.plugins</groupId>

--- a/store/ant-store.xml
+++ b/store/ant-store.xml
@@ -45,8 +45,8 @@
   </target>
 
   <target name="generate-buildinfo" depends="build-init, set-dev-version">
-    <mkdir dir="${maven.build.dir}/buildinfo/com/zimbra/cs/util"/>
-    <echo file="${maven.build.dir}/buildinfo/com/zimbra/cs/util/BuildInfoGenerated.java">
+    <mkdir dir="${maven.build.dir}/generated-sources/buildinfo/com/zimbra/cs/util"/>
+    <echo file="${maven.build.dir}/generated-sources/buildinfo/com/zimbra/cs/util/BuildInfoGenerated.java">
       package com.zimbra.cs.util;
 
       class BuildInfoGenerated {

--- a/store/ant-store.xml
+++ b/store/ant-store.xml
@@ -24,8 +24,8 @@
     </not>
   </condition>
 
-  <target name="generate-sources"
-    depends="generate-buildinfo, generate-getters,generate-rights, create-version-sql,create-version-ldap ">
+  <target name="generate-resources"
+    depends="create-version-sql, create-version-ldap ">
   </target>
 
   <!--  TODO: remove unnecessary folder-->
@@ -62,11 +62,6 @@
       public static final String HOST = "${zimbra.buildinfo.host}";
       }
     </echo>
-    <javac includeantruntime="false" destdir="${build.classes.dir}"
-      target="${javac.target}" srcdir="${maven.build.dir}/buildinfo">
-      <compilerarg value="-Xlint:deprecation"/>
-      <compilerarg value="-Xlint:unchecked"/>
-    </javac>
   </target>
 
   <!-- Cleans up store directory and maven build in maven clean phase -->
@@ -87,7 +82,10 @@
     <copy todir="${basedir}/build/zimbra/conf/" file="${basedir}/../store-conf/conf/contacts/contact-fields.xml"/>
   </target>
 
-  <target name="generate-getters" description="generate methods for attributes in attrs.xml">
+  <target name="generate-zattr-rights" description="generate ZAttr and rights"
+    depends="generate-zattr,generate-rights"/>
+
+  <target name="generate-zattr" description="generate methods for attributes in attrs.xml">
     <antcall target="generate-getter">
       <param name="getter.class" value="account"/>
       <param name="getter.output" value="ZAttrAccount.java"/>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -519,6 +519,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/buildinfo</source><!-- adjust folder name to your needs -->
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <dependencies>
           <dependency>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -518,21 +518,6 @@
 
   <build>
     <plugins>
-      <!-- This is a hack: some code is generated from same module, so we compile, generate code,
-        compile again, run tests, etc. TODO: find a way to move generator classes on another module -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>pre-compile</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Generate build-info, getters and rights -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <dependencies>
@@ -554,7 +539,7 @@
           </dependency>
         </dependencies>
         <executions>
-          <!-- generate sources -->
+          <!-- Generate Build Info -->
           <execution>
             <configuration>
               <target>
@@ -562,15 +547,32 @@
                 <taskdef classpathref="maven.plugin.classpath"
                   resource="net/sf/antcontrib/antlib.xml"/>
                 <ant antfile="${basedir}/ant-store.xml">
-                  <target name="generate-sources"/>
+                  <target name="generate-buildinfo"/>
                 </ant>
               </target>
             </configuration>
             <goals>
               <goal>run</goal>
             </goals>
-            <id>generate-buildinfo</id>
             <phase>generate-sources</phase>
+            <id>generate-buildinfo</id>
+          </execution>
+          <!-- Generate ZAttr* and Rights -->
+          <execution>
+            <configuration>
+              <target>
+                <property name="maven_compile_classpath" refid="maven.compile.classpath"/>
+                <taskdef classpathref="maven.plugin.classpath"
+                  resource="net/sf/antcontrib/antlib.xml"/>
+                <ant antfile="${basedir}/ant-store.xml">
+                  <target name="generate-zattr-rights"/>
+                </ant>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <id>generate-zattr-rights</id>
           </execution>
           <!-- LDAP Config gen before packaging -->
           <execution>


### PR DESCRIPTION
To slim down build time we decided to remove few steps:

- Avoid pre-compile (compile twice)
- Avoid generating ZAttr classes automatically (this required pre-compile to call generator classes)
- Avoid generating soap docs. Only WSDL is generated

Added:
- generate BuildInfo class during generate-sources
- in README.md instructions on how to generate rights and ZAttr manually after attrs.xml has been modified (tested)
- in README.md instructions on how to generate soap docs
