### PR TITLE
feat:[CO-1008] Update defaults for carbonioReverseProxyResponseCSPHeader attribute

### DIFF
--- a/store/ant-store.xml
+++ b/store/ant-store.xml
@@ -72,7 +72,7 @@
   </target>
 
   <target name="generate-zattr-rights" description="generate ZAttr and rights"
-    depends="generate-zattr,generate-rights"/>
+    depends="generate-zattr,generate-rights,generate-ldap-config"/>
 
   <target name="generate-zattr" description="generate methods for attributes in attrs.xml">
     <antcall target="generate-getter">

--- a/store/ldap/src/updates/attrs/1710337715.json
+++ b/store/ldap/src/updates/attrs/1710337715.json
@@ -1,0 +1,6 @@
+{
+  "zimbra_globalconfig": [
+    "carbonioReverseProxyResponseCSPHeader"
+  ]
+}
+

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -1900,13 +1900,13 @@ public abstract class ZAttrConfig extends Entry {
      * will enforce CSP rule on the client side. Note: the value MUST be the
      * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
      *
-     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
+     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools *.jsdelivr.net; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools *.jsdelivr.net; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
      *
      * @since ZCS 23.7.0
      */
     @ZAttr(id=3133)
     public String getCarbonioReverseProxyResponseCSPHeader() {
-        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
+        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools *.jsdelivr.net; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools *.jsdelivr.net; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
     }
 
     /**

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1450,13 +1450,13 @@ public abstract class ZAttrDomain extends NamedEntry {
      * will enforce CSP rule on the client side. Note: the value MUST be the
      * entire header line (e.g. X-Foo: Bar, X-Zoo: &quot;Bar1; Bar2&quot;).
      *
-     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
+     * @return carbonioReverseProxyResponseCSPHeader, or "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools *.jsdelivr.net; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools *.jsdelivr.net; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"" if unset
      *
      * @since ZCS 23.7.0
      */
     @ZAttr(id=3133)
     public String getCarbonioReverseProxyResponseCSPHeader() {
-        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
+        return getAttr(ZAttrProvisioning.A_carbonioReverseProxyResponseCSPHeader, "Content-Security-Policy: \"default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools *.jsdelivr.net; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools *.jsdelivr.net; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';\"", true);
     }
 
     /**

--- a/store/src/main/resources/conf/attrs/attrs.xml
+++ b/store/src/main/resources/conf/attrs/attrs.xml
@@ -10083,7 +10083,7 @@ TODO: delete them permanently from here
 </attr>
 
 <attr id="3133" name="carbonioReverseProxyResponseCSPHeader" type="string" cardinality="single" optionalIn="globalConfig,domain" flags="domainInfo,domainInherited" requiresRestart="nginxproxy" since="23.7.0">
-  <globalConfigValue>Content-Security-Policy: "default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';"</globalConfigValue>
+  <globalConfigValue>Content-Security-Policy: "default-src 'self' data: blob: cid:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.zextras.tools *.jsdelivr.net; style-src * 'unsafe-inline'; img-src * data: blob: cid:; font-src * data:; connect-src 'self' *.zextras.tools *.jsdelivr.net; media-src * blob: data: cid:; object-src 'self'; child-src 'self' blob: data: cid:; frame-src 'self' blob: data: cid:; frame-ancestors 'self'; form-action 'self';"</globalConfigValue>
   <desc>
     Content Security Policy headers to be added by the proxy. This is used along with the zimbraReverseProxyResponseHeaders by the ProxyConfGen
     to produce a complete set of Response Headers returned by the by the proxy.


### PR DESCRIPTION
**What has changed:**
- add `*.jsdelivr.net` in allowed hosts from where web app can load javascripts  
- provide migration to update defaults of carbonioReverseProxyResponseCSPHeader