### PR TITLE
chore: [CO-925] upgrade curator-recipes to 5.5.0

### DIFF
--- a/packages/common-core-libs/PKGBUILD
+++ b/packages/common-core-libs/PKGBUILD
@@ -59,8 +59,8 @@ package() {
   install -D carbonio-jetty-libs/target/dependencies/concurrentlinkedhashmap-lru-1.3.1.jar \
     "${pkgdir}/opt/zextras/lib/jars/concurrentlinkedhashmap-lru-1.3.1.jar"
 
-  install -D carbonio-jetty-libs/target/dependencies/curator-recipes-2.0.1-incubating.jar \
-    "${pkgdir}/opt/zextras/lib/jars/curator-recipes-2.0.1-incubating.jar"
+  install -D carbonio-jetty-libs/target/dependencies/curator-recipes-5.5.0.jar \
+    "${pkgdir}/opt/zextras/lib/jars/curator-recipes-5.5.0.jar"
 
   install -D carbonio-jetty-libs/target/dependencies/cxf-core-3.3.4.jar \
     "${pkgdir}/opt/zextras/lib/jars/cxf-core-3.3.4.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-recipes</artifactId>
-        <version>2.0.1-incubating</version>
+        <version>5.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This is to prevent multiple bindings for SLF4J, new version of curator-recipes do not bring log4j as dependency.

see: CO-925 for more info.
