### PR TITLE
Fix (CO-933): make SearchDirectory response isMore and searchTotal fields properly work

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/admin/SearchDirectory.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/SearchDirectory.java
@@ -178,7 +178,7 @@ public class SearchDirectory extends AdminDocumentHandler {
             accounts = session.searchDirectory(options, offset, rightChecker);
         } else {
             accounts = prov.searchDirectory(options);
-            accounts = rightChecker.getAllowed(accounts, limitMax);
+            accounts = rightChecker.getAllowed(accounts, accounts.size());
         }
 
         if (isCountOnly) {

--- a/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static com.zextras.mailbox.util.MailboxTestUtil.DEFAULT_DOMAIN;
 import static com.zimbra.common.soap.Element.parseXML;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("api")
 class SearchDirectoryTest extends SoapTestSuite {
@@ -71,8 +71,8 @@ class SearchDirectoryTest extends SoapTestSuite {
     SearchDirectoryResponse firstPageResponse = parseSoapResponse(firstPageHttpResponse);
     assertEquals(1, firstPageResponse.getAccounts().size());
     assertEquals(adminAccount.getName(), firstPageResponse.getAccounts().get(0).getName());
-//    assertTrue(firstPageResponse.isMore());
-//    assertEquals(3, firstPageResponse.getSearchTotal());
+    assertEquals(3, firstPageResponse.getSearchTotal());
+    assertTrue(firstPageResponse.isMore());
   }
 
   @Test
@@ -86,8 +86,8 @@ class SearchDirectoryTest extends SoapTestSuite {
     SearchDirectoryResponse secondPageResponse = parseSoapResponse(secondPageHttpResponse);
     assertEquals(1, secondPageResponse.getAccounts().size());
     assertEquals(firstAccount.getName(), secondPageResponse.getAccounts().get(0).getName());
-//    assertTrue(secondPageResponse.isMore());
-//    assertEquals(3, secondPageResponse.getSearchTotal());
+    assertEquals(3, secondPageResponse.getSearchTotal());
+    assertTrue(secondPageResponse.isMore());
   }
 
   @Test
@@ -101,14 +101,9 @@ class SearchDirectoryTest extends SoapTestSuite {
     SearchDirectoryResponse lastPageResponse = parseSoapResponse(lastPageHttpResponse);
     assertEquals(1, lastPageResponse.getAccounts().size());
     assertEquals(secondAccount.getName(), lastPageResponse.getAccounts().get(0).getName());
-//    assertFalse(secondPageResponse.isMore());
-//    assertEquals(3, secondPageResponse.getSearchTotal());
+    assertEquals(3, lastPageResponse.getSearchTotal());
+    assertFalse(lastPageResponse.isMore());
   }
-
-  // TEST CASES:
-  // pagination (more and searchTotal should have the bug)
-  // read some attributes
-  // sorting
 
   private static SearchDirectoryResponse parseSoapResponse(HttpResponse httpResponse) throws IOException, ServiceException {
     final String responseBody = EntityUtils.toString(httpResponse.getEntity());

--- a/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
@@ -9,6 +9,7 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.message.SearchDirectoryRequest;
 import com.zimbra.soap.admin.message.SearchDirectoryResponse;
+import com.zimbra.soap.admin.type.AccountInfo;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
@@ -17,7 +18,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
 
+import static com.zextras.mailbox.util.MailboxTestUtil.DEFAULT_DOMAIN;
 import static com.zimbra.common.soap.Element.parseXML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -29,23 +33,35 @@ class SearchDirectoryTest extends SoapTestSuite {
   @BeforeAll
   static void setUp() throws Exception {
     provisioning = Provisioning.getInstance();
+    provisioning.createDomain("different.com", new HashMap<>());
     accountCreatorFactory = new AccountCreator.Factory(provisioning);
   }
 
   @Test
-  void todo() throws Exception {
-    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
-    String domain = adminAccount.getDomainName();
+  void searchAccountsInADomain() throws Exception {
+    Account adminAccount = newAccountOn(DEFAULT_DOMAIN).withUsername("admin.account").asGlobalAdmin().create();
+    Account normalAccount = newAccountOn(DEFAULT_DOMAIN).withUsername("normal.account").create();
+    newAccountOn("different.com").withUsername("different.account").create();
 
     final HttpResponse httpResponse = getSoapClient().newRequest()
         .setCaller(adminAccount)
-        .setSoapBody(searchAccountsByDomain(domain))
+        .setSoapBody(searchAccountsByDomain(DEFAULT_DOMAIN))
         .execute();
 
     assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
     SearchDirectoryResponse response = parseSoapResponse(httpResponse);
-    assertEquals(1, response.getAccounts().size());
+    List<AccountInfo> accounts = response.getAccounts();
+    assertEquals(1 + 1, accounts.size());
+    assertEquals(adminAccount.getId(), accounts.get(0).getId());
+    assertEquals("admin.account@" + DEFAULT_DOMAIN, accounts.get(0).getName());
+    assertEquals(normalAccount.getId(), accounts.get(1).getId());
+    assertEquals("normal.account@" + DEFAULT_DOMAIN, accounts.get(1).getName());
   }
+
+  // TEST CASES:
+  // read some attributes
+  // sorting
+  // pagination (more and searchTotal should have the bug)
 
   private static SearchDirectoryResponse parseSoapResponse(HttpResponse httpResponse) throws IOException, ServiceException {
     final String responseBody = EntityUtils.toString(httpResponse.getEntity());
@@ -57,38 +73,12 @@ class SearchDirectoryTest extends SoapTestSuite {
     SearchDirectoryRequest request = new SearchDirectoryRequest();
     request.setDomain(domain);
     request.setTypes("accounts");
-    request.setAttrs("mail");
+    request.setAttrs("");
     return request;
   }
 
-//  @Test
-//  void shouldRenameAccountByChangingOnlyDomain() throws Exception {
-//    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
-//    final String accountName = UUID.randomUUID().toString();
-//    Account userAccount = accountCreatorFactory.get().withUsername(accountName).create();
-//    final Domain newDomain = provisioning.createDomain("myDomain.com", new HashMap<>());
-//
-//    RenameAccountRequest request =
-//        new RenameAccountRequest(userAccount.getId(), accountName + "@" + newDomain.getName());
-//    final HttpResponse response =
-//        getSoapClient().newRequest().setCaller(adminAccount).setSoapBody(request).execute();
-//
-//    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-//  }
-//
-//  @Test
-//  void shouldThrowNoSuchDomainWhenRenamingToNotExistingDomain() throws Exception {
-//    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
-//    final String accountName = UUID.randomUUID().toString();
-//    Account userAccount = accountCreatorFactory.get().withUsername(accountName).create();
-//
-//    RenameAccountRequest request =
-//        new RenameAccountRequest(userAccount.getId(), accountName + "@" + UUID.randomUUID() + ".com");
-//    final HttpResponse response =
-//        getSoapClient().newRequest().setCaller(adminAccount).setSoapBody(request).execute();
-//
-//    Assertions.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusLine().getStatusCode());
-//    final String responseBody = EntityUtils.toString(response.getEntity());
-//    Assertions.assertTrue(responseBody.contains(ERROR_CODE_NO_SUCH_DOMAIN));
-//  }
+  private static AccountCreator newAccountOn(String domain) {
+    return accountCreatorFactory.get().withDomain(domain);
+  }
+
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/SearchDirectoryTest.java
@@ -1,0 +1,94 @@
+package com.zimbra.cs.service.admin;
+
+import com.zextras.mailbox.soap.SoapTestSuite;
+import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.admin.message.SearchDirectoryRequest;
+import com.zimbra.soap.admin.message.SearchDirectoryResponse;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.zimbra.common.soap.Element.parseXML;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("api")
+class SearchDirectoryTest extends SoapTestSuite {
+  private static AccountCreator.Factory accountCreatorFactory;
+  private static Provisioning provisioning;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    provisioning = Provisioning.getInstance();
+    accountCreatorFactory = new AccountCreator.Factory(provisioning);
+  }
+
+  @Test
+  void todo() throws Exception {
+    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
+    String domain = adminAccount.getDomainName();
+
+    final HttpResponse httpResponse = getSoapClient().newRequest()
+        .setCaller(adminAccount)
+        .setSoapBody(searchAccountsByDomain(domain))
+        .execute();
+
+    assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
+    SearchDirectoryResponse response = parseSoapResponse(httpResponse);
+    assertEquals(1, response.getAccounts().size());
+  }
+
+  private static SearchDirectoryResponse parseSoapResponse(HttpResponse httpResponse) throws IOException, ServiceException {
+    final String responseBody = EntityUtils.toString(httpResponse.getEntity());
+    final Element rootElement = parseXML(responseBody).getElement("Body").getElement("SearchDirectoryResponse");
+    return JaxbUtil.elementToJaxb(rootElement, SearchDirectoryResponse.class);
+  }
+
+  private static SearchDirectoryRequest searchAccountsByDomain(String domain) {
+    SearchDirectoryRequest request = new SearchDirectoryRequest();
+    request.setDomain(domain);
+    request.setTypes("accounts");
+    request.setAttrs("mail");
+    return request;
+  }
+
+//  @Test
+//  void shouldRenameAccountByChangingOnlyDomain() throws Exception {
+//    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
+//    final String accountName = UUID.randomUUID().toString();
+//    Account userAccount = accountCreatorFactory.get().withUsername(accountName).create();
+//    final Domain newDomain = provisioning.createDomain("myDomain.com", new HashMap<>());
+//
+//    RenameAccountRequest request =
+//        new RenameAccountRequest(userAccount.getId(), accountName + "@" + newDomain.getName());
+//    final HttpResponse response =
+//        getSoapClient().newRequest().setCaller(adminAccount).setSoapBody(request).execute();
+//
+//    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+//  }
+//
+//  @Test
+//  void shouldThrowNoSuchDomainWhenRenamingToNotExistingDomain() throws Exception {
+//    Account adminAccount = accountCreatorFactory.get().asGlobalAdmin().create();
+//    final String accountName = UUID.randomUUID().toString();
+//    Account userAccount = accountCreatorFactory.get().withUsername(accountName).create();
+//
+//    RenameAccountRequest request =
+//        new RenameAccountRequest(userAccount.getId(), accountName + "@" + UUID.randomUUID() + ".com");
+//    final HttpResponse response =
+//        getSoapClient().newRequest().setCaller(adminAccount).setSoapBody(request).execute();
+//
+//    Assertions.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusLine().getStatusCode());
+//    final String responseBody = EntityUtils.toString(response.getEntity());
+//    Assertions.assertTrue(responseBody.contains(ERROR_CODE_NO_SUCH_DOMAIN));
+//  }
+}


### PR DESCRIPTION
We fixed the behaviour of SearchDirectory command:
- now the 'more' field that tell if there are more pages other than the current is working
- now the 'searchTotal' field provides the correct total items

The current behaviour mimics the one present in the GetQuotaUsage command