### PR TITLE
chore: fix CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,18 +55,23 @@ pipeline {
             label 'carbonio-agent-v2'
         }
     }
+
     parameters {
         booleanParam defaultValue: false, description: 'Upload packages in playground repositories.', name: 'PLAYGROUND'
         booleanParam defaultValue: false, description: 'Skip test and sonar analysis.', name: 'SKIP_TEST_WITH_COVERAGE'
         booleanParam defaultValue: false, description: 'Skip sonar analysis.', name: 'SKIP_SONARQUBE'
     }
+
     environment {
+        JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
+        JAVA_PATH='${JAVA_HOME}/bin'
         JAVA_OPTS='-Dfile.encoding=UTF8'
         LC_ALL='C.UTF-8'
         MAVEN_OPTS = "-Xmx4g"
         BUILD_PROPERTIES_PARAMS='-Ddebug=0 -Dis-production=1'
         GITHUB_BOT_PR_CREDS = credentials('jenkins-integration-with-github-account')
     }
+
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
         timeout(time: 2, unit: 'HOURS')
@@ -100,10 +105,6 @@ pipeline {
             }
         }
         stage('Build') {
-            environment {
-                JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
-                JAVA_PATH='${JAVA_HOME}/bin'
-            }
             steps {
                 mvnCmd("$BUILD_PROPERTIES_PARAMS -DskipTests=true clean install")
 
@@ -162,10 +163,6 @@ pipeline {
             }
         }
         stage('Publish SNAPSHOT to maven') {
-            environment {
-                JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
-                JAVA_PATH='${JAVA_HOME}/bin'
-            }
             when {
                 branch 'devel';
             }


### PR DESCRIPTION
This change ensure that we use same version of JDK/JVM(11) across all stages of our pipeline.

We have two versions (11 and 17) of JDK and java runtime in our build environment/agent  since 94c777469a2d24ca5fafa1c7a6bf056ae64f7367 due to that some of the statges were failing.

