### PR TITLE
feat: [COR-936] Create account with given zimbraId

### DIFF
--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1425,14 +1425,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
       entry.addAttr(A_objectClass, ocs);
 
-      // fail account creation if zimbraId attribute is passed in create account(ca) command
-      if (uuid != null) {
-        throw ServiceException.FAILURE(
-            "Failed to create account, passing account zimbraId in attributes is not allowed.",
-            null);
+      String zimbraIdStr;
+      if (uuid == null) {
+        zimbraIdStr = LdapUtil.generateUUID();
+      } else {
+        zimbraIdStr = uuid;
       }
 
-      String zimbraIdStr = LdapUtil.generateUUID();
       entry.setAttr(A_zimbraId, zimbraIdStr);
       entry.setAttr(A_zimbraCreateTimestamp, LdapDateUtil.toGeneralizedTime(new Date()));
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/SpecialAttrs.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/SpecialAttrs.java
@@ -41,7 +41,7 @@ public class SpecialAttrs {
         
         if (zimbraId != null) {
             // present, validate if it is a valid uuid
-            LdapUtil.isValidZimbraId(zimbraId);
+            LdapUtil.validateZimbraId(zimbraId);
 
             /* check for uniqueness of the zimbraId
             * 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/SpecialAttrs.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/SpecialAttrs.java
@@ -41,13 +41,8 @@ public class SpecialAttrs {
         
         if (zimbraId != null) {
             // present, validate if it is a valid uuid
-            try {
-                if (!LdapUtil.isValidUUID(zimbraId))
-                throw ServiceException.INVALID_REQUEST(zimbraId + " is not a valid UUID", null);
-            } catch (IllegalArgumentException e) {
-                throw ServiceException.INVALID_REQUEST(zimbraId + " is not a valid UUID", e);
-            }
-        
+            LdapUtil.isValidZimbraId(zimbraId);
+
             /* check for uniqueness of the zimbraId
             * 
             * for now we go with GIGO (garbage in, garbage out) and not check, since there is a race condition 

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapUtil.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapUtil.java
@@ -127,16 +127,15 @@ public class LdapUtil {
         return true;
     }
 
-    public static void isValidZimbraId(String strRep) throws ServiceException {
-
-        if (strRep.length() > 36) {
-            throw new IllegalArgumentException("uuid must be no longer than 36 characters");
+    public static void validateZimbraId(String zimbraId) throws ServiceException {
+        if (zimbraId == null ) {
+            throw ServiceException.INVALID_REQUEST("null is not a valid zimbraId", null);
         }
 
         try {
-            UUID.fromString(strRep);
+            UUID.fromString(zimbraId);
         } catch (IllegalArgumentException e) {
-            throw ServiceException.INVALID_REQUEST(strRep + " is not a valid UUID", e);
+            throw ServiceException.INVALID_REQUEST(zimbraId + " is not a valid UUID", e);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapUtil.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapUtil.java
@@ -7,10 +7,12 @@ package com.zimbra.cs.ldap;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 // TODO: get rid of this
 import javax.naming.ldap.Rdn;
 
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.UUIDUtil;
 import com.zimbra.cs.account.Provisioning;
@@ -123,6 +125,19 @@ public class LdapUtil {
         }
 
         return true;
+    }
+
+    public static void isValidZimbraId(String strRep) throws ServiceException {
+
+        if (strRep.length() > 36) {
+            throw new IllegalArgumentException("uuid must be no longer than 36 characters");
+        }
+
+        try {
+            UUID.fromString(strRep);
+        } catch (IllegalArgumentException e) {
+            throw ServiceException.INVALID_REQUEST(strRep + " is not a valid UUID", e);
+        }
     }
 
     /**

--- a/store/src/main/java/com/zimbra/cs/service/admin/CreateAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/CreateAccount.java
@@ -55,12 +55,6 @@ public class CreateAccount extends AdminDocumentHandler {
         String name = req.getName().toLowerCase();
         Map<String, Object> attrs = req.getAttrsAsOldMultimap(true /* ignoreEmptyValues */);
 
-        //fail account creation if zimbraId attribute is passed in CreateAccountRequest
-        if(attrs.containsKey(A_zimbraId)){
-            throw ServiceException.INVALID_REQUEST(
-                "Failed to create account, passing account zimbraId in attributes is not allowed.", null);
-        }
-
         checkDomainRightByEmail(zsc, name, Admin.R_createAccount);
         checkSetAttrsOnCreate(zsc, TargetType.account, name, attrs);
         checkCos(zsc, attrs);

--- a/store/src/main/java/com/zimbra/cs/service/admin/CreateAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/CreateAccount.java
@@ -5,8 +5,6 @@
 
 package com.zimbra.cs.service.admin;
 
-import static com.zimbra.common.account.ZAttrProvisioning.A_zimbraId;
-
 import java.util.List;
 import java.util.Map;
 

--- a/store/src/test/java/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/ldap/LdapProvisioningTest.java
@@ -1,8 +1,5 @@
 package com.zimbra.cs.account.ldap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AccountServiceException;
@@ -11,207 +8,211 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.auth.AuthContext.Protocol;
 import com.zimbra.cs.account.auth.AuthMechanism.AuthMech;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link LdapProvisioning}.
  */
 public class LdapProvisioningTest {
 
-  @BeforeAll
-  public static void init() throws Exception {
-    MailboxTestUtil.initServer();
-    Provisioning prov = Provisioning.getInstance();
+    @BeforeAll
+    public static void init() throws Exception {
+        MailboxTestUtil.initServer();
+        Provisioning prov = Provisioning.getInstance();
 
-    HashMap<String, Object> exampleAccountAttrs;
-    exampleAccountAttrs = new HashMap<>();
-    exampleAccountAttrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    exampleAccountAttrs.put(Provisioning.A_sn, "Leesa");
-    exampleAccountAttrs.put(Provisioning.A_cn, "Natalie Leesa");
-    exampleAccountAttrs.put(Provisioning.A_initials, "James");
-    exampleAccountAttrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
-    prov.createAccount("natalie.leesa@example.com", "testpassword", exampleAccountAttrs);
+        HashMap<String, Object> exampleAccountAttrs;
+        exampleAccountAttrs = new HashMap<>();
+        exampleAccountAttrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        exampleAccountAttrs.put(Provisioning.A_sn, "Leesa");
+        exampleAccountAttrs.put(Provisioning.A_cn, "Natalie Leesa");
+        exampleAccountAttrs.put(Provisioning.A_initials, "James");
+        exampleAccountAttrs.put(Provisioning.A_mail, "natalie.leesa@example.com");
+        prov.createAccount("natalie.leesa@example.com", "testpassword", exampleAccountAttrs);
 
-    HashMap<String, Object> exampleAccountAttrs2;
-    exampleAccountAttrs2 = new HashMap<>();
-    exampleAccountAttrs2.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    exampleAccountAttrs2.put(Provisioning.A_sn, "Lamborghini");
-    exampleAccountAttrs2.put(Provisioning.A_cn, "Milano");
-    exampleAccountAttrs2.put(Provisioning.A_initials, "Cars");
-    exampleAccountAttrs2.put(Provisioning.A_mail, "milano@lamborghini");
-    prov.createAccount("milano@lamborghini", "testpassword", exampleAccountAttrs2);
+        HashMap<String, Object> exampleAccountAttrs2;
+        exampleAccountAttrs2 = new HashMap<>();
+        exampleAccountAttrs2.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        exampleAccountAttrs2.put(Provisioning.A_sn, "Lamborghini");
+        exampleAccountAttrs2.put(Provisioning.A_cn, "Milano");
+        exampleAccountAttrs2.put(Provisioning.A_initials, "Cars");
+        exampleAccountAttrs2.put(Provisioning.A_mail, "milano@lamborghini");
+        prov.createAccount("milano@lamborghini", "testpassword", exampleAccountAttrs2);
 
-    HashMap<String, Object> exampleAccountAttrs3;
-    exampleAccountAttrs3 = new HashMap<>();
-    exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    exampleAccountAttrs3.put(Provisioning.A_sn, "Lamborghini");
-    exampleAccountAttrs3.put(Provisioning.A_cn, "Milano");
-    exampleAccountAttrs3.put(Provisioning.A_initials, "Cars");
-    exampleAccountAttrs3.put(Provisioning.A_mail, "milano@lamborghini-europe.com");
-    prov.createAccount("milano@lamborghini-europe.com", "testpassword", exampleAccountAttrs3);
-  }
+        HashMap<String, Object> exampleAccountAttrs3;
+        exampleAccountAttrs3 = new HashMap<>();
+        exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        exampleAccountAttrs3.put(Provisioning.A_sn, "Lamborghini");
+        exampleAccountAttrs3.put(Provisioning.A_cn, "Milano");
+        exampleAccountAttrs3.put(Provisioning.A_initials, "Cars");
+        exampleAccountAttrs3.put(Provisioning.A_mail, "milano@lamborghini-europe.com");
+        prov.createAccount("milano@lamborghini-europe.com", "testpassword", exampleAccountAttrs3);
+    }
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    MailboxTestUtil.clearData();
-  }
+    @BeforeEach
+    public void setUp() throws Exception {
+        MailboxTestUtil.clearData();
+    }
 
- /**
-  * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
-   * Account)}) for personal data
-  *
-  * @throws ServiceException
-   */
- @Test
- void shouldFindPersonalDataInPassword() throws ServiceException {
-  assertThrows(AccountServiceException.class, () -> {
+    /**
+     * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+     * Account)}) for personal data
+     *
+     * @throws ServiceException
+     */
+    @Test
+    void shouldFindPersonalDataInPassword() throws ServiceException {
+        assertThrows(AccountServiceException.class, () -> {
 
-   Account acct = Provisioning.getInstance().getAccount("natalie.leesa@example.com");
+            Account acct = Provisioning.getInstance().getAccount("natalie.leesa@example.com");
 
-   // fake passwords for test against created user account
-   String[] testPasswords = {
-     "natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"
-   };
-   for (String testPassword : testPasswords) {
-    String passwordLower = testPassword.toLowerCase();
-    LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
-   }
-  });
- }
+            // fake passwords for test against created user account
+            String[] testPasswords = {
+                    "natalie", "Natalie123", "Leesa34", "example01", "Leesa.Example", "eXamPle", "2022james"
+            };
+            for (String testPassword : testPasswords) {
+                String passwordLower = testPassword.toLowerCase();
+                LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+            }
+        });
+    }
 
- /**
-  * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
-   * Account)}) for specific case in which user might be <b>using a dotless domain</b>
-  *
-  * @throws ServiceException
-   */
- @Test
- void shouldFindPersonalDataInPasswordForDotLessDomainsEmails() throws ServiceException {
-  assertThrows(AccountServiceException.class, () -> {
+    /**
+     * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+     * Account)}) for specific case in which user might be <b>using a dotless domain</b>
+     *
+     * @throws ServiceException
+     */
+    @Test
+    void shouldFindPersonalDataInPasswordForDotLessDomainsEmails() throws ServiceException {
+        assertThrows(AccountServiceException.class, () -> {
 
-   Account acct = Provisioning.getInstance().getAccount("milano@lamborghini");
+            Account acct = Provisioning.getInstance().getAccount("milano@lamborghini");
 
-   // fake passwords for test against created user account
-   String[] testPasswords = {
-     "milano",
-     "Lamborghini123",
-     "Milano34",
-     "lamborghini01",
-     "Milano.Lamborghini",
-     "lAmbOrgHini",
-     "2022cars"
-   };
+            // fake passwords for test against created user account
+            String[] testPasswords = {
+                    "milano",
+                    "Lamborghini123",
+                    "Milano34",
+                    "lamborghini01",
+                    "Milano.Lamborghini",
+                    "lAmbOrgHini",
+                    "2022cars"
+            };
 
-   for (String testPassword : testPasswords) {
-    String passwordLower = testPassword.toLowerCase();
-    LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
-   }
-  });
- }
+            for (String testPassword : testPasswords) {
+                String passwordLower = testPassword.toLowerCase();
+                LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+            }
+        });
+    }
 
- /**
-  * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
-   * Account)}) for specific case in which user's <b>domain name contains special chars</b>
-  *
-  * @throws ServiceException
-   */
- @Test
- void shouldFindPersonalDataInPasswordForDomainsContainingSpecialChars()
-   throws ServiceException {
-  assertThrows(AccountServiceException.class, () -> {
+    /**
+     * This test is to validate functionality of ({@link com.zimbra.cs.account.ldap.LdapProvisioning#validatePasswordEntropyForPersonalData(String,
+     * Account)}) for specific case in which user's <b>domain name contains special chars</b>
+     *
+     * @throws ServiceException
+     */
+    @Test
+    void shouldFindPersonalDataInPasswordForDomainsContainingSpecialChars()
+            throws ServiceException {
+        assertThrows(AccountServiceException.class, () -> {
 
-   Account acct = Provisioning.getInstance().getAccount("milano@lamborghini-europe.com");
+            Account acct = Provisioning.getInstance().getAccount("milano@lamborghini-europe.com");
 
-   // fake passwords for test against created user account
-   String[] testPasswords = {"Adjbiuhkl2022europe", "Lamborghini123"};
+            // fake passwords for test against created user account
+            String[] testPasswords = {"Adjbiuhkl2022europe", "Lamborghini123"};
 
-   for (String testPassword : testPasswords) {
-    String passwordLower = testPassword.toLowerCase();
-    LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
-   }
-  });
- }
+            for (String testPassword : testPasswords) {
+                String passwordLower = testPassword.toLowerCase();
+                LdapProvisioning.validatePasswordEntropyForPersonalData(passwordLower, acct);
+            }
+        });
+    }
 
- /**
-  * Tests CO-284 When zimbraAuthfallbackToLocal is FALSE, auth should not fallback to local even
-  * for admin Tested against external ldap authentication
-  */
- @Test
- @Disabled("Find a way to use a real Ldap and not the Mock, since auth is not implemented")
- void shouldNotFallbackAdminAuthWhenFallbackFalse() throws Exception {
-  assertThrows(ServiceException.class, () -> {
-   Provisioning prov = Provisioning.getInstance();
-   // create domain
-   final String domain = "demo.com";
-   Map<String, Object> domainAttrs = new HashMap<>();
-   domainAttrs.put(Provisioning.A_zimbraAuthMech, AuthMech.ldap.toString());
-   prov.createDomain(domain, domainAttrs);
-   // create account
-   HashMap<String, Object> exampleAccountAttrs3;
-   exampleAccountAttrs3 = new HashMap<>();
-   exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-   exampleAccountAttrs3.put(Provisioning.A_sn, "Demo");
-   exampleAccountAttrs3.put(Provisioning.A_cn, "Test");
-   exampleAccountAttrs3.put(Provisioning.A_initials, "Admin");
-   exampleAccountAttrs3.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
-   final String email = "testAdmin@" + domain;
-   final String password = "testPassword";
-   exampleAccountAttrs3.put(Provisioning.A_mail, email);
-   final Account testAdminAccount = prov.createAccount(email, password, exampleAccountAttrs3);
-   prov.authAccount(testAdminAccount, password, Protocol.soap);
-  });
- }
+    /**
+     * Tests CO-284 When zimbraAuthfallbackToLocal is FALSE, auth should not fallback to local even
+     * for admin Tested against external ldap authentication
+     */
+    @Test
+    @Disabled("Find a way to use a real Ldap and not the Mock, since auth is not implemented")
+    void shouldNotFallbackAdminAuthWhenFallbackFalse() throws Exception {
+        assertThrows(ServiceException.class, () -> {
+            Provisioning prov = Provisioning.getInstance();
+            // create domain
+            final String domain = "demo.com";
+            Map<String, Object> domainAttrs = new HashMap<>();
+            domainAttrs.put(Provisioning.A_zimbraAuthMech, AuthMech.ldap.toString());
+            prov.createDomain(domain, domainAttrs);
+            // create account
+            HashMap<String, Object> exampleAccountAttrs3;
+            exampleAccountAttrs3 = new HashMap<>();
+            exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+            exampleAccountAttrs3.put(Provisioning.A_sn, "Demo");
+            exampleAccountAttrs3.put(Provisioning.A_cn, "Test");
+            exampleAccountAttrs3.put(Provisioning.A_initials, "Admin");
+            exampleAccountAttrs3.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
+            final String email = "testAdmin@" + domain;
+            final String password = "testPassword";
+            exampleAccountAttrs3.put(Provisioning.A_mail, email);
+            final Account testAdminAccount = prov.createAccount(email, password, exampleAccountAttrs3);
+            prov.authAccount(testAdminAccount, password, Protocol.soap);
+        });
+    }
 
- /**
-  * Tests CO-284 When zimbraAuthfallbackToLocal is FALSE, auth should fallback to local even for
-  * admin
-  */
- @Test
- @Disabled("Find a way to use a real Ldap and not the Mock, since auth is not implemented")
- void shouldFallbackAdminAuthWhenFallbackTrue() throws Exception {
-  Provisioning prov = Provisioning.getInstance();
-  // create domain
-  final String domain = "demo.com";
-  Map<String, Object> domainAttrs = new HashMap<>();
-  domainAttrs.put(Provisioning.A_zimbraAuthMech, AuthMech.ldap.toString());
-  prov.createDomain(domain, domainAttrs);
-  // create account
-  HashMap<String, Object> exampleAccountAttrs3;
-  exampleAccountAttrs3 = new HashMap<>();
-  exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-  exampleAccountAttrs3.put(Provisioning.A_sn, "Demo");
-  exampleAccountAttrs3.put(Provisioning.A_cn, "Test");
-  exampleAccountAttrs3.put(Provisioning.A_initials, "Admin");
-  exampleAccountAttrs3.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
-  final String email = "testAdmin@" + domain;
-  final String password = "testPassword";
-  exampleAccountAttrs3.put(Provisioning.A_mail, email);
-  final Account testAdminAccount = prov.createAccount(email, password, exampleAccountAttrs3);
-  prov.authAccount(testAdminAccount, password, Protocol.soap);
- }
+    /**
+     * Tests CO-284 When zimbraAuthfallbackToLocal is FALSE, auth should fallback to local even for
+     * admin
+     */
+    @Test
+    @Disabled("Find a way to use a real Ldap and not the Mock, since auth is not implemented")
+    void shouldFallbackAdminAuthWhenFallbackTrue() throws Exception {
+        Provisioning prov = Provisioning.getInstance();
+        // create domain
+        final String domain = "demo.com";
+        Map<String, Object> domainAttrs = new HashMap<>();
+        domainAttrs.put(Provisioning.A_zimbraAuthMech, AuthMech.ldap.toString());
+        prov.createDomain(domain, domainAttrs);
+        // create account
+        HashMap<String, Object> exampleAccountAttrs3;
+        exampleAccountAttrs3 = new HashMap<>();
+        exampleAccountAttrs3.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
+        exampleAccountAttrs3.put(Provisioning.A_sn, "Demo");
+        exampleAccountAttrs3.put(Provisioning.A_cn, "Test");
+        exampleAccountAttrs3.put(Provisioning.A_initials, "Admin");
+        exampleAccountAttrs3.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
+        final String email = "testAdmin@" + domain;
+        final String password = "testPassword";
+        exampleAccountAttrs3.put(Provisioning.A_mail, email);
+        final Account testAdminAccount = prov.createAccount(email, password, exampleAccountAttrs3);
+        prov.authAccount(testAdminAccount, password, Protocol.soap);
+    }
 
- @Test
- void aliasDomainShouldHaveZimbraMailCatchAllForwardingAddressSetByDefault() throws ServiceException {
-  Provisioning prov = Provisioning.getInstance();
+    @Test
+    void aliasDomainShouldHaveZimbraMailCatchAllForwardingAddressSetByDefault() throws ServiceException {
+        Provisioning prov = Provisioning.getInstance();
 
-  // create target domain
-  final String domainName = "co477.com";
-  final String aliasDomainName = "aka.co477.com";
-  final Domain targetDomain = prov.createDomain(domainName, new HashMap<String, Object>());
+        // create target domain
+        final String domainName = "co477.com";
+        final String aliasDomainName = "aka.co477.com";
+        final Domain targetDomain = prov.createDomain(domainName, new HashMap<String, Object>());
 
-  // create alias domain
-  final HashMap<String, Object> attrs = new HashMap<>();
-  attrs.put(Provisioning.A_zimbraDomainType, Provisioning.DomainType.alias.name());
-  attrs.put(Provisioning.A_zimbraDomainAliasTargetId, targetDomain.getId());
-  final Domain aliasDomain = prov.createDomain(aliasDomainName, attrs);
+        // create alias domain
+        final HashMap<String, Object> attrs = new HashMap<>();
+        attrs.put(Provisioning.A_zimbraDomainType, Provisioning.DomainType.alias.name());
+        attrs.put(Provisioning.A_zimbraDomainAliasTargetId, targetDomain.getId());
+        final Domain aliasDomain = prov.createDomain(aliasDomainName, attrs);
 
-  assertEquals(aliasDomain.getAttr(Provisioning.A_zimbraMailCatchAllForwardingAddress),
-    "@" + domainName);
- }
+        assertEquals(aliasDomain.getAttr(Provisioning.A_zimbraMailCatchAllForwardingAddress),
+                "@" + domainName);
+    }
 }

