### PR TITLE
fix(attrs-schema): create-version-ldap fails silently with error 128

### DIFF
--- a/store/ant-store.xml
+++ b/store/ant-store.xml
@@ -143,11 +143,11 @@
 
   <target name="create-version-ldap" depends="build-init"
     description="Creates ldap schema version: attrs-schema">
-    <exec executable="git" failonerror="false" output="${maven.build.dir}/conf/attrs/attrs-schema">
+    <exec executable="git" failonerror="true" output="${maven.build.dir}/conf/attrs/attrs-schema">
       <arg value="log"/>
       <arg value="-1"/>
       <arg value="--pretty=format:%at"/>
-      <arg value="conf/attrs/attrs.xml"/>
+      <arg value="src/main/resources/conf/attrs/attrs.xml"/>
     </exec>
   </target>
 


### PR DESCRIPTION
Since b741b7da317ae988a6a93fc2a7e5fb96e2a39a02 the attrs file location moved and the build reports the log
> [INFO] --- antrun:3.1.0:run (generate-sql-ldap-versions) @ zm-store ---
[INFO] Executing tasks
[INFO]      [echo] Using version 24.2.0_ZEXTRAS_202402
[ERROR]      [exec] Result: 128
[INFO] Executed tasks
>

Fixed this job to fail in case of error + use new path for attrs.xml.