### PR TITLE
chore: update attributes description

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2863,10 +2863,11 @@ public class ZAttrProvisioning {
     public static final String A_carbonioAmavisDisableVirusCheck = "carbonioAmavisDisableVirusCheck";
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @since ZCS 24.2.0
      */

--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -2863,7 +2863,10 @@ public class ZAttrProvisioning {
     public static final String A_carbonioAmavisDisableVirusCheck = "carbonioAmavisDisableVirusCheck";
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @since ZCS 24.2.0
      */
@@ -3386,7 +3389,7 @@ public class ZAttrProvisioning {
     public static final String A_userCertificate = "userCertificate";
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      */
     @ZAttr()
     public static final String A_userPassword = "userPassword";
@@ -8564,7 +8567,7 @@ public class ZAttrProvisioning {
     public static final String A_zimbraHttpThrottleSafeIPs = "zimbraHttpThrottleSafeIPs";
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      */
     @ZAttr(id=1)
     public static final String A_zimbraId = "zimbraId";

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -2988,7 +2988,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      *
      * @return userPassword, or null if unset
      */
@@ -2998,7 +2998,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      *
      * @param userPassword new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -3011,7 +3011,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      *
      * @param userPassword new value
      * @param attrs existing map to populate, or null to create a new map
@@ -3025,7 +3025,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -3037,7 +3037,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)
+     * RFC2256/2307: password of user.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -23809,7 +23809,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -23819,7 +23819,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -23832,7 +23832,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -23846,7 +23846,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -23858,7 +23858,7 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrCalendarResource.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrCalendarResource.java
@@ -1363,7 +1363,7 @@ public class ZAttrCalendarResource extends Account {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -1373,7 +1373,7 @@ public class ZAttrCalendarResource extends Account {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1386,7 +1386,7 @@ public class ZAttrCalendarResource extends Account {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1400,7 +1400,7 @@ public class ZAttrCalendarResource extends Account {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -1412,7 +1412,7 @@ public class ZAttrCalendarResource extends Account {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
@@ -18205,7 +18205,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -18215,7 +18215,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -18228,7 +18228,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -18242,7 +18242,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -18254,7 +18254,7 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDistributionList.java
@@ -1365,7 +1365,7 @@ public abstract class ZAttrDistributionList extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -1375,7 +1375,7 @@ public abstract class ZAttrDistributionList extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1388,7 +1388,7 @@ public abstract class ZAttrDistributionList extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1402,7 +1402,7 @@ public abstract class ZAttrDistributionList extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -1414,7 +1414,7 @@ public abstract class ZAttrDistributionList extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -982,10 +982,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @return carbonioAutoProvAllowedDomains, or null if unset
      *
@@ -997,10 +998,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @param carbonioAutoProvAllowedDomains new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1015,10 +1017,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @param carbonioAutoProvAllowedDomains new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1034,10 +1037,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -1051,10 +1055,11 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names Used for
-     * checks autoProvAccountNameMap value. If value is full email, domain of
-     * the email should be one of the value of carbonioAutoProvAllowedDomains
-     * active directory domain names may exists at autoProvAccountNameMap.
+     * Comma-separated domain names used for checking the
+     * autoProvAccountNameMap value. If the value is a full email, the domain
+     * of the email should be one of the values in
+     * carbonioAutoProvAllowedDomains. Active Directory domain names may
+     * exist in autoProvAccountNameMap.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -982,7 +982,10 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @return carbonioAutoProvAllowedDomains, or null if unset
      *
@@ -994,7 +997,10 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @param carbonioAutoProvAllowedDomains new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1009,7 +1015,10 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @param carbonioAutoProvAllowedDomains new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1025,7 +1034,10 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -1039,7 +1051,10 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * carbonioAutoProvAllowedDomains comma separated domain names
+     * carbonioAutoProvAllowedDomains comma separated domain names Used for
+     * checks autoProvAccountNameMap value. If value is full email, domain of
+     * the email should be one of the value of carbonioAutoProvAllowedDomains
+     * active directory domain names may exists at autoProvAccountNameMap.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs
@@ -17253,7 +17268,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -17263,7 +17278,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -17276,7 +17291,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -17290,7 +17305,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -17302,7 +17317,7 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDynamicGroup.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDynamicGroup.java
@@ -1075,7 +1075,7 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -1085,7 +1085,7 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -1098,7 +1098,7 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -1112,7 +1112,7 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -1124,7 +1124,7 @@ public abstract class ZAttrDynamicGroup extends Group {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrServer.java
@@ -11472,7 +11472,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @return zimbraId, or null if unset
      */
@@ -11482,7 +11482,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -11495,7 +11495,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param zimbraId new value
      * @param attrs existing map to populate, or null to create a new map
@@ -11509,7 +11509,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      */
@@ -11521,7 +11521,7 @@ public abstract class ZAttrServer extends NamedEntry {
     }
 
     /**
-     * Zimbra Systems Unique ID
+     * Unique identifier for an entry
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/resources/conf/attrs/attrs.xml
+++ b/store/src/main/resources/conf/attrs/attrs.xml
@@ -10130,10 +10130,9 @@ TODO: delete them permanently from here
 </attr>
 <attr id="3142" name="carbonioAutoProvAllowedDomains" type="string" max="51200" cardinality="single" optionalIn="domain" since="24.2.0">
   <desc>
-    carbonioAutoProvAllowedDomains comma separated domain names
-    Used for checks autoProvAccountNameMap value.
-    If value is full email, domain of the email should be one of the value of carbonioAutoProvAllowedDomains
-    active directory domain names may exists at autoProvAccountNameMap.
+    Comma-separated domain names used for checking the autoProvAccountNameMap value.
+    If the value is a full email, the domain of the email should be one of the values in carbonioAutoProvAllowedDomains.
+    Active Directory domain names may exist in autoProvAccountNameMap.
   </desc>
 </attr>
 </attrs>

--- a/store/src/main/resources/conf/attrs/attrs.xml
+++ b/store/src/main/resources/conf/attrs/attrs.xml
@@ -335,7 +335,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 </attr>
 
 <attr name="userPassword" type="string" optionalIn="account">
-    <desc>RFC2256/2307: password of user. Stored encoded as SSHA (salted-SHA1)</desc>
+    <desc>RFC2256/2307: password of user.</desc>
 </attr>
 
 <attr name="userSMIMECertificate" type="binary" cardinality="multi" optionalIn="account">
@@ -348,7 +348,7 @@ TODO - add support for multi-line values in globalConfigValue and defaultCOSValu
 
 
 <attr id="1" name="zimbraId" type="id" immutable="1" cardinality="single" requiredIn="account,alias,distributionList,cos,domain,server,calendarResource,xmppComponent,group,groupDynamicUnit,groupStaticUnit,addressList" flags="accountInfo">
-  <desc>Zimbra Systems Unique ID</desc>
+  <desc>Unique identifier for an entry</desc>
 </attr>
 
 <attr id="2" name="zimbraAccountStatus" type="enum" value="active,maintenance,locked,closed,lockout,pending" callback="AccountStatus" cardinality="single" requiredIn="account" flags="domainAdminModifiable">


### PR DESCRIPTION
- update outdated information about `userPassword` attribute (we do not use SHA1 to produce password salt. We use Argon2), avoid unnecessary used hashing information in description. 
- minor cleanup in attrs.xml