### PR TITLE
feat: [CO-982] Enhance ordering of matches in FullAutoComplete

### DIFF
--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -10,7 +10,7 @@ import org.dom4j.QName;
 
 public final class MailConstants {
 
-  public static final String E_EXTRA_ACCOUNT_ID = "extraAccountId";
+  public static final String E_ORDERED_ACCOUNT_IDS = "orderedAccountIds";
   public static final String A_REQUIRES_SMART_LINK_CONVERSION = "requiresSmartLinkConversion";
 
   public static final class ShareConstants {

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -42,7 +42,7 @@ public class FullAutocompleteRequest {
    *
    * <p>
    * This field is used to specify the accounts from which autocomplete matches should be retrieved. The order of the
-   * account IDs determines the preference order for autocomplete matches.
+   * account IDs determines the order in which matches in response are returned.
    * </p>
    *
    * @zm-api-field-tag orderedAccountIds

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -15,7 +15,8 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @zm-api-command-admin-auth-required false
  * @zm-api-command-description Retrieves AutoComplete matches from multiple source Accounts defined by
  * 'orderedAccountIds'. The ordering logic ensures that the most relevant results are returned based on the values
- * supplied in the 'orderedAccountIds' element.
+ * supplied in the 'orderedAccountIds' element. The returned matches are ordered (top match being most relevant) based
+ * on account IDs order passed in 'orderedAccountIds'. Hence, the 'ranking' attribute of matches should be ignored.
  *
  * <p>
  * The sorting/ordering and limiting algorithm works as follows:
@@ -46,7 +47,7 @@ public class FullAutocompleteRequest {
    *
    * @zm-api-field-tag orderedAccountIds
    * @zm-api-field-description ordered, comma-separated list of account IDs whose matches will be included in the
-   * FullAutocompleteResponse.
+   * FullAutocompleteResponse. Duplicate account IDs are ignored.
    */
   @XmlElement(name = MailConstants.E_ORDERED_ACCOUNT_IDS, required = false)
   private String orderedAccountIds;

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -5,8 +5,6 @@
 package com.zimbra.soap.mail.message;
 
 import com.zimbra.common.soap.MailConstants;
-import java.util.ArrayList;
-import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -15,16 +13,25 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * @zm-api-command-auth-required true
  * @zm-api-command-admin-auth-required false
- * @zm-api-command-description FullAutoComplete
- * This API executes an AutoComplete on current logged in account and all extra requested accounts.
- * If one of the requests in extra accounts fails, the whole API will fail.
- * The API returns the same content of AutoComplete by merging the result and discarding duplicates
- * following the order of requested accounts, starting from logged user response.
- *
+ * @zm-api-command-description FullAutoComplete This API executes an AutoComplete on current logged in account and all
+ * extra requested accounts. If one of the requests in extra accounts fails, the whole API will fail. The API returns
+ * the same content of AutoComplete by merging the result and discarding duplicates following the order of requested
+ * accounts, starting from logged user response.
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name= MailConstants.E_FULL_AUTO_COMPLETE_REQUEST)
+@XmlRootElement(name = MailConstants.E_FULL_AUTO_COMPLETE_REQUEST)
 public class FullAutocompleteRequest {
+
+  @XmlElement(name = MailConstants.E_AUTO_COMPLETE_REQUEST, required = true)
+  private AutoCompleteRequest autoCompleteRequest;
+  /**
+   * @zm-api-field-tag orderedAccountIds
+   * @zm-api-field-description ordered, comma seperated list of account IDs whose matches will be included in the
+   * response.
+   */
+  @XmlElement(name = MailConstants.E_ORDERED_ACCOUNT_IDS, required = false)
+  private String orderedAccountIds;
+
 
   public FullAutocompleteRequest() {
   }
@@ -32,10 +39,6 @@ public class FullAutocompleteRequest {
   public FullAutocompleteRequest(AutoCompleteRequest autoCompleteRequest) {
     this.autoCompleteRequest = autoCompleteRequest;
   }
-
-
-  @XmlElement(name=MailConstants.E_AUTO_COMPLETE_REQUEST, required=true)
-  private AutoCompleteRequest autoCompleteRequest;
 
   public AutoCompleteRequest getAutoCompleteRequest() {
     return autoCompleteRequest;
@@ -45,18 +48,11 @@ public class FullAutocompleteRequest {
     this.autoCompleteRequest = autoCompleteRequest;
   }
 
-  /**
-   * @zm-api-field-tag extraAccountIds
-   * @zm-api-field-description Extra accounts where to execute the autocomplete on
-   */
-  @XmlElement(name=MailConstants.E_EXTRA_ACCOUNT_ID, required=false)
-  private final List<String> extraAccountIds = new ArrayList<>();
-
-  public void addAccount(String account) {
-    this.extraAccountIds.add(account);
+  public String getOrderedAccountIds() {
+    return orderedAccountIds;
   }
 
-  public List<String> getExtraAccountIds() {
-    return extraAccountIds;
+  public void setOrderedAccountIds(String orderedAccountIds) {
+    this.orderedAccountIds = orderedAccountIds;
   }
 }

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -13,10 +13,20 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * @zm-api-command-auth-required true
  * @zm-api-command-admin-auth-required false
- * @zm-api-command-description FullAutoComplete This API executes an AutoComplete on current logged in account and all
- * extra requested accounts. If one of the requests in extra accounts fails, the whole API will fail. The API returns
- * the same content of AutoComplete by merging the result and discarding duplicates following the order of requested
- * accounts, starting from logged user response.
+ * @zm-api-command-description Retrieves AutoComplete matches from multiple source Accounts defined by
+ * 'orderedAccountIds'. The ordering logic ensures that the most relevant results are returned based on the values
+ * supplied in the 'orderedAccountIds' element.
+ *
+ * <p>
+ * The sorting/ordering and limiting algorithm works as follows:
+ * <ul>
+ *     <li>Matches from the most preferred source account (the first accountId in 'orderedAccountIds') are given higher priority and are placed on top.</li>
+ *     <li>Matches from other source accounts are sorted primarily based on ranking, followed by alphabetical ordering.</li>
+ *     <li>Duplicate matches from other source accounts are omitted, with comparison against matches from the preferred source account.</li>
+ *     <li>If the optional 'orderedAccountIds' element is not passed, matches from the authenticated Account are returned, which is equivalent to a regular AutoCompleteRequest.</li>
+ *     <li>The number of matches returned depends on the value set for authenticated account's ContactAutoCompleteMaxResults.</li>
+ * </ul>
+ * </p>
  */
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlRootElement(name = MailConstants.E_FULL_AUTO_COMPLETE_REQUEST)
@@ -24,10 +34,19 @@ public class FullAutocompleteRequest {
 
   @XmlElement(name = MailConstants.E_AUTO_COMPLETE_REQUEST, required = true)
   private AutoCompleteRequest autoCompleteRequest;
+
   /**
+   * Represents an ordered, comma-separated list of account IDs whose autocomplete matches will be included in the
+   * {@link FullAutocompleteResponse}.
+   *
+   * <p>
+   * This field is used to specify the accounts from which autocomplete matches should be retrieved. The order of the
+   * account IDs determines the preference order for autocomplete matches.
+   * </p>
+   *
    * @zm-api-field-tag orderedAccountIds
-   * @zm-api-field-description ordered, comma seperated list of account IDs whose matches will be included in the
-   * response.
+   * @zm-api-field-description ordered, comma-separated list of account IDs whose matches will be included in the
+   * FullAutocompleteResponse.
    */
   @XmlElement(name = MailConstants.E_ORDERED_ACCOUNT_IDS, required = false)
   private String orderedAccountIds;

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  *     <li>Matches from other source accounts are sorted primarily based on ranking, followed by alphabetical ordering.</li>
  *     <li>Duplicate matches from other source accounts are omitted, with comparison against matches from the preferred source account.</li>
  *     <li>If the optional 'orderedAccountIds' element is not passed, matches from the authenticated Account are returned, which is equivalent to a regular AutoCompleteRequest.</li>
- *     <li>The number of matches returned depends on the value set for authenticated account's ContactAutoCompleteMaxResults.</li>
+ *     <li>The number of matches returned depends on the value set for authenticated account's ContactAutoCompleteMaxResults attribute.</li>
  * </ul>
  * </p>
  */

--- a/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
@@ -5,6 +5,7 @@
 
 package com.zimbra.soap.mail.type;
 
+import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -14,7 +15,7 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class AutoCompleteMatch {
+public class AutoCompleteMatch implements Comparable<AutoCompleteMatch>{
 
     /**
      * @zm-api-field-tag email-addresses-for-group
@@ -182,5 +183,28 @@ public class AutoCompleteMatch {
     @Override
     public String toString() {
         return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AutoCompleteMatch that = (AutoCompleteMatch) o;
+        return Objects.equals(email, that.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email, matchType, ranking, group, canExpandGroupMembers, id, folder, displayName, firstName,
+            middleName, lastName, fullName, nickname, company, fileAs);
+    }
+
+    @Override
+    public int compareTo(AutoCompleteMatch autoCompleteMatch) {
+        return Integer.compare(this.getRanking(), autoCompleteMatch.getRanking());
     }
 }

--- a/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
@@ -15,7 +15,7 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.soap.type.ZmBoolean;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class AutoCompleteMatch implements Comparable<AutoCompleteMatch>{
+public class AutoCompleteMatch {
 
     /**
      * @zm-api-field-tag email-addresses-for-group
@@ -201,10 +201,5 @@ public class AutoCompleteMatch implements Comparable<AutoCompleteMatch>{
     public int hashCode() {
         return Objects.hash(email, matchType, ranking, group, canExpandGroupMembers, id, folder, displayName, firstName,
             middleName, lastName, fullName, nickname, company, fileAs);
-    }
-
-    @Override
-    public int compareTo(AutoCompleteMatch autoCompleteMatch) {
-        return Integer.compare(this.getRanking(), autoCompleteMatch.getRanking());
     }
 }

--- a/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
@@ -184,22 +184,4 @@ public class AutoCompleteMatch {
     public String toString() {
         return addToStringInfo(MoreObjects.toStringHelper(this)).toString();
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        AutoCompleteMatch that = (AutoCompleteMatch) o;
-        return Objects.equals(email, that.email);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(email, matchType, ranking, group, canExpandGroupMembers, id, folder, displayName, firstName,
-            middleName, lastName, fullName, nickname, company, fileAs);
-    }
 }

--- a/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/AutoCompleteMatch.java
@@ -5,7 +5,6 @@
 
 package com.zimbra.soap.mail.type;
 
-import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -62,14 +62,13 @@ public class FullAutoComplete extends MailDocumentHandler {
               .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
                   .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
               .forEachOrdered(otherAutoCompleteMatches::add));
-
-      otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
-          .thenComparing(AutoCompleteMatch::getEmail));
     } catch (ServiceException e) {
       throw ServiceException.FAILURE(e.getMessage());
     }
 
     otherAutoCompleteMatches.stream()
+        .sorted(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
+            .thenComparing(AutoCompleteMatch::getEmail))
         .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
             .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
         .limit(Math.max(contactAutoCompleteMaxResultsLimit - fullAutoCompleteMatches.size(), 0))

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -153,15 +153,18 @@ public class FullAutoComplete extends MailDocumentHandler {
    */
   Tuple2<String, List<String>> parsePreferredAccountsFrom(String preferredAccountsStr) {
     String preferredAccount = null;
-    List<String> otherAccounts = new ArrayList<>();
+    final var otherAccounts = new ArrayList<String>();
 
     if (preferredAccountsStr != null && !preferredAccountsStr.isEmpty()) {
       String[] tokens = preferredAccountsStr.split(",");
-      preferredAccount = tokens[0].trim();
-      for (int i = 1; i < tokens.length; i++) {
-        String trimmedToken = tokens[i].trim();
+      for (String token : tokens) {
+        String trimmedToken = token.trim();
         if (!trimmedToken.isEmpty()) {
-          otherAccounts.add(trimmedToken);
+          if (preferredAccount == null) {
+            preferredAccount = trimmedToken;
+          } else {
+            otherAccounts.add(trimmedToken);
+          }
         }
       }
     }

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -20,6 +20,8 @@ import io.vavr.Tuple2;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -35,49 +37,44 @@ public class FullAutoComplete extends MailDocumentHandler {
     final var fullAutocompleteRequest = getFullAutocompleteRequestFrom(request);
     final var fullAutoCompleteMatches = new ArrayList<AutoCompleteMatch>();
     final var otherAutoCompleteMatches = new ArrayList<AutoCompleteMatch>();
+    final var authenticatedAccount = zsc.getAuthToken().getAccount();
+    final int contactAutoCompleteMaxResultsLimit = authenticatedAccount.getContactAutoCompleteMaxResults();
 
     try {
       final var autoCompleteRequest = fullAutocompleteRequest.getAutoCompleteRequest();
-      final var authenticatedAccount = zsc.getAuthToken().getAccount();
       final var zAuthToken = zsc.getAuthToken().toZAuthToken();
-      final int contactAutoCompleteMaxResultsLimit = authenticatedAccount.getContactAutoCompleteMaxResults();
       final var parsedAccountIds = parsePreferredAccountsFrom(
           fullAutocompleteRequest.getOrderedAccountIds());
       final var preferredAccountId = parsedAccountIds._1();
       final var otherPreferredAccountIds = parsedAccountIds._2();
 
       // process matches from "preferred account"
-      final var preferredAccountAutoCompleteResponse = doAutoCompleteOnAccount(authenticatedAccount,
-          zAuthToken, preferredAccountId, autoCompleteRequest);
-      for (var autoCompleteMatch : preferredAccountAutoCompleteResponse.getMatches()) {
-        if (contactAutoCompleteMaxResultsLimit > 0
-            && fullAutoCompleteMatches.size() >= contactAutoCompleteMaxResultsLimit) {
-          break;
-        }
-        fullAutoCompleteMatches.add(autoCompleteMatch);
-      }
+      doAutoCompleteOnAccount(authenticatedAccount, zAuthToken, preferredAccountId, autoCompleteRequest).getMatches()
+          .stream()
+          .takeWhile(autoCompleteMatch -> contactAutoCompleteMaxResultsLimit <= 0
+              || fullAutoCompleteMatches.size() < contactAutoCompleteMaxResultsLimit)
+          .forEachOrdered(fullAutoCompleteMatches::add);
 
       // process matches from "other preferred accounts"
-      for (var otherAccountId : otherPreferredAccountIds) {
-        final var otherAccountAutoCompleteResponse = doAutoCompleteOnAccount(authenticatedAccount,
-            zAuthToken, otherAccountId, autoCompleteRequest);
-        for (var autoCompleteMatch : otherAccountAutoCompleteResponse.getMatches()) {
-          if (contactAutoCompleteMaxResultsLimit > 0
-              && fullAutoCompleteMatches.size() + otherAutoCompleteMatches.size()
-              >= contactAutoCompleteMaxResultsLimit) {
-            break;
-          }
-          if (!fullAutoCompleteMatches.contains(autoCompleteMatch)) {
-            otherAutoCompleteMatches.add(autoCompleteMatch);
-          }
-        }
-      }
+      otherPreferredAccountIds.stream()
+          .map(otherAccountId -> doAutoCompleteOnAccount(authenticatedAccount, zAuthToken, otherAccountId,
+              autoCompleteRequest))
+          .forEachOrdered(otherAccountAutoCompleteResponse -> otherAccountAutoCompleteResponse.getMatches().stream()
+              .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
+                  .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
+              .forEachOrdered(otherAutoCompleteMatches::add));
+
       otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
           .thenComparing(AutoCompleteMatch::getEmail));
-    } catch (ServiceException | IOException e) {
+    } catch (ServiceException e) {
       throw ServiceException.FAILURE(e.getMessage());
     }
-    fullAutoCompleteMatches.addAll(otherAutoCompleteMatches);
+
+    otherAutoCompleteMatches.stream()
+        .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
+            .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
+        .limit(Math.max(contactAutoCompleteMaxResultsLimit - fullAutoCompleteMatches.size(), 0))
+        .forEach(fullAutoCompleteMatches::add);
 
     return fullAutoCompleteResponseFor(fullAutoCompleteMatches, false);
   }
@@ -124,50 +121,56 @@ public class FullAutoComplete extends MailDocumentHandler {
    * @param autoCompleteRequest  The original {@link AutoCompleteRequest} element that will be used to perform {@link
    *                             AutoComplete} SOAP call
    * @return {@link AutoCompleteResponse}
-   * @throws ServiceException If something goes wrong.
-   * @throws IOException      If an I/O error occurs during the request transport.
    */
   private AutoCompleteResponse doAutoCompleteOnAccount(Account authenticatedAccount, ZAuthToken zAuthToken,
-      String requestedAccountId, AutoCompleteRequest autoCompleteRequest)
-      throws ServiceException, IOException {
-    final var soapUrl = URLUtil.getSoapURL(authenticatedAccount.getServer(), true);
-    final var autocompleteRequestElement = JaxbUtil.jaxbToElement(autoCompleteRequest);
+      String requestedAccountId, AutoCompleteRequest autoCompleteRequest) {
+    try {
+      final var soapUrl = URLUtil.getSoapURL(authenticatedAccount.getServer(), true);
+      final var autocompleteRequestElement = JaxbUtil.jaxbToElement(autoCompleteRequest);
 
-    final AutoCompleteResponse autoCompleteResponse;
-    if (authenticatedAccount.getId().equalsIgnoreCase(requestedAccountId)) {
-      autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
-          autocompleteRequestElement), AutoCompleteResponse.class);
-    } else {
-      autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
-          autocompleteRequestElement, requestedAccountId));
+      final AutoCompleteResponse autoCompleteResponse;
+      if (authenticatedAccount.getId().equalsIgnoreCase(requestedAccountId)) {
+        autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
+            autocompleteRequestElement), AutoCompleteResponse.class);
+      } else {
+        autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
+            autocompleteRequestElement, requestedAccountId));
+      }
+      return autoCompleteResponse;
+    } catch (ServiceException | IOException ignored) {
+      // TODO add logging
+      return new AutoCompleteResponse();
     }
-    return autoCompleteResponse;
   }
 
   /**
    * Parses {@link com.zimbra.common.soap.MailConstants#E_ORDERED_ACCOUNT_IDS} into a {@link Tuple2} object containing
-   * first object as "Preferred Account" and second object as "Other Preferred Account"
+   * the "preferred account" and "other preferred accounts". Duplicates account IDs are omitted.
    *
-   * @param preferredAccountsStr {@link String} containing comma seperated ordered list of accounts IDs
-   * @return a tuple containing first object as "Preferred Account" and second object as "Other Preferred Account".
+   * @param preferredAccountsStr A {@link String} containing a comma-separated ordered list of account IDs.
+   * @return A tuple containing the preferred account and other preferred accounts.
    */
-  Tuple2<String, List<String>> parsePreferredAccountsFrom(String preferredAccountsStr) {
-    String preferredAccount = null;
-    final var otherAccounts = new ArrayList<String>();
+  Tuple2<String, LinkedHashSet<String>> parsePreferredAccountsFrom(String preferredAccountsStr) {
+    if (preferredAccountsStr == null || preferredAccountsStr.isEmpty()) {
+      return new Tuple2<>(null, new LinkedHashSet<>());
+    }
 
-    if (preferredAccountsStr != null && !preferredAccountsStr.isEmpty()) {
-      String[] tokens = preferredAccountsStr.split(",");
-      for (String token : tokens) {
-        String trimmedToken = token.trim();
-        if (!trimmedToken.isEmpty()) {
-          if (preferredAccount == null) {
-            preferredAccount = trimmedToken;
-          } else {
-            otherAccounts.add(trimmedToken);
-          }
+    final var seenTokens = new HashSet<String>();
+    final var otherAccounts = new LinkedHashSet<String>();
+    String preferredAccount = null;
+
+    for (var token : preferredAccountsStr.split(",")) {
+      var trimmedToken = token.trim();
+      if (!trimmedToken.isEmpty() && !seenTokens.contains(trimmedToken)) {
+        if (preferredAccount == null) {
+          preferredAccount = trimmedToken;
+        } else {
+          otherAccounts.add(trimmedToken);
         }
+        seenTokens.add(trimmedToken);
       }
     }
+
     return new Tuple2<>(preferredAccount, otherAccounts);
   }
 }

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -100,10 +100,11 @@ public class FullAutoComplete extends MailDocumentHandler {
           }
         }
       }
-      otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed());
     } catch (ServiceException | IOException e) {
       throw ServiceException.FAILURE(e.getMessage());
     }
+    otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
+        .thenComparing(AutoCompleteMatch::getEmail));
 
     fullAutoCompleteMatches.addAll(otherAutoCompleteMatches);
 

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -100,12 +100,11 @@ public class FullAutoComplete extends MailDocumentHandler {
           }
         }
       }
+      otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
+          .thenComparing(AutoCompleteMatch::getEmail));
     } catch (ServiceException | IOException e) {
       throw ServiceException.FAILURE(e.getMessage());
     }
