### PR TITLE
chore: export HSQLDB class for testing

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -790,6 +790,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>com/zimbra/cs/db/HSQLDB.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Maven WAR plugin -->
       <!-- https://maven.apache.org/plugins/maven-war-plugin/examples/including-excluding-files-from-war.html -->
       <plugin>

--- a/store/src/test/java/com/zimbra/cs/db/HSQLDB.java
+++ b/store/src/test/java/com/zimbra/cs/db/HSQLDB.java
@@ -27,7 +27,7 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
  *
  * @author ysasaki
  */
-public final class HSQLDB extends Db {
+public class HSQLDB extends Db {
 
     /**
      * Populates ZIMBRA and MBOXGROUP1 schema.


### PR DESCRIPTION
Add possibility to use some classes in test scenarios.
For now only the in memory database.

The plan is also to add, in future, an in memory ldap with mailbox required data for easier test setup.

In test-jars only minimum required set of classes are included.