### PR TITLE
chore: add zm-charset as test dependency to fix imap-utf-7 warnings

### DIFF
--- a/carbonio-jetty-libs/pom.xml
+++ b/carbonio-jetty-libs/pom.xml
@@ -733,7 +733,6 @@
     <dependency>
       <groupId>zimbra</groupId>
       <artifactId>zm-charset</artifactId>
-      <version>22.5.0</version>
     </dependency>
     <dependency>
       <groupId>zimbra</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -836,6 +836,11 @@
         <artifactId>mariadb-java-client</artifactId>
         <version>${mariadb-java-client.version}</version>
       </dependency>
+      <dependency>
+        <groupId>zimbra</groupId>
+        <artifactId>zm-charset</artifactId>
+        <version>22.5.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -207,6 +207,12 @@
     </dependency>
 
     <dependency>
+      <artifactId>zm-charset</artifactId>
+      <groupId>zimbra</groupId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <artifactId>commons-compress</artifactId>
       <groupId>org.apache.commons</groupId>
     </dependency>


### PR DESCRIPTION
- Noticed during tests lots of logs about missing imap-utf-7 which is provided in jetty-libs by zm-charset at runtime (provided) but missing during test executions