-    otherAutoCompleteMatches.sort(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
-        .thenComparing(AutoCompleteMatch::getEmail));
-
     fullAutoCompleteMatches.addAll(otherAutoCompleteMatches);
 
     final AutoCompleteResponse autoCompleteResponse = new FullAutocompleteResponse();

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -136,7 +136,7 @@ public class FullAutoComplete extends MailDocumentHandler {
       }
       return autoCompleteResponse;
     } catch (ServiceException | IOException e) {
-      ZimbraLog.misc.warn(e.getMessage(), e);
+      ZimbraLog.misc.warn(e.getMessage());
       return new AutoCompleteResponse();
     }
   }

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -31,6 +31,13 @@ import java.util.Map;
 public class FullAutoComplete extends MailDocumentHandler {
 
 
+  /**
+   * Parses {@link com.zimbra.common.soap.MailConstants#E_ORDERED_ACCOUNT_IDS} into a {@link Tuple2} object containing
+   * first object as "Preferred Account" and second object as "Other Preferred Account"
+   *
+   * @param input {@link String} containing comma seperated ordered list of accounts IDs
+   * @return a tuple containing first object as "Preferred Account" and second object as "Other Preferred Account"
+   */
   private Tuple2<String, List<String>> parsePreferredAccounts(String input) {
     String preferredAccount = null;
     List<String> otherAccounts = new ArrayList<>();
@@ -106,6 +113,16 @@ public class FullAutoComplete extends MailDocumentHandler {
     return JaxbUtil.jaxbToElement(autoCompleteResponse);
   }
 
+  /**
+   * @param authenticatedAccount The Authenticated account
+   * @param zAuthToken           The {@link ZAuthToken} that will be used to perform SOAP calls
+   * @param requestedAccountId   The account ID for which the {@link AutoComplete} matches will be returned
+   * @param autoCompleteRequest  The original {@link AutoCompleteRequest} element that will be used to perform {@link
+   *                             AutoComplete} SOAP call
+   * @return {@link AutoCompleteResponse}
+   * @throws ServiceException If something goes wrong.
+   * @throws IOException      If an I/O error occurs during the request transport.
+   */
   private AutoCompleteResponse doAutoCompleteOnAccount(Account authenticatedAccount, ZAuthToken zAuthToken,
       String requestedAccountId, AutoCompleteRequest autoCompleteRequest)
       throws ServiceException, IOException {

--- a/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.zextras.mailbox.soap.SoapTestSuite;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountAction;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
+import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.cs.account.Account;
@@ -24,9 +25,12 @@ import com.zimbra.soap.mail.message.FullAutocompleteResponse;
 import com.zimbra.soap.mail.type.AutoCompleteMatch;
 import com.zimbra.soap.mail.type.ContactSpec;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import org.apache.http.HttpResponse;
 import org.junit.jupiter.api.BeforeAll;
@@ -163,75 +167,39 @@ class FullAutoCompleteTest extends SoapTestSuite {
   @Test
   void should_return_relevant_matches_ordered_by_ranking_without_duplicates() throws Exception {
     String searchTerm = "test-";
-    String email1 = searchTerm + UUID.randomUUID() + "_email1@something.com";
-    String email2 = searchTerm + UUID.randomUUID() + "_email2@something.com";
-    String email3 = searchTerm + UUID.randomUUID() + "_email3@something.com";
-    String email4 = searchTerm + UUID.randomUUID() + "_email4@something.com";
-    String email5 = searchTerm + UUID.randomUUID() + "_email5@something.com";
+    String domain = "something.com";
+    String userName = searchTerm + "_email";
 
-    // create accounts
-    Account account = accountCreatorFactory.get().withUsername(searchTerm + "user1-" + UUID.randomUUID()).create();
-    Account account2 = accountCreatorFactory.get().withUsername(searchTerm + "user2-" + UUID.randomUUID()).create();
-    Account account3 = accountCreatorFactory.get().withUsername(searchTerm + "user3-" + UUID.randomUUID()).create();
+    String contactEmail1 = userName + "1" + "@" + domain;
+    String contactEmail2 = userName + "2" + "@" + domain;
+    String contactEmail3 = userName + "3" + "@" + domain;
+    String contactEmail4 = userName + "4" + "@" + domain;
+    String contactEmail5 = userName + "5" + "@" + domain;
 
-    // create contacts account
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email1)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email2)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email3)));
+    Account account = createAccountWithContacts(contactEmail1, contactEmail2, contactEmail3);
+    Account account2 = createAccountWithContacts(contactEmail1, contactEmail2, contactEmail3);
+    Account account3 = createAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4,
+        contactEmail5);
 