--- a/store/src/test/java/com/zimbra/cs/ldap/LdapUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/ldap/LdapUtilTest.java
@@ -1,0 +1,82 @@
+package com.zimbra.cs.ldap;
+
+import com.zimbra.common.service.ServiceException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class LdapUtilTest {
+
+    @Test
+    void validateZimbraId_throws_IllegalArgumentException_when_length_is_too_large() {
+        String id = "1234567890123456789012345678901234567";
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(id));
+        Assertions.assertInstanceOf(IllegalArgumentException.class, serviceException.getCause());
+        Assertions.assertEquals("UUID string too large", serviceException.getCause().getMessage());
+        Assertions.assertEquals("invalid request: 1234567890123456789012345678901234567 is not a valid UUID",
+                serviceException.getMessage());
+    }
+
+    @Test
+    void validateZimbraId_throws_IllegalArgumentException_when_the_format_is_not_valid() throws ServiceException {
+        String id = "123456789012345678901234567890123456";
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(id));
+        Assertions.assertInstanceOf(IllegalArgumentException.class, serviceException.getCause());
+        Assertions.assertEquals("Invalid UUID string: 123456789012345678901234567890123456", serviceException.getCause().getMessage());
+        Assertions.assertEquals("invalid request: 123456789012345678901234567890123456 is not a valid UUID",
+                serviceException.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"123456789012345678901234567890123456",
+            "1-1-1-1",
+            "08c690d5-a6e9-4692-9035"
+    })
+    void validateZimbraId_throws_IllegalArgumentException_when_invalid_zimbra_ids(String zimbraId) throws ServiceException {
+        String id = "123456789012345678901234567890123456";
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(zimbraId));
+        Assertions.assertInstanceOf(IllegalArgumentException.class, serviceException.getCause());
+        Assertions.assertEquals("Invalid UUID string: " + zimbraId, serviceException.getCause().getMessage());
+        Assertions.assertEquals("invalid request: " + zimbraId + " is not a valid UUID",
+                serviceException.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1-1-1-1-", "----1", "----", "-1--2-3", "1-1--2-3"})
+    void validateZimbraId_throws_NumberFormatException_when_invalid_zimbra_ids_without_ends_number(String zimbraId) throws ServiceException {
+        String id = "123456789012345678901234567890123456";
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(zimbraId));
+        Assertions.assertInstanceOf(NumberFormatException.class, serviceException.getCause());
+        Assertions.assertEquals("invalid request: " + zimbraId + " is not a valid UUID",
+                serviceException.getMessage());
+    }
+
+    @Test
+    void validateZimbraId_throws_IllegalArgumentException_when_input_is_empty() throws ServiceException {
+        String id = "";
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(id));
+        Assertions.assertInstanceOf(IllegalArgumentException.class, serviceException.getCause());
+        Assertions.assertEquals("Invalid UUID string: ", serviceException.getCause().getMessage());
+        Assertions.assertEquals("invalid request:  is not a valid UUID",
+                serviceException.getMessage());
+    }
+
+    @Test
+    void validateZimbraId_throws_ServiceException_when_input_is_null() {
+        ServiceException serviceException = Assertions.assertThrows(ServiceException.class, () -> LdapUtil.validateZimbraId(null));
+        Assertions.assertNull(serviceException.getCause());
+        Assertions.assertEquals("invalid request: null is not a valid zimbraId",
+                serviceException.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"08c690d5-a6e9-4692-9035-f7b5885a12b8",
+            "1-1-1-1-1",
+            "08c690d5-a6e9-4692-9035-f7b"
+    })
+    void should_validate_zimbra_id_when_id_is_valid(String zimbraId) throws ServiceException {
+        LdapUtil.validateZimbraId(zimbraId);
+        Assertions.assertTrue(true);
+    }
+}

--- a/store/src/test/java/com/zimbra/cs/ldap/LdapUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/ldap/LdapUtilTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class LdapUtilTest {
+class LdapUtilTest {
 
     @Test
     void validateZimbraId_throws_IllegalArgumentException_when_length_is_too_large() {


### PR DESCRIPTION
**What has changed:**
- allow creating account using supplied `zimbraId` in both LDAP and SOAP provisioning
    - passed `zimbraId` should be a valid UUID
    - if the `zimbraId` is not supplied, a new UUID is generated and used as usual.