### PR TITLE
chore: Exclude generated classes from SonarQube analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                    mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar -Dsonar.exclusions=**/ZAttr*.java")
+                    mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar -Dsonar.exclusions=**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java")
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,7 @@ pipeline {
         timeout(time: 2, unit: 'HOURS')
         skipDefaultCheckout()
     }
+
     stages {
         stage('Checkout') {
             steps {
@@ -142,6 +143,7 @@ pipeline {
                 junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml'
             }
         }
+
         stage('Sonarqube Analysis') {
             when {
                 allOf {
@@ -151,7 +153,7 @@ pipeline {
             }
             steps {
                 withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                    mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar")
+                    mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar -Dsonar.exclusions=**/ZAttr*.java")
                 }
             }
         }


### PR DESCRIPTION
**Motivation:**
We've noticed that during SonarQube scanning, certain autogenerated classes(`**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java`) are being included in the analysis. These classes typically contain thousands of lines of Java code and consist mainly of simple getter, setter, and unsetter methods. As these classes are autogenerated and not manually maintained, they don't require scrutiny from SonarQube, and their inclusion in the analysis results in noise and unnecessary reports.

**In this MR:**
We update the CI to exclude these autogenerated classes from SonarQube scanning process. By doing so, we can focus SonarQube's analysis on the code that requires attention and avoid false positives.