-    // create contacts account2
-    getSoapClient().executeSoap(account2, new CreateContactRequest(new ContactSpec().addEmail(email1)));
-    getSoapClient().executeSoap(account2, new CreateContactRequest(new ContactSpec().addEmail(email2)));
-    getSoapClient().executeSoap(account2, new CreateContactRequest(new ContactSpec().addEmail(email3)));
+    shareAccountWithPrimary(account2, account);
+    shareAccountWithPrimary(account3, account);
 
-    // create contacts account3
-    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(email1)));
-    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(email2)));
-    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(email3)));
-    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(email4)));
-    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(email5)));
+    incrementRankings(account, contactEmail1, 2);
+    incrementRankings(account, contactEmail3, 3);
+    incrementRankings(account2, contactEmail2, 3);
+    incrementRankings(account2, contactEmail3, 2);
+    incrementRankings(account3, contactEmail1, 2);
+    incrementRankings(account3, contactEmail4, 4);
 
-    // share accounts with primary account (account)
-    accountActionFactory.forAccount(account2).shareWith(account);
-    accountActionFactory.forAccount(account3).shareWith(account);
-
-    // increment the ranking
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email3)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email3)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email3)));
-
-    ContactRankings.increment(account2.getId(), Collections.singleton(new InternetAddress(email2)));
-    ContactRankings.increment(account2.getId(), Collections.singleton(new InternetAddress(email2)));
-    ContactRankings.increment(account2.getId(), Collections.singleton(new InternetAddress(email2)));
-    ContactRankings.increment(account2.getId(), Collections.singleton(new InternetAddress(email3)));
-    ContactRankings.increment(account2.getId(), Collections.singleton(new InternetAddress(email3)));
-
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email4)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email4)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email4)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email4)));
-
-    FullAutocompleteRequest fullAutocompleteRequest = new FullAutocompleteRequest(
-        new AutoCompleteRequest(searchTerm));
-    fullAutocompleteRequest.setOrderedAccountIds(account.getId() + "," + account2.getId() + "," + account3.getId());
-
-    Element request = JaxbUtil.jaxbToElement(fullAutocompleteRequest);
-    HttpResponse execute = getSoapClient().newRequest().setCaller(account).setSoapBody(request).execute();
-    String responseBody = new String(execute.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
-
-    Element rootElement = Element.parseXML(responseBody).getElement("Body").getElement(
-        MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
-    FullAutocompleteResponse fullAutocompleteResponse = JaxbUtil.elementToJaxb(rootElement,
-        FullAutocompleteResponse.class);
+    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account, account,
+        account2,
+        account3);
 
     assertEquals(5, fullAutocompleteResponse.getMatches().size());
 
     List<Integer> expectedRanking = List.of(3, 2, 0, 4, 0);
-    List<String> expectedMatchedEmailAddresses = List.of(email3, email1, email2, email4, email5);
+    List<String> expectedMatchedEmailAddresses = List.of(contactEmail3, contactEmail1, contactEmail2, contactEmail4,
+        contactEmail5, contactEmail5);
     for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
       AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
       assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
@@ -242,73 +210,37 @@ class FullAutoCompleteTest extends SoapTestSuite {
   @Test
   void should_order_relevant_matches_by_ranking_and_alphabetically_when_matches_have_same_ranking() throws Exception {
     String searchTerm = "test";
-    String email1 = searchTerm + "_email1@something.com";
-    String email2 = searchTerm + "_email2@something.com";
-    String email3 = searchTerm + "_email3@something.com";
-    String email4 = searchTerm + "_email4@something.com";
-    String email5 = searchTerm + "_email5@something.com";
-    String email6 = searchTerm + "_email6@something.com";
-    String email7 = searchTerm + "_email7@something.com";
-    String email8 = UUID.randomUUID() + "_email8@something.com";
+    String domain = "something.com";
+    String userName = searchTerm + "_email";
 
-    // create accounts
-    Account account = accountCreatorFactory.get()
-        .withUsername(searchTerm + "user1-" + UUID.randomUUID()).create();
-    Account account2 = accountCreatorFactory.get()
-        .withUsername(searchTerm + "user2-" + UUID.randomUUID()).create();
-    Account account3 = accountCreatorFactory.get()
-        .withUsername(searchTerm + "user3-" + UUID.randomUUID()).create();
+    String contactEmail1 = userName + "1" + "@" + domain;
+    String contactEmail2 = userName + "2" + "@" + domain;
+    String contactEmail3 = userName + "3" + "@" + domain;
+    String contactEmail4 = userName + "4" + "@" + domain;
+    String contactEmail5 = userName + "5" + "@" + domain;
+    String contactEmail6 = userName + "6" + "@" + domain;
+    String contactEmail7 = userName + "7" + "@" + domain;
 
-    // create contacts for account
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email1)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email2)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email3)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email4)));
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(email8)));
+    Account account = createAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
+    Account account2 = createAccountWithContacts(contactEmail5);
+    Account account3 = createAccountWithContacts(contactEmail6, contactEmail7);
 
