### PR TITLE
chore: fix directory-server config files location

### DIFF
--- a/packages/directory-server/PKGBUILD
+++ b/packages/directory-server/PKGBUILD
@@ -59,9 +59,9 @@ package() {
   install -D store/ldap/src/migrations/migrate-23.5.0-01-COS-AddFeatures.pl \
     "${pkgdir}/opt/zextras/libexec/scripts/migrate-23.5.0-01-COS-AddFeatures.pl"
 
-  install -Ddm755 store/build/ldap \
-    "${pkgdir}/opt/zextras/common/etc/openldap/zimbra"
-  rsync -a store/build/ldap "${pkgdir}/opt/zextras/common/etc/openldap/zimbra"
+  install -Ddm755 store/build/ldap/ \
+    "${pkgdir}/opt/zextras/common/etc/openldap/zimbra/"
+  rsync -a store/build/ldap/ "${pkgdir}/opt/zextras/common/etc/openldap/zimbra/"
 }
 
 postinst__apt() {


### PR DESCRIPTION
- fixed an issue with rsync that was copying the ldap directory, resulting in /opt/zextras/common/etc/openldap/zimbra/ldap/