### PR TITLE
chore: remove PIDFile from systemd units

### DIFF
--- a/packages/appserver-service/carbonio-appserver.service
+++ b/packages/appserver-service/carbonio-appserver.service
@@ -6,7 +6,6 @@ PartOf=carbonio-appserver.target carbonio-ce.target carbonio.target
 
 [Service]
 User=zextras
-PIDFile=/opt/zextras/log/zmmailboxd_java.pid
 EnvironmentFile=-/opt/zextras/data/systemd.env
 ExecStartPre=/opt/zextras/bin/zmtlsctl
 ExecStart=/opt/zextras/common/bin/java \

--- a/packages/common-appserver-conf/carbonio-milter.service
+++ b/packages/common-appserver-conf/carbonio-milter.service
@@ -6,7 +6,6 @@ PartOf=carbonio-mta.target carbonio-ce.target carbonio.target
 
 [Service]
 User=zextras
-PIDFile=/opt/zextras/log/milter.pid
 EnvironmentFile=-/opt/zextras/data/systemd.env
 ExecStart=/opt/zextras/common/lib/jvm/java/bin/java \
   -XX:ErrorFile=/opt/zextras/log \


### PR DESCRIPTION
`PIDFile` is only used in conjunction with `Type=forking` and its usage is discouraged