### PR TITLE
chore: forgot to include nested classes of HSQLDB

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -802,7 +802,7 @@
             </goals>
             <configuration>
               <includes>
-                <include>com/zimbra/cs/db/HSQLDB.class</include>
+                <include>com/zimbra/cs/db/HSQLDB*</include>
               </includes>
             </configuration>
           </execution>


### PR DESCRIPTION
Fix on a9000caa02c58cd04bacf5ffa879d4d96037d1c0 

HSQLDB had nested classes, forgot to include them