### PR TITLE
fix: [CO-863] Missing log4j class using zmproxypurge

### DIFF
--- a/packages/appserver-store-libs/PKGBUILD
+++ b/packages/appserver-store-libs/PKGBUILD
@@ -139,8 +139,8 @@ package() {
     "${pkgdir}/opt/zextras/jetty_base/common/lib/owasp-java-html-sanitizer-20191001.1.jar"
   install -D carbonio-jetty-libs/target/dependencies/slf4j-api-1.7.36.jar \
     "${pkgdir}/opt/zextras/jetty_base/common/lib/slf4j-api-1.7.36.jar"
-  install -D carbonio-jetty-libs/target/dependencies/spymemcached-2.12.1.jar \
-    "${pkgdir}/opt/zextras/jetty_base/common/lib/spymemcached-2.12.1.jar"
+  install -D carbonio-jetty-libs/target/dependencies/spymemcached-2.12.3.jar \
+    "${pkgdir}/opt/zextras/jetty_base/common/lib/spymemcached-2.12.3.jar"
   install -D carbonio-jetty-libs/target/dependencies/sshd-common-2.7.0.jar \
     "${pkgdir}/opt/zextras/jetty_base/common/lib/sshd-common-2.7.0.jar"
   install -D carbonio-jetty-libs/target/dependencies/sshd-core-2.7.0.jar \

--- a/packages/common-core-libs/PKGBUILD
+++ b/packages/common-core-libs/PKGBUILD
@@ -197,8 +197,8 @@ package() {
   install -D carbonio-jetty-libs/target/dependencies/slf4j-api-1.7.36.jar \
     "${pkgdir}/opt/zextras/lib/jars/slf4j-api-1.7.36.jar"
 
-  install -D carbonio-jetty-libs/target/dependencies/spymemcached-2.12.1.jar \
-    "${pkgdir}/opt/zextras/lib/jars/spymemcached-2.12.1.jar"
+  install -D carbonio-jetty-libs/target/dependencies/spymemcached-2.12.3.jar \
+    "${pkgdir}/opt/zextras/lib/jars/spymemcached-2.12.3.jar"
   install -D carbonio-jetty-libs/target/dependencies/jedis-2.9.0.jar \
     "${pkgdir}/opt/zextras/lib/jars/jedis-2.9.0.jar"
   install -D carbonio-jetty-libs/target/dependencies/commons-pool2-2.4.2.jar \

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
       <dependency>
         <groupId>net.spy</groupId>
         <artifactId>spymemcached</artifactId>
-        <version>2.12.1</version>
+        <version>2.12.3</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>

--- a/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
@@ -4,17 +4,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 package com.zimbra.cs.util;
-import com.zimbra.common.util.ZimbraLog;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.CliUtil;
 import com.zimbra.common.util.memcached.ZimbraMemcachedClient;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.GnuParser;
-import org.apache.commons.cli.ParseException;
-import java.util.*;
-import java.io.*;
-
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
@@ -24,425 +19,454 @@ import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapServerType;
 import com.zimbra.cs.ldap.LdapUsage;
 import com.zimbra.cs.ldap.ZLdapContext;
-import com.zimbra.common.account.Key;
-import com.zimbra.common.account.Key.DomainBy;
-import com.zimbra.common.service.ServiceException;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** @author mansoor peerbhoy 
+/**
+ * @author mansoor peerbhoy
  */
-public class ProxyPurgeUtil
-{
-    static final String memcachedPort = "11211";
-    
-    public static void main (String[] args) throws ServiceException
-    {
-        CommandLine         commandLine;
-        ArrayList<String>   servers;
-        ArrayList<String>   accounts;
-        String              outputformat;
-        boolean             purge = false;
-        Provisioning        prov;
-        List<Server>        memcachedServers;
-        String              logLevel = "ERROR";
+public class ProxyPurgeUtil {
 
-        /* Parse the command-line arguments, and display usage if necessary */
-        try {
-            commandLine = parseCommandLine (args);
-        } catch (ParseException pe) {
-            commandLine = null;
-        }
+  static final String MEMCACHED_PORT = "11211";
+  private static final Logger LOG = LoggerFactory.getLogger(ProxyPurgeUtil.class);
 
-        if ((commandLine == null) || 
-            commandLine.hasOption ("h") || 
-            commandLine.hasOption ("u")
-           ) {
-            usage ();
-            System.exit (1);
-        }
 
-        if (commandLine.hasOption("v")) { logLevel = "DEBUG"; }
-        ZimbraLog.toolSetupLog4j (logLevel, null, false);
+  public static void main(String[] args) throws ServiceException {
+    CommandLine commandLine;
+    ArrayList<String> servers;
+    ArrayList<String> accounts;
+    String outputFormat;
+    boolean purge;
+    Provisioning prov;
+    List<Server> memcachedServers;
+    String logLevel = "INFO";
 
-        /* Initialize the logging system and the zimbra environment */
-        prov = Provisioning.getInstance();
+    /* Parse the command-line arguments, and display usage if necessary */
+    try {
+      commandLine = parseCommandLine(args);
+      if (commandLine.hasOption("v")) {
+        logLevel = "DEBUG";
+      }
+      CliUtil.toolSetup(logLevel);
+    } catch (ParseException pe) {
+      commandLine = null;
+    }
+
+    if ((commandLine == null) || commandLine.hasOption("h") || commandLine.hasOption("u")) {
+      usage();
+      System.exit(1);
+    }
+
+    /* Initialize the logging system and the zimbra environment */
+    prov = Provisioning.getInstance();
 
         /* Get the list of servers running the memcached service
            this is equivalent to the $(zmprov gamcs) command
          */
-        memcachedServers = prov.getAllServers(Provisioning.SERVICE_MEMCACHED);
-        servers = new ArrayList <String> ();
+    memcachedServers = prov.getAllServers(Provisioning.SERVICE_MEMCACHED);
+    servers = new ArrayList<>();
 
-        for (Iterator<Server> it=memcachedServers.iterator(); it.hasNext();) {
-            Server s = it.next();
-            String serverName = s.getAttr (Provisioning.A_zimbraMemcachedBindAddress, "localhost");
-            String servicePort = s.getAttr (Provisioning.A_zimbraMemcachedBindPort, memcachedPort);
-            servers.add (serverName + ":" + servicePort);
-        }
+    for (Server s : memcachedServers) {
+      String serverName = s.getAttr(ZAttrProvisioning.A_zimbraMemcachedBindAddress, "localhost");
+      String servicePort = s.getAttr(ZAttrProvisioning.A_zimbraMemcachedBindPort,
+          MEMCACHED_PORT);
+      servers.add(serverName + ":" + servicePort);
+    }
 
-        accounts = getAccounts (commandLine);
-        servers.addAll (getCacheServers (commandLine));
+    accounts = getAccounts(commandLine);
+    servers.addAll(getCacheServers(commandLine));
 
-        if (servers.size() == 0) {
-            System.err.println ("No memcached servers found, and none specified (--help for help)");
-            System.exit (1);
-        }
+    if (servers.isEmpty()) {
+      LOG.error("No memcached servers found, and none specified (--help for help)");
+      System.exit(1);
+    }
 
-        if (accounts.size() == 0) {
-            System.err.println ("No accounts specified (--help for help)");
-            System.exit (1);
-        }
+    if (accounts.isEmpty()) {
+      LOG.error("No accounts specified (--help for help)");
+      System.exit(1);
+    }
 
-        /* Assume purge unless `-i' is specified */
+    /* Assume purge unless `-i' is specified */
         /* -i (info) indicates that account route info should be printed
         -p (purge) indicates that account route info should be purged
         */
-        purge = (commandLine.hasOption ("i") == false);
+    purge = (!commandLine.hasOption("i"));
 
-        /* parse the format string */
-        if (commandLine.hasOption ("o")) {
-            outputformat = commandLine.getOptionValue ("o");
-        } else {
-            outputformat = "[%1$s] %2$s -- %3$s";
-        }
-        
-        purgeAccounts(servers, accounts, purge, outputformat);
-    }
-    
-    /**
-     * Purges or, prints all the routes for the accounts supplied. 
-     * @param servers list of memcached servers supplied, if null the function gets all the  
-     *                memcached servers from provisioning
-     * @param accounts list of accounts (qualified or, unqualified)
-     * @param purge true for the account routes purging, false for printing the routes
-     * @param outputformat format of the output in case of printing
-     * @throws ServiceException 
-     */
-    public static void purgeAccounts(List<String> servers, List<String> accounts, boolean purge, String outputformat) throws ServiceException {
-        
-        Provisioning prov = Provisioning.getInstance();
-        
-        // Some sanity checks. 
-        if (accounts == null || accounts.isEmpty()) {
-            System.err.println("No account supplied");
-            System.exit(1);
-        }
-        
-        if (!purge) {
-            // the outputformat must be supplied. 
-            if (outputformat == null || outputformat.length() == 0) {
-                System.err.println("outputformat must be supplied for info");
-                System.exit(1);
-            }
-        }
-        
-        if (servers == null) {
-            List<Server> memcachedServers = prov.getAllServers(Provisioning.SERVICE_MEMCACHED);
-            servers = new ArrayList<String> ();
-            
-            for (Iterator<Server> it=memcachedServers.iterator(); it.hasNext();) {
-                Server s = it.next();
-                String serverName = s.getAttr (Provisioning.A_zimbraMemcachedBindAddress, "localhost");
-                String servicePort = s.getAttr (Provisioning.A_zimbraMemcachedBindPort, memcachedPort);
-                servers.add (serverName + ":" + servicePort);
-            }
-            
-        }
-        
-        // Connect to all memcached servers.
-        int numServers = servers.size();
-        ArrayList<ZimbraMemcachedClient> zmcs = new ArrayList<ZimbraMemcachedClient>();
-        
-        for (int i = 0; i < numServers; ++i) {
-            ZimbraMemcachedClient zmc = new ZimbraMemcachedClient();
-            zmc.connect(new String[] { servers.get(i) }, false, null, 0, 5000);
-            zmcs.add(zmc);
-        }
-        
-        for (String a: accounts) {
-            // Bug 24463
-            // The route keying in memcached is governed by the following rules: 
-            // 1. if login name is fully qualified, use that as the route key
-            // 2. otherwise, if memcache_entry_allow_unqualified is true, then use the bare login as the route key
-            // 3. else, append the IP address of the proxy interface to the login and use that as the route key
-            // 4. for the login store all the user's alias, append the ip address of the proxy interface. 
-            //
-            // For accounts authenticating without domain, NGINX internally suffixes @domain
-            // to the login name, by first looking up an existing domain by the IP address of
-            // the proxy interface where the connection came in. If no such domain is found,
-            // then NGINX falls back to the default domain name specified by the config
-            // attribute zimbraDefaultDomainName.
-            // The IP to domain mapping is done based on the zimbraVirtualIPAddress attribute
-            // of the domain (The IP-to-domain mapping is a many-to-one relationship.) 
-            //
-            // For the zmproxypurge utility if the account supplied (-a option) is:
-            //    1. For fully qualified account with @domain; it will find all the virtual IP
-            //        addresses for that domain and will delete all the entries on all memcached servers:
-            //        i) with the user@domain (case 1 as described above) 
-            //        ii) with just the user (case 2 as described above) 
-            //        iii) with all the virtual IP addresses configured for the domain
-            //        iv) find all the alias for the account and repeat (i) to (iii) 
-            //    2. For the account supplied with the IP address; the utility will only try to
-            //       purge the entries with the user@IP. 
-            //    3. If there is a single domain and the account supplied is not fully qualified;
-            //       the utility will append the default domain to that entry and will execute step 1.
-            //       (In this case the provisioning lookup will return the correct domain)
-                        
-            ArrayList<String> routes = new ArrayList<String> ();
-            
-            // Lookup the account; at this point we don't whether the user is fully qualified.
-            Account account = prov.get(Key.AccountBy.name, a);
-            if (account == null) {
-                // In this case just purge the entries with the given account name as supplied.
-                System.out.println("error looking up accout: " + a);
-                routes.add("route:proto=http;user=" + a);
-                routes.add("route:proto=imap;user=" + a);
-                routes.add("route:proto=pop3;user=" + a);
-                routes.add("route:proto=httpssl;user=" + a);
-                routes.add("route:proto=imapssl;user=" + a);
-                routes.add("route:proto=pop3ssl;user=" + a);
-            } else {
-                String uid = account.getUid();
-                routes.add("route:proto=http;id=" + account.getId());
-                routes.add("route:proto=http;user=" + uid);
-                routes.add("route:proto=imap;user=" + uid);
-                routes.add("route:proto=pop3;user=" + uid);
-                routes.add("route:proto=httpssl;id=" + account.getId());
-                routes.add("route:proto=httpssl;user=" + uid);
-                routes.add("route:proto=imapssl;user=" + uid);
-                routes.add("route:proto=pop3ssl;user=" + uid);
-                routes.add("route:proto=httpssl;admin=1;id=" + account.getId());
-
-                String domain = account.getDomainName();
-                routes.add("route:proto=http;user=" + uid + "@" + domain);
-                routes.add("route:proto=imap;user=" + uid + "@" + domain);
-                routes.add("route:proto=pop3;user=" + uid + "@" + domain);
-                routes.add("route:proto=httpssl;user=" + uid + "@" + domain);
-                routes.add("route:proto=imapssl;user=" + uid + "@" + domain);
-                routes.add("route:proto=pop3ssl;user=" + uid + "@" + domain);
-                routes.add("alias:user=" + uid + ";ip=" + domain);
-
-                Domain d = prov.get(Key.DomainBy.name, domain);
-                String[] vips = d.getVirtualIPAddress();
-                for (String vip : vips) {
-                    // for each virtual ip add the routes to the list.
-                    routes.add("route:proto=http;user=" + uid + "@" + vip);
-                    routes.add("route:proto=imap;user=" + uid + "@" + vip);
-                    routes.add("route:proto=pop3;user=" + uid + "@" + vip);
-                    routes.add("route:proto=httpssl;user=" + uid + "@" + vip);
-                    routes.add("route:proto=imapssl;user=" + uid + "@" + vip);
-                    routes.add("route:proto=pop3ssl;user=" + uid + "@" + vip);
-                    routes.add("alias:user=" + uid + ";ip=" + vip);
-                }
-                String[] vhostnames = d.getVirtualHostname();
-                for (String vhost : vhostnames) {
-                    // for each virtual host name add the alias to the list
-                    routes.add("alias:user=" + uid + ";vhost=" + vhost);
-                }
-
-                String[] aliases = account.getMailAlias();
-                List<String> uids = new ArrayList<String>();
-                uids.add(uid);
-                for (String alias : aliases) {
-                    if (alias.indexOf('@') != -1 && alias.substring(alias.indexOf('@') + 1).equals(domain)) {
-                        uids.add(alias.substring(0, alias.indexOf('@')));
-                    }
-                }
-                // get domain alias from the given the domain
-                // this logic works for for all cases account=addr@<alias domain> or alias-name@<alias domain>
-                if (prov instanceof LdapProvisioning) {
-                    ZLdapContext ldpCtx = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
-                    try {
-                        List<String> aliasDomainIds = ((LdapProvisioning) prov).getEmptyAliasDomainIds(ldpCtx, d, false);
-                        if (aliasDomainIds != null) {
-                            for (String aliasDomainId : aliasDomainIds) {
-                                String aliasDomain = prov.getDomainById(aliasDomainId).getDomainName();
-                                for (String userName : uids) {
-                                    routes.add("route:proto=http;user=" + userName + "@" + aliasDomain);
-                                    routes.add("route:proto=imap;user=" + userName + "@" + aliasDomain);
-                                    routes.add("route:proto=pop3;user=" + userName + "@" + aliasDomain);
-                                    routes.add("route:proto=httpssl;user=" + userName + "@" + aliasDomain);
-                                    routes.add("route:proto=imapssl;user=" + userName + "@" + aliasDomain);
-                                    routes.add("route:proto=pop3ssl;user=" + userName + "@" + aliasDomain);
-                                    routes.add("alias:user=" + userName + ";ip=" + aliasDomain);
-                                }
-                            }
-                        }
-                    } finally {
-                        LdapClient.closeContext(ldpCtx);
-                    }
-                }
-
-                // for each alias add routes for it's domain and all virtual IPs for that domain
-                // I haven't found any alias in the http/httpssl routes. Hence skipping it.
-                // bug:79940 says Active Sync routes are stored as http/https - alias@domain.com
-                for (String alias : aliases) {
-                    routes.add("route:proto=http;user=" + alias);
-                    routes.add("route:proto=imap;user=" + alias);
-                    routes.add("route:proto=pop3;user=" + alias);
-                    routes.add("route:proto=httpssl;user=" + alias);
-                    routes.add("route:proto=imapssl;user=" + alias);
-                    routes.add("route:proto=pop3ssl;user=" + alias);
-
-                    if (alias.indexOf('@') != -1) {
-                        alias = alias.substring(0, alias.indexOf('@'));
-                    }
-                    for (String vhost : vhostnames) {
-                        // for each virtual host name add the alias to the alias user
-                        routes.add("alias:user=" + alias + ";vhost=" + vhost);
-                    }
-                    for (String vip : vips) {
-                        // for each virtual ip add the routes to the list.
-                        routes.add("route:proto=http;user=" + alias + "@" + vip);
-                        routes.add("route:proto=imap;user=" + alias + "@" + vip);
-                        routes.add("route:proto=pop3;user=" + alias + "@" + vip);
-                        routes.add("route:proto=httpssl;user=" + alias + "@" + vip);
-                        routes.add("route:proto=imapssl;user=" + alias + "@" + vip);
-                        routes.add("route:proto=pop3ssl;user=" + alias + "@" + vip);
-                        routes.add("alias:user=" + alias + ";ip=" + vip);
-                    }
-                }
-            }
- 
-            for (int i = 0; i < numServers; ++i) {
-                ZimbraMemcachedClient zmc = zmcs.get(i);
-                
-                for (String route : routes) {
-                    if (purge) {
-                        // Note: there is no guarantee that all the routes will be present.
-                        // We just try to purge all of them without waiting on ack.
-                        System.out.println("Purging " + route + " on server " + servers.get(i));
-                        zmc.remove(route, false);
-                    } else {
-                        String output = String.format(outputformat, servers.get(i), route, zmc.get(route));
-                        System.out.println(output);
-                    }
-                }
-            }
-        }
-
-        for (ZimbraMemcachedClient zmc : zmcs) {
-            zmc.disconnect(ZimbraMemcachedClient.DEFAULT_TIMEOUT);
-        }
+    /* parse the format string */
+    if (commandLine.hasOption("o")) {
+      outputFormat = commandLine.getOptionValue("o");
+    } else {
+      outputFormat = "[%1$s] %2$s -- %3$s";
     }
 
-    /** Extract the account names
-     *  @param  commandLine Command Line object (org.apache.commons.cli.CommandLine)
-     *  @return ArrayList containing the account names specified on the command line (-a or -L)
-     */
-    static ArrayList<String> getAccounts (CommandLine commandLine)
-    {
-        ArrayList<String>   accounts = new ArrayList<String> ();
-        String[]            values = commandLine.getOptionValues ("a");
-        String              filename = commandLine.getOptionValue ("L");
+    purgeAccounts(servers, accounts, purge, outputFormat);
+  }
 
-        /* Start off with any account specified with `-a' */
-        if (values != null) {
-          accounts.addAll(Arrays.asList(commandLine.getOptionValues("a")));
+  /**
+   * Purges or, prints all the routes for the accounts supplied.
+   *
+   * @param servers      list of memcached servers supplied, if null the function gets all the
+   *                     memcached servers from provisioning
+   * @param accounts     list of accounts (qualified or, unqualified)
+   * @param purge        true for the account routes purging, false for printing the routes
+   * @param outputformat format of the output in case of printing
+   * @throws ServiceException
+   */
+  public static void purgeAccounts(List<String> servers, List<String> accounts, boolean purge,
+      String outputformat) throws ServiceException {
+
+    Provisioning prov = Provisioning.getInstance();
+
+    // Some sanity checks.
+    if (accounts == null || accounts.isEmpty()) {
+      LOG.error("No account supplied");
+      System.exit(1);
+    }
+
+    if (!purge) {
+      // the outputformat must be supplied.
+      if (outputformat == null || outputformat.length() == 0) {
+        LOG.error("outputformat must be supplied for info");
+        System.exit(1);
+      }
+    }
+
+    if (servers == null) {
+      List<Server> memcachedServers = prov.getAllServers(Provisioning.SERVICE_MEMCACHED);
+      servers = new ArrayList<>();
+
+      for (Server server : memcachedServers) {
+        String serverName = server.getAttr(ZAttrProvisioning.A_zimbraMemcachedBindAddress,
+            "localhost");
+        String servicePort = server.getAttr(ZAttrProvisioning.A_zimbraMemcachedBindPort,
+            MEMCACHED_PORT);
+        servers.add(serverName + ":" + servicePort);
+      }
+
+    }
+
+    // Connect to all memcached servers.
+    int numServers = servers.size();
+    ArrayList<ZimbraMemcachedClient> zmcs = new ArrayList<>();
+
+    for (String server : servers) {
+      ZimbraMemcachedClient zmc = new ZimbraMemcachedClient();
+      zmc.connect(new String[]{server}, false, null, 0, 5000);
+      zmcs.add(zmc);
+    }
+
+    for (String a : accounts) {
+      // Bug 24463
+      // The route keying in memcached is governed by the following rules:
+      // 1. if login name is fully qualified, use that as the route key
+      // 2. otherwise, if memcache_entry_allow_unqualified is true, then use the bare login as the route key
+      // 3. else, append the IP address of the proxy interface to the login and use that as the route key
+      // 4. for the login store all the user's alias, append the ip address of the proxy interface.
+      //
+      // For accounts authenticating without domain, NGINX internally suffixes @domain
+      // to the login name, by first looking up an existing domain by the IP address of
+      // the proxy interface where the connection came in. If no such domain is found,
+      // then NGINX falls back to the default domain name specified by the config
+      // attribute zimbraDefaultDomainName.
+      // The IP to domain mapping is done based on the zimbraVirtualIPAddress attribute
+      // of the domain (The IP-to-domain mapping is a many-to-one relationship.)
+      //
+      // For the zmproxypurge utility if the account supplied (-a option) is:
+      //    1. For fully qualified account with @domain; it will find all the virtual IP
+      //        addresses for that domain and will delete all the entries on all memcached servers:
+      //        i) with the user@domain (case 1 as described above)
+      //        ii) with just the user (case 2 as described above)
+      //        iii) with all the virtual IP addresses configured for the domain
+      //        iv) find all the alias for the account and repeat (i) to (iii)
+      //    2. For the account supplied with the IP address; the utility will only try to
+      //       purge the entries with the user@IP.
+      //    3. If there is a single domain and the account supplied is not fully qualified;
+      //       the utility will append the default domain to that entry and will execute step 1.
+      //       (In this case the provisioning lookup will return the correct domain)
+
+      ArrayList<String> routes = new ArrayList<>();
+
+      // Lookup the account; at this point we don't whether the user is fully qualified.
+      Account account = prov.get(Key.AccountBy.name, a);
+      if (account == null) {
+        // In this case just purge the entries with the given account name as supplied.
+        LOG.error("error looking up account: {}" , a);
+        routes.add("route:proto=http;user=" + a);
+        routes.add("route:proto=imap;user=" + a);
+        routes.add("route:proto=pop3;user=" + a);
+        routes.add("route:proto=httpssl;user=" + a);
+        routes.add("route:proto=imapssl;user=" + a);
+        routes.add("route:proto=pop3ssl;user=" + a);
+      } else {
+        String uid = account.getUid();
+        routes.add("route:proto=http;id=" + account.getId());
+        routes.add("route:proto=http;user=" + uid);
+        routes.add("route:proto=imap;user=" + uid);
+        routes.add("route:proto=pop3;user=" + uid);
+        routes.add("route:proto=httpssl;id=" + account.getId());
+        routes.add("route:proto=httpssl;user=" + uid);
+        routes.add("route:proto=imapssl;user=" + uid);
+        routes.add("route:proto=pop3ssl;user=" + uid);
+        routes.add("route:proto=httpssl;admin=1;id=" + account.getId());
+
+        String domain = account.getDomainName();
+        routes.add("route:proto=http;user=" + uid + "@" + domain);
+        routes.add("route:proto=imap;user=" + uid + "@" + domain);
+        routes.add("route:proto=pop3;user=" + uid + "@" + domain);
+        routes.add("route:proto=httpssl;user=" + uid + "@" + domain);
+        routes.add("route:proto=imapssl;user=" + uid + "@" + domain);
+        routes.add("route:proto=pop3ssl;user=" + uid + "@" + domain);
+        routes.add("alias:user=" + uid + ";ip=" + domain);
+
+        Domain d = prov.get(Key.DomainBy.name, domain);
+        String[] vips = d.getVirtualIPAddress();
+        for (String vip : vips) {
+          // for each virtual ip add the routes to the list.
+          routes.add("route:proto=http;user=" + uid + "@" + vip);
+          routes.add("route:proto=imap;user=" + uid + "@" + vip);
+          routes.add("route:proto=pop3;user=" + uid + "@" + vip);
+          routes.add("route:proto=httpssl;user=" + uid + "@" + vip);
+          routes.add("route:proto=imapssl;user=" + uid + "@" + vip);
+          routes.add("route:proto=pop3ssl;user=" + uid + "@" + vip);
+          routes.add("alias:user=" + uid + ";ip=" + vip);
         }
+        String[] vhostnames = d.getVirtualHostname();
+        for (String vhost : vhostnames) {
+          // for each virtual host name add the alias to the list
+          routes.add("alias:user=" + uid + ";vhost=" + vhost);
+        }
+
+        String[] aliases = account.getMailAlias();
+        List<String> uids = new ArrayList<>();
+        uids.add(uid);
+        for (String alias : aliases) {
+          if (alias.indexOf('@') != -1 && alias.substring(alias.indexOf('@') + 1).equals(domain)) {
+            uids.add(alias.substring(0, alias.indexOf('@')));
+          }
+        }
+        // get domain alias from the given the domain
+        // this logic works for for all cases account=addr@<alias domain> or alias-name@<alias domain>
+        if (prov instanceof LdapProvisioning) {
+          ZLdapContext ldpCtx = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
+          try {
+            List<String> aliasDomainIds = ((LdapProvisioning) prov).getEmptyAliasDomainIds(ldpCtx,
+                d, false);
+            if (aliasDomainIds != null) {
+              for (String aliasDomainId : aliasDomainIds) {
+                String aliasDomain = prov.getDomainById(aliasDomainId).getDomainName();
+                for (String userName : uids) {
+                  routes.add("route:proto=http;user=" + userName + "@" + aliasDomain);
+                  routes.add("route:proto=imap;user=" + userName + "@" + aliasDomain);
+                  routes.add("route:proto=pop3;user=" + userName + "@" + aliasDomain);
+                  routes.add("route:proto=httpssl;user=" + userName + "@" + aliasDomain);
+                  routes.add("route:proto=imapssl;user=" + userName + "@" + aliasDomain);
+                  routes.add("route:proto=pop3ssl;user=" + userName + "@" + aliasDomain);
+                  routes.add("alias:user=" + userName + ";ip=" + aliasDomain);
+                }
+              }
+            }
+          } finally {
+            LdapClient.closeContext(ldpCtx);
+          }
+        }
+
+        // for each alias add routes for it's domain and all virtual IPs for that domain
+        // I haven't found any alias in the http/httpssl routes. Hence skipping it.
+        // bug:79940 says Active Sync routes are stored as http/https - alias@domain.com
+        for (String alias : aliases) {
+          routes.add("route:proto=http;user=" + alias);
+          routes.add("route:proto=imap;user=" + alias);
+          routes.add("route:proto=pop3;user=" + alias);
+          routes.add("route:proto=httpssl;user=" + alias);
+          routes.add("route:proto=imapssl;user=" + alias);
+          routes.add("route:proto=pop3ssl;user=" + alias);
+
+          if (alias.indexOf('@') != -1) {
+            alias = alias.substring(0, alias.indexOf('@'));
+          }
+          for (String vhost : vhostnames) {
+            // for each virtual host name add the alias to the alias user
+            routes.add("alias:user=" + alias + ";vhost=" + vhost);
+          }
+          for (String vip : vips) {
+            // for each virtual ip add the routes to the list.
+            routes.add("route:proto=http;user=" + alias + "@" + vip);
+            routes.add("route:proto=imap;user=" + alias + "@" + vip);
+            routes.add("route:proto=pop3;user=" + alias + "@" + vip);
+            routes.add("route:proto=httpssl;user=" + alias + "@" + vip);
+            routes.add("route:proto=imapssl;user=" + alias + "@" + vip);
+            routes.add("route:proto=pop3ssl;user=" + alias + "@" + vip);
+            routes.add("alias:user=" + alias + ";ip=" + vip);
+          }
+        }
+      }
+
+      for (int i = 0; i < numServers; ++i) {
+        ZimbraMemcachedClient zmc = zmcs.get(i);
+
+        for (String route : routes) {
+          if (purge) {
+            // Note: there is no guarantee that all the routes will be present.
+            // We just try to purge all of them without waiting on ack.
+            final String server = servers.get(i);
+            LOG.info("Purging {} on server {}", route, server);
+
+            zmc.remove(route, false);
+          } else {
+            String output = String.format(outputformat, servers.get(i), route, zmc.get(route));
+            LOG.info(output);
+          }
+        }
+      }
+    }
+
+    for (ZimbraMemcachedClient zmc : zmcs) {
+      zmc.disconnect(ZimbraMemcachedClient.DEFAULT_TIMEOUT);
+    }
+  }
+
+  /**
+   * Extract the account names
+   *
+   * @param commandLine Command Line object (org.apache.commons.cli.CommandLine)
+   * @return ArrayList containing the account names specified on the command line (-a or -L)
+   */
+  static ArrayList<String> getAccounts(CommandLine commandLine) {
+    ArrayList<String> accounts = new ArrayList<>();
+    String[] values = commandLine.getOptionValues("a");
+    String filename = commandLine.getOptionValue("L");
+
+    /* Start off with any account specified with `-a' */
+    if (values != null) {
+      accounts.addAll(Arrays.asList(commandLine.getOptionValues("a")));
+    }
 
         /* Other accounts may be read from a list file specified with -L 
            Each line of input will contain one account name
          */
-        if (filename != null) {
-            BufferedReader br;
-            if (filename == "-") {
-                br = new BufferedReader (new InputStreamReader (System.in));
-            }
-            else {
-                try {
-                    br = new BufferedReader (new FileReader (filename));
-                } catch (FileNotFoundException e) {
-                    br = null;
-                    System.err.println ("File not found: " + filename);
-                }
-            }
-
-            if (br != null) {
-                String s;
-                do {
-                    try { s = br.readLine(); }
-                    catch (IOException e) { 
-                        s = null; 
-                    }
-
-                    if (s != null) {
-                        accounts.add (s);
-                    }
-                } while (s != null);
-
-                try { br.close (); }
-                catch (IOException e) { }
-            }
+    if (filename != null) {
+      BufferedReader br;
+      if (filename.equals("-")) {
+        br = new BufferedReader(new InputStreamReader(System.in));
+      } else {
+        try {
+          br = new BufferedReader(new FileReader(filename));
+        } catch (FileNotFoundException e) {
+          br = null;
+          LOG.error("File not found: {}", filename);
         }
+      }
 
-        return accounts;
-    }
+      if (br != null) {
+        String s;
+        do {
+          try {
+            s = br.readLine();
+          } catch (IOException e) {
+            s = null;
+          }
 
-    /** Extract the account names
-     *  @param  commandLine     Command Line object (org.apache.commons.cli.CommandLine)
-     *  @return An ArrayList containing the server names specified in the command line
-     */
-    static ArrayList<String> getCacheServers (CommandLine commandLine)
-    {
-        ArrayList<String>   servers = new ArrayList<String> ();
-        String[]            values = commandLine.getArgs ();
+          if (s != null) {
+            accounts.add(s);
+          }
+        } while (s != null);
 
-        if (values != null) {
-          servers.addAll(Arrays.asList(commandLine.getArgs()));
+        try {
+          br.close();
+        } catch (IOException e) {
         }
-
-        return servers;
+      }
     }
 
-    /** Parse command line arguments
-        @param  args    An array of strings representing the command line arguments
-        @return         An instance of org.apache.commons.cli.CommandLine
-        @throws         ParseException
-     */
-    static CommandLine parseCommandLine (String[] args)
-        throws ParseException
-    {
-        CommandLineParser   parser;
-        Options             options;
+    return accounts;
+  }
 
-        parser = new GnuParser ();
-        options = new Options ();
+  /**
+   * Extract the account names
+   *
+   * @param commandLine Command Line object (org.apache.commons.cli.CommandLine)
+   * @return An ArrayList containing the server names specified in the command line
+   */
+  static ArrayList<String> getCacheServers(CommandLine commandLine) {
+    ArrayList<String> servers = new ArrayList<>();
+    String[] values = commandLine.getArgs();
 
-        options.addOption ("h", "help", false, "print usage");
-        options.addOption ("u", "usage", false, "print usage");
-        options.addOption ("v", "verbose", false, "be verbose");
-        options.addOption ("i", "info", false, "display route information");
-        options.addOption ("a", "account", true, "account name");
-        options.addOption ("L", "list", true, "file containing list of accounts, one per line");
-        options.addOption ("o", "output", true, "format for displaying routing information");
-
-        return parser.parse (options, args);
+    if (values != null) {
+      servers.addAll(Arrays.asList(commandLine.getArgs()));
     }
 
-    /** Display program usage */
-    static void usage ()
-    {
-        System.err.println (" ");
-        System.err.println (" Purges POP/IMAP routing information from one or more memcached servers");
-        System.err.println (" Available Memcached servers are discovered by the 'zmprov gamcs' function, others can be specified");
-        System.err.println (" If necessary, please specify additional memcached servers in the form of server:port at the end of the command line");
-        System.err.println (" ");
-        System.err.println (" Usage: zmproxypurge [-v] [-i] -a account [-L accountlist] [cache1 [cache2 ... ]]");
-        System.err.println ("  -h, --help     Display help");
-        System.err.println ("  -v, --verbose  Be verbose");
-        System.err.println ("  -i, --info     Just display account routing information, don't purge (dry run)");
-        System.err.println ("  -a, --account  Account name");
-        System.err.println ("  -L, --list     File containing list of accounts, one per line");
-        System.err.println ("                 Use `-' to indicate standard input");
-        System.err.println ("  -o, --output   Format to be used to print routing information with -i");
-        System.err.println ("                 Three fields are displayed by default:");
-        System.err.println ("                 . the cache server");
-        System.err.println ("                 . the account name");
-        System.err.println ("                 . the route information");
-        System.err.println ("                 Default format is `[%1$s] %2$s -- %3$s'");
-        System.err.println ("  cacheN         (Optional) Additional memcache server, of the form server:port");
-        System.err.println (" ");
-    }
+    return servers;
+  }
+
+  /**
+   * Parse command line arguments
+   *
+   * @param args An array of strings representing the command line arguments
+   * @return An instance of org.apache.commons.cli.CommandLine
+   * @throws ParseException
+   */
+  static CommandLine parseCommandLine(String[] args)
+      throws ParseException {
+    CommandLineParser parser;
+    Options options;
+
+    parser = new GnuParser();
+    options = new Options();
+
+    options.addOption("h", "help", false, "print usage");
+    options.addOption("u", "usage", false, "print usage");
+    options.addOption("v", "verbose", false, "be verbose");
+    options.addOption("i", "info", false, "display route information");
+    options.addOption("a", "account", true, "account name");
+    options.addOption("L", "list", true, "file containing list of accounts, one per line");
+    options.addOption("o", "output", true, "format for displaying routing information");
+
+    return parser.parse(options, args);
+  }
+
+  /**
+   * Display program usage
+   */
+  static void usage() {
+    System.out.println(" ");
+    System.out.println(" Purges POP/IMAP routing information from one or more memcached servers");
+    System.out.println(
+        " Available Memcached servers are discovered by the 'zmprov gamcs' function, others can be specified");
+    System.out.println(
+        " If necessary, please specify additional memcached servers in the form of server:port at the end of the command line");
+    System.out.println(" ");
+    System.out.println(
+        " Usage: zmproxypurge [-v] [-i] -a account [-L accountlist] [cache1 [cache2 ... ]]");
+    System.out.println("  -h, --help     Display help");
+    System.out.println("  -v, --verbose  Be verbose");
+    System.out.println(
+        "  -i, --info     Just display account routing information, don't purge (dry run)");
+    System.out.println("  -a, --account  Account name");
+    System.out.println("  -L, --list     File containing list of accounts, one per line");
+    System.out.println("                 Use `-' to indicate standard input");
+    System.out.println("  -o, --output   Format to be used to print routing information with -i");
+    System.out.println("                 Three fields are displayed by default:");
+    System.out.println("                 . the cache server");
+    System.out.println("                 . the account name");
+    System.out.println("                 . the route information");
+    System.out.println("                 Default format is `[%1$s] %2$s -- %3$s'");
+    System.out.println(
+        "  cacheN         (Optional) Additional memcache server, of the form server:port");
+    System.out.println(" ");
+  }
 
 }
 

--- a/store/src/test/java/com/zimbra/cs/util/ProxyPurgeUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/util/ProxyPurgeUtilTest.java
@@ -1,0 +1,39 @@
+package com.zimbra.cs.util;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ProxyPurgeUtilTest {
+
+  @BeforeAll
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  @Test
+  void shouldLogInfoByDefault() throws Exception {
+    catchSystemExit(() -> ProxyPurgeUtil.main(new String[] {""}));
+    final Logger rootLogger = org.apache.logging.log4j.LogManager.getRootLogger();
+    Assertions.assertEquals(Level.INFO, rootLogger.getLevel());
+  }
+
+  @Test
+  void shouldLogDebugWhenVerbose() throws Exception {
+    catchSystemExit(() -> ProxyPurgeUtil.main(new String[] {"-v"}));
+    final Logger rootLogger = org.apache.logging.log4j.LogManager.getRootLogger();
+    Assertions.assertEquals(Level.DEBUG, rootLogger.getLevel());
+  }
+
+}


### PR DESCRIPTION
**What has changed:**
- use SLF4JLogger logger Implementation for logging spymemcached
- allow overriding LoggerImpl for spymemcached using system property(fallsback to SLF4JLogger if not defined)
- bump spymemcached from version 2.12.1 to 2.12.3