-    // create contacts for account2
-    getSoapClient().executeSoap(account2,
-        new CreateContactRequest(new ContactSpec().addEmail(email5)));
+    shareAccountWithPrimary(account2, account);
+    shareAccountWithPrimary(account3, account);
 
-    // create contacts for account3
-    getSoapClient().executeSoap(account3,
-        new CreateContactRequest(new ContactSpec().addEmail(email6)));
-    getSoapClient().executeSoap(account3,
-        new CreateContactRequest(new ContactSpec().addEmail(email7)));
+    incrementRankings(account, contactEmail1, 2);
+    incrementRankings(account, contactEmail3, 2);
+    incrementRankings(account3, contactEmail6, 2);
 
-    // share accounts with primary account (account)
-    accountActionFactory.forAccount(account2).shareWith(account);
-    accountActionFactory.forAccount(account3).shareWith(account);
-
-    // increment the ranking
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email1)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email3)));
-    ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email3)));
-
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email6)));
-    ContactRankings.increment(account3.getId(), Collections.singleton(new InternetAddress(email6)));
-
-    FullAutocompleteRequest fullAutocompleteRequest = new FullAutocompleteRequest(
-        new AutoCompleteRequest(searchTerm));
-    fullAutocompleteRequest.setOrderedAccountIds(
-        account.getId() + "," + account2.getId() + "," + account3.getId());
-
-    Element request = JaxbUtil.jaxbToElement(fullAutocompleteRequest);
-    HttpResponse execute = getSoapClient().newRequest().setCaller(account).setSoapBody(request)
-        .execute();
-    String responseBody = new String(execute.getEntity().getContent().readAllBytes(),
-        StandardCharsets.UTF_8);
-
-    Element rootElement = Element.parseXML(responseBody).getElement("Body").getElement(
-        MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
-    FullAutocompleteResponse fullAutocompleteResponse = JaxbUtil.elementToJaxb(rootElement,
-        FullAutocompleteResponse.class);
-    System.out.println("responseBody = " + responseBody);
+    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account, account,
+        account2,
+        account3);
 
     assertEquals(7, fullAutocompleteResponse.getMatches().size());
     List<Integer> expectedRanking = List.of(2, 2, 0, 0, 2, 0, 0);
-    List<String> expectedMatchedEmailAddresses = List.of(email1, email3, email2, email4, email6, email5, email7);
+    List<String> expectedMatchedEmailAddresses = Arrays.asList(contactEmail1, contactEmail3, contactEmail2,
+        contactEmail4, contactEmail6,
+        contactEmail5, contactEmail7);
     for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
       AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
       assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
@@ -319,7 +251,44 @@ class FullAutoCompleteTest extends SoapTestSuite {
   @Test
   @Disabled("Behavior needed to be discussed")
   void should_do_something_when_request_misses_OrderedAccountIds() {
-      // should return AutoComplete matches from authenticated
+    // should return AutoComplete matches from authenticated
+  }
+
+
+  private Account createAccountWithContacts(String... emails) throws Exception {
+    Account account = accountCreatorFactory.get().withUsername("user-" + UUID.randomUUID()).create();
+    for (String contactEmail : emails) {
+      getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(contactEmail)));
+    }
+    return account;
+  }
+
+  private void shareAccountWithPrimary(Account accountToShare, Account primaryAccount) throws ServiceException {
+    accountActionFactory.forAccount(accountToShare).shareWith(primaryAccount);
+  }
+
+  private void incrementRankings(Account account, String email, int times) throws AddressException, ServiceException {
+    for (int i = 0; i < times; i++) {
+      ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(email)));
+    }
+  }
+
+  private FullAutocompleteResponse performFullAutocompleteRequest(String searchTerm, Account authenticatorAccount,
+      Account... orderedAccountIds)
+      throws Exception {
+    FullAutocompleteRequest request = new FullAutocompleteRequest(new AutoCompleteRequest(searchTerm));
+    String orderedAccountIdsStr = Arrays.stream(orderedAccountIds).map(Account::getId).collect(Collectors.joining(","));
+    request.setOrderedAccountIds(orderedAccountIdsStr);
+    Element requestElement = JaxbUtil.jaxbToElement(request);
+    HttpResponse response = getSoapClient().newRequest().setCaller(authenticatorAccount).setSoapBody(requestElement)
+        .execute();
+    String responseBody = new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+
+    System.out.println("responseBody = " + responseBody);
+
+    Element rootElement = Element.parseXML(responseBody).getElement("Body")
+        .getElement(MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
+    return JaxbUtil.elementToJaxb(rootElement, FullAutocompleteResponse.class);
   }
 }
 

--- a/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
@@ -294,5 +294,11 @@ class FullAutoCompleteTest extends SoapTestSuite {
 //
 //    Assertions.assertEquals(5, fullAutocompleteResponse.getMatches().size());
   }
+
+  @Test
+  @Disabled("Behavior needed to be discussed")
+  void should_do_something_when_request_misses_OrderedAccountIds() {
+      // should return AutoComplete matches from authenticated
+  }
 }
 


### PR DESCRIPTION
**What has changed:**
- A new element `'orderedAccountIds'` was introduced in `FullAutocompleteRequest` . This field is used to specify the accounts from which autocomplete matches will be returned. The order of the account IDs in this field determines the  order in which the macthes are returned in `FullAutocompleteResponse` .
- Enhacned ordering algorithm to return FullAutocomplete matches. The new sorting/ordering and limiting algorithm works as follows:
    - Matches from the most preferred source account (the first accountId in 'orderedAccountIds') are given higher priority and are placed on top.
    - Matches from other source accounts are sorted primarily based on ranking, followed by alphabetical ordering.
    - Duplicate matches are omitted keeping the highest ranked match from both preferred account and other source accounts.
    - If the optional `'orderedAccountIds'` element is not passed, matches from the authenticated Account are returned.
    - The number of matches returned depends on the value set for authenticated account's `ContactAutoCompleteMaxResults` attribute.
    
- API call no more fails if call to retrieve matches from one or more  remote accounts fails due to permissions, network issues, or for any other reason. Instead, the failure is logged, and matches from the functioning accounts/mailboxes are returned. 