### PR TITLE
revert: [CO-982] Enhance ordering of matches in FullAutoComplet…

### DIFF
--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -10,7 +10,7 @@ import org.dom4j.QName;
 
 public final class MailConstants {
 
-  public static final String E_ORDERED_ACCOUNT_IDS = "orderedAccountIds";
+  public static final String E_EXTRA_ACCOUNT_ID = "extraAccountId";
   public static final String A_REQUIRES_SMART_LINK_CONVERSION = "requiresSmartLinkConversion";
 
   public static final class ShareConstants {

--- a/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/message/FullAutocompleteRequest.java
@@ -5,6 +5,8 @@
 package com.zimbra.soap.mail.message;
 
 import com.zimbra.common.soap.MailConstants;
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -13,45 +15,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * @zm-api-command-auth-required true
  * @zm-api-command-admin-auth-required false
- * @zm-api-command-description Retrieves AutoComplete matches from multiple source Accounts defined by
- * 'orderedAccountIds'. The ordering logic ensures that the most relevant results are returned based on the values
- * supplied in the 'orderedAccountIds' element. The returned matches are ordered (top match being most relevant) based
- * on account IDs order passed in 'orderedAccountIds'. Hence, the 'ranking' attribute of matches should be ignored.
+ * @zm-api-command-description FullAutoComplete
+ * This API executes an AutoComplete on current logged in account and all extra requested accounts.
+ * If one of the requests in extra accounts fails, the whole API will fail.
+ * The API returns the same content of AutoComplete by merging the result and discarding duplicates
+ * following the order of requested accounts, starting from logged user response.
  *
- * <p>
- * The sorting/ordering and limiting algorithm works as follows:
- * <ul>
- *     <li>Matches from the most preferred source account (the first accountId in 'orderedAccountIds') are given higher priority and are placed on top.</li>
- *     <li>Matches from other source accounts are sorted primarily based on ranking, followed by alphabetical ordering.</li>
- *     <li>Duplicate matches from other source accounts are omitted, with comparison against matches from the preferred source account.</li>
- *     <li>If the optional 'orderedAccountIds' element is not passed, matches from the authenticated Account are returned, which is equivalent to a regular AutoCompleteRequest.</li>
- *     <li>The number of matches returned depends on the value set for authenticated account's ContactAutoCompleteMaxResults attribute.</li>
- * </ul>
- * </p>
  */
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlRootElement(name = MailConstants.E_FULL_AUTO_COMPLETE_REQUEST)
+@XmlRootElement(name= MailConstants.E_FULL_AUTO_COMPLETE_REQUEST)
 public class FullAutocompleteRequest {
-
-  @XmlElement(name = MailConstants.E_AUTO_COMPLETE_REQUEST, required = true)
-  private AutoCompleteRequest autoCompleteRequest;
-
-  /**
-   * Represents an ordered, comma-separated list of account IDs whose autocomplete matches will be included in the
-   * {@link FullAutocompleteResponse}.
-   *
-   * <p>
-   * This field is used to specify the accounts from which autocomplete matches should be retrieved. The order of the
-   * account IDs determines the order in which matches in response are returned.
-   * </p>
-   *
-   * @zm-api-field-tag orderedAccountIds
-   * @zm-api-field-description ordered, comma-separated list of account IDs whose matches will be included in the
-   * FullAutocompleteResponse. Duplicate account IDs are ignored.
-   */
-  @XmlElement(name = MailConstants.E_ORDERED_ACCOUNT_IDS, required = false)
-  private String orderedAccountIds;
-
 
   public FullAutocompleteRequest() {
   }
@@ -59,6 +32,10 @@ public class FullAutocompleteRequest {
   public FullAutocompleteRequest(AutoCompleteRequest autoCompleteRequest) {
     this.autoCompleteRequest = autoCompleteRequest;
   }
+
+
+  @XmlElement(name=MailConstants.E_AUTO_COMPLETE_REQUEST, required=true)
+  private AutoCompleteRequest autoCompleteRequest;
 
   public AutoCompleteRequest getAutoCompleteRequest() {
     return autoCompleteRequest;
@@ -68,11 +45,18 @@ public class FullAutocompleteRequest {
     this.autoCompleteRequest = autoCompleteRequest;
   }
 
-  public String getOrderedAccountIds() {
-    return orderedAccountIds;
+  /**
+   * @zm-api-field-tag extraAccountIds
+   * @zm-api-field-description Extra accounts where to execute the autocomplete on
+   */
+  @XmlElement(name=MailConstants.E_EXTRA_ACCOUNT_ID, required=false)
+  private final List<String> extraAccountIds = new ArrayList<>();
+
+  public void addAccount(String account) {
+    this.extraAccountIds.add(account);
   }
 
-  public void setOrderedAccountIds(String orderedAccountIds) {
-    this.orderedAccountIds = orderedAccountIds;
+  public List<String> getExtraAccountIds() {
+    return extraAccountIds;
   }
 }

--- a/store/src/main/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/ContactAutoComplete.java
@@ -102,22 +102,6 @@ public class ContactAutoComplete {
 
     }
 
-    public enum ContactEntryType {
-        GAL("gal"),
-        RANKING_TABLE("rankingTable"),
-        CONTACT("contact");
-
-        public String getName() {
-            return name;
-        }
-
-        private final String name;
-
-        ContactEntryType(String name) {
-            this.name = name;
-        }
-    }
-
     public static final class ContactEntry implements Comparable<ContactEntry> {
         String mEmail;
         String mDisplayName;

--- a/store/src/main/java/com/zimbra/cs/service/mail/AutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/AutoComplete.java
@@ -5,7 +5,6 @@
 
 package com.zimbra.cs.service.mail;
 
-import com.zimbra.cs.mailbox.ContactAutoComplete.ContactEntryType;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -86,7 +85,7 @@ public class AutoComplete extends MailDocumentHandler {
     protected void toXML(Element response, AutoCompleteResult result, String authAccountId) {
         response.addAttribute(MailConstants.A_CANBECACHED, result.canBeCached);
         for (ContactEntry entry : result.entries) {
-            Element cn = response.addNonUniqueElement(MailConstants.E_MATCH);
+            Element cn = response.addElement(MailConstants.E_MATCH);
             
             // for contact group, emails of members will be expanded 
             // separately on user request
@@ -152,10 +151,10 @@ public class AutoComplete extends MailDocumentHandler {
 
     private String getType(ContactEntry entry) {
         if (entry.getFolderId() == ContactAutoComplete.FOLDER_ID_GAL)
-            return ContactEntryType.GAL.getName();
+            return "gal";
         else if (entry.getFolderId() == ContactAutoComplete.FOLDER_ID_UNKNOWN)
-            return ContactEntryType.RANKING_TABLE.getName();
+            return "rankingTable";
         else
-            return ContactEntryType.CONTACT.getName();
+            return "contact";
     }
 }

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -7,13 +7,9 @@ package com.zimbra.cs.service.mail;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
-import com.zimbra.common.soap.Element.XMLElement;
-import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapHttpTransport;
-import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.httpclient.URLUtil;
-import com.zimbra.cs.mailbox.ContactAutoComplete.ContactEntryType;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.message.AutoCompleteRequest;
@@ -21,233 +17,83 @@ import com.zimbra.soap.mail.message.AutoCompleteResponse;
 import com.zimbra.soap.mail.message.FullAutocompleteRequest;
 import com.zimbra.soap.mail.message.FullAutocompleteResponse;
 import com.zimbra.soap.mail.type.AutoCompleteMatch;
-import io.vavr.Tuple2;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
- * A variant of {@link AutoComplete} that returns {@link AutoCompleteMatch}es from multiple sources ({@link Account}s)
- * based on the order provided by the {@link com.zimbra.common.soap.MailConstants#E_ORDERED_ACCOUNT_IDS}
+ * A variant of {@link AutoComplete} that returns all contacts of authenticated account
+ * + contacts of all accounts shared with it.
+ * It doesn't support delegated requests.
+ *
  */
 public class FullAutoComplete extends MailDocumentHandler {
 
   @Override
   public Element handle(Element request, Map<String, Object> context) throws ServiceException {
-    final var zsc = getZimbraSoapContext(context);
-    final var fullAutocompleteRequest = getFullAutocompleteRequestFrom(request);
-    final var fullAutoCompleteMatches = new ArrayList<AutoCompleteMatch>();
-    final var otherAutoCompleteMatches = new ArrayList<AutoCompleteMatch>();
-    final var authenticatedAccount = zsc.getAuthToken().getAccount();
-    final int contactAutoCompleteMaxResultsLimit = authenticatedAccount.getContactAutoCompleteMaxResults();
+    ZimbraSoapContext zsc = getZimbraSoapContext(context);
+    final List<AutoCompleteResponse> autoCompleteResponses = new ArrayList<>();
+    final FullAutocompleteRequest fullAutocompleteRequest = JaxbUtil.elementToJaxb(request);
 
+    final Account authenticatedAccount = zsc.getAuthToken().getAccount();
+    final ZAuthToken zAuthToken = zsc.getAuthToken().toZAuthToken();
+    final AutoCompleteRequest autoCompleteRequest = fullAutocompleteRequest.getAutoCompleteRequest();
+    Map<String, AutoCompleteMatch> matchesComparator = new HashMap<>();
     try {
-      final var autoCompleteRequest = fullAutocompleteRequest.getAutoCompleteRequest();
-      final var zAuthToken = zsc.getAuthToken().toZAuthToken();
-      final var parsedAccountIds = parsePreferredAccountsFrom(
-          fullAutocompleteRequest.getOrderedAccountIds());
-      final var preferredAccountId = parsedAccountIds._1();
-      final var otherPreferredAccountIds = parsedAccountIds._2();
-
-      doAutoCompleteOnAccount(authenticatedAccount, zAuthToken, preferredAccountId, autoCompleteRequest)
-          .getMatches()
-          .stream()
-          .limit(Math.max(contactAutoCompleteMaxResultsLimit, 0))
-          .forEachOrdered(fullAutoCompleteMatches::add);
-
-      otherPreferredAccountIds.stream()
-          .map(otherAccountId -> doAutoCompleteOnAccount(authenticatedAccount, zAuthToken, otherAccountId,
-              autoCompleteRequest))
-          .forEachOrdered(otherAccountAutoCompleteResponse -> otherAccountAutoCompleteResponse.getMatches().stream()
-              .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
-                  .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
-              .forEachOrdered(otherAutoCompleteMatches::add));
-    } catch (ServiceException e) {
+      final AutoCompleteResponse selfAutoComplete;
+      selfAutoComplete = doSelfAutoComplete(authenticatedAccount, zAuthToken,
+          autoCompleteRequest);
+      autoCompleteResponses.add(selfAutoComplete);
+    } catch (IOException e) {
       throw ServiceException.FAILURE(e.getMessage());
     }
 
-    otherAutoCompleteMatches.stream()
-        .sorted(Comparator.comparing(AutoCompleteMatch::getRanking).reversed()
-            .thenComparing(AutoCompleteMatch::getEmail))
-        .filter(autoCompleteMatch -> fullAutoCompleteMatches.stream()
-            .noneMatch(m -> m.getEmail().equalsIgnoreCase(autoCompleteMatch.getEmail())))
-        .limit(Math.max(contactAutoCompleteMaxResultsLimit - fullAutoCompleteMatches.size(), 0))
-        .forEachOrdered(fullAutoCompleteMatches::add);
-
-    return fullAutoCompleteResponseFor(fullAutoCompleteMatches, false, zsc);
-  }
-
-  /**
-   * Retrieves a {@link FullAutocompleteRequest} object from the provided raw XML {@link Element}.
-   *
-   * @param request The raw XML {@link Element} containing the {@link FullAutocompleteRequest}.
-   * @return The {@link FullAutocompleteRequest} object parsed from the raw XML {@link Element}.
-   * @throws ServiceException If the raw XML {@link Element} does not contain a valid {@link FullAutocompleteRequest}
-   *                          element.
-   */
-  private FullAutocompleteRequest getFullAutocompleteRequestFrom(Element request) throws ServiceException {
-    final FullAutocompleteRequest fullAutocompleteRequest = JaxbUtil.elementToJaxb(request);
-
-    if (fullAutocompleteRequest == null) {
-      throw ServiceException.FAILURE("Invalid Request");
+    for (String requestedAccountId: fullAutocompleteRequest.getExtraAccountIds()) {
+      final AutoCompleteResponse accountAutoComplete;
+      try {
+        accountAutoComplete = doAutoCompleteOnAccount(authenticatedAccount, zAuthToken,
+            requestedAccountId, autoCompleteRequest);
+      } catch (IOException e) {
+        throw  ServiceException.FAILURE(e.getMessage());
+      }
+      autoCompleteResponses.add(accountAutoComplete);
     }
-    return fullAutocompleteRequest;
+
+    autoCompleteResponses.forEach(
+        autoCompleteResponse -> autoCompleteResponse.getMatches().forEach(
+            match -> matchesComparator.putIfAbsent(match.getEmail(), match)
+        )
+    );
+
+    AutoCompleteResponse autoCompleteResponse = new FullAutocompleteResponse();
+    autoCompleteResponse.setMatches(matchesComparator.values());
+    autoCompleteResponse.setCanBeCached(false);
+    return JaxbUtil.jaxbToElement(autoCompleteResponse);
+
   }
 
   /**
-   * Generates an XML {@link Element} representing a {@link FullAutocompleteResponse} based on the provided list of
-   * autocomplete matches ({@link AutoCompleteMatch}) and cache flag.
+   * Executes and {@link AutoCompleteRequest} from the requested Account.
    *
-   * @param fullAutoCompleteMatches The list of autocomplete({@link AutoCompleteMatch}) matches.
-   * @param canBeCached             A boolean flag indicating whether the response can be cached.
-   * @return The XML {@link  Element} representing the {@link FullAutocompleteResponse}.
-   */
-  @SuppressWarnings("SameParameterValue")
-  private Element fullAutoCompleteResponseFor(List<AutoCompleteMatch> fullAutoCompleteMatches, boolean canBeCached,
-      ZimbraSoapContext zsc) {
-    final var response = zsc.createElement(MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
-    response.addAttribute(MailConstants.A_CANBECACHED, canBeCached);
-    getElementsForMatches(fullAutoCompleteMatches, zsc).forEach(response::addNonUniqueElement);
-    return response;
-  }
-
-  /**
-   * @param fullAutoCompleteMatches List of full {@link AutoCompleteMatch}es
-   * @return List of match {@link Element}s
-   */
-  private ArrayList<Element> getElementsForMatches(List<AutoCompleteMatch> fullAutoCompleteMatches, ZimbraSoapContext zsc) {
-
-    return fullAutoCompleteMatches.stream().map(match -> {
-      var matchElement = zsc.createElement(MailConstants.E_MATCH);
-      matchElement.addAttribute(MailConstants.A_RANKING, Integer.toString(match.getRanking()));
-      matchElement.addAttribute(MailConstants.A_MATCH_TYPE, match.getMatchType());
-      matchElement.addAttribute(MailConstants.A_IS_GROUP, match.getGroup());
-
-      // for contact group, emails of members will be expanded separately on user request
-      if (Boolean.FALSE.equals(match.getGroup())) {
-        matchElement.addAttribute(MailConstants.A_EMAIL, match.getEmail());
-      }
-
-      if (match.getGroup() && match.getCanExpandGroupMembers()) {
-        matchElement.addAttribute(MailConstants.A_EXP, true);
-      }
-
-      final String id = match.getId();
-      if (id != null) {
-        matchElement.addAttribute(MailConstants.A_ID, id);
-      }
-
-      final String folder = match.getFolder();
-      if (folder != null) {
-        matchElement.addAttribute(MailConstants.A_FOLDER, folder);
-      }
-
-      if (Boolean.TRUE.equals(match.getGroup()) || !Objects.equals(match.getMatchType(),
-          ContactEntryType.GAL.getName())) {
-        matchElement.addAttribute(MailConstants.A_DISPLAYNAME, match.getDisplayName());
-      }
-
-      final String firstName = match.getFirstName();
-      if (firstName != null) {
-        matchElement.addAttribute(MailConstants.A_FIRSTNAME, firstName);
-      }
-
-      final String middleName = match.getMiddleName();
-      if (middleName != null) {
-        matchElement.addAttribute(MailConstants.A_MIDDLENAME, middleName);
-      }
-
-      final String lastName = match.getLastName();
-      if (lastName != null) {
-        matchElement.addAttribute(MailConstants.A_LASTNAME, lastName);
-      }
-
-      final String fullName = match.getFullName();
-      if (fullName != null) {
-        matchElement.addAttribute(MailConstants.A_FULLNAME, fullName);
-      }
-
-      final String nickname = match.getNickname();
-      if (nickname != null) {
-        matchElement.addAttribute(MailConstants.A_NICKNAME, nickname);
-      }
-
-      final String company = match.getCompany();
-      if (company != null) {
-        matchElement.addAttribute(MailConstants.A_COMPANY, company);
-      }
-
-      final String fileAs = match.getFileAs();
-      if (fileAs != null) {
-        matchElement.addAttribute(MailConstants.A_FILEAS, fileAs);
-      }
-      return matchElement;
-    }).collect(Collectors.toCollection(ArrayList::new));
-  }
-
-  /**
-   * @param authenticatedAccount The Authenticated account
-   * @param zAuthToken           The {@link ZAuthToken} that will be used to perform SOAP calls
-   * @param requestedAccountId   The account ID for which the {@link AutoComplete} matches will be returned
-   * @param autoCompleteRequest  The original {@link AutoCompleteRequest} element that will be used to perform {@link
-   *                             AutoComplete} SOAP call
+   * @param zAuthToken a {@link ZAuthToken}
+   * @param requestedAccountId requested account id
+   * @param autoCompleteRequest the request to execute against requested target
    * @return {@link AutoCompleteResponse}
    */
-  private AutoCompleteResponse doAutoCompleteOnAccount(Account authenticatedAccount, ZAuthToken zAuthToken,
-      String requestedAccountId, AutoCompleteRequest autoCompleteRequest) {
-    try {
-      final var soapUrl = URLUtil.getSoapURL(authenticatedAccount.getServer(), true);
-      final var autocompleteRequestElement = JaxbUtil.jaxbToElement(autoCompleteRequest);
-
-      final AutoCompleteResponse autoCompleteResponse;
-      if (authenticatedAccount.getId().equalsIgnoreCase(requestedAccountId)) {
-        autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
-            autocompleteRequestElement), AutoCompleteResponse.class);
-      } else {
-        autoCompleteResponse = JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
+  private AutoCompleteResponse doAutoCompleteOnAccount(Account authenticatedAccount, ZAuthToken zAuthToken, String requestedAccountId, AutoCompleteRequest autoCompleteRequest)
+      throws ServiceException, IOException {
+    String soapUrl = URLUtil.getSoapURL(authenticatedAccount.getServer(), true);
+    final Element autocompleteRequestElement = JaxbUtil.jaxbToElement(autoCompleteRequest);
+    return JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
             autocompleteRequestElement, requestedAccountId));
-      }
-      return autoCompleteResponse;
-    } catch (ServiceException | IOException e) {
-      ZimbraLog.misc.warn(e.getMessage());
-      return new AutoCompleteResponse();
-    }
   }
 
-  /**
-   * Parses {@link com.zimbra.common.soap.MailConstants#E_ORDERED_ACCOUNT_IDS} into a {@link Tuple2} object containing
-   * the "preferred account" and "other preferred accounts". Duplicates account IDs are omitted.
-   *
-   * @param preferredAccountsStr A {@link String} containing a comma-separated ordered list of account IDs.
-   * @return A tuple containing the preferred account and other preferred accounts.
-   */
-  Tuple2<String, LinkedHashSet<String>> parsePreferredAccountsFrom(String preferredAccountsStr) {
-    if (preferredAccountsStr == null || preferredAccountsStr.isEmpty()) {
-      return new Tuple2<>(null, new LinkedHashSet<>());
-    }
-
-    final var seenTokens = new HashSet<String>();
-    final var otherAccounts = new LinkedHashSet<String>();
-    String preferredAccount = null;
-
-    for (var token : preferredAccountsStr.split(",")) {
-      var trimmedToken = token.trim();
-      if (!trimmedToken.isEmpty() && !seenTokens.contains(trimmedToken)) {
-        if (preferredAccount == null) {
-          preferredAccount = trimmedToken;
-        } else {
-          otherAccounts.add(trimmedToken);
-        }
-        seenTokens.add(trimmedToken);
-      }
-    }
-
-    return new Tuple2<>(preferredAccount, otherAccounts);
+  private AutoCompleteResponse doSelfAutoComplete(Account authenticatedAccount, ZAuthToken zAuthToken, AutoCompleteRequest autoCompleteRequest) throws ServiceException, IOException {
+    String soapUrl = URLUtil.getSoapURL(authenticatedAccount.getServer(), true);
+    final Element autocompleteRequestElement = JaxbUtil.jaxbToElement(autoCompleteRequest);
+    return JaxbUtil.elementToJaxb(new SoapHttpTransport(zAuthToken, soapUrl).invoke(
+        autocompleteRequestElement),  AutoCompleteResponse.class);
   }
 }

--- a/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
@@ -4,45 +4,30 @@
 
 package com.zimbra.cs.service.mail;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.zextras.mailbox.soap.SoapTestSuite;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountAction;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
-import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Cos;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.RightManager;
-import com.zimbra.cs.mailbox.ContactRankings;
-import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
-import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.mail.message.AutoCompleteRequest;
 import com.zimbra.soap.mail.message.CreateContactRequest;
 import com.zimbra.soap.mail.message.FullAutocompleteRequest;
 import com.zimbra.soap.mail.message.FullAutocompleteResponse;
-import com.zimbra.soap.mail.type.AutoCompleteMatch;
 import com.zimbra.soap.mail.type.ContactSpec;
-import io.vavr.Tuple2;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("api")
 class FullAutoCompleteTest extends SoapTestSuite {
@@ -52,305 +37,79 @@ class FullAutoCompleteTest extends SoapTestSuite {
 
   @BeforeAll
   static void beforeAll() throws Exception {
+    Provisioning provisioning = Provisioning.getInstance();
     accountActionFactory = new AccountAction.Factory(
         MailboxManager.getInstance(), RightManager.getInstance());
-    accountCreatorFactory = new AccountCreator.Factory(Provisioning.getInstance());
+    accountCreatorFactory = new AccountCreator.Factory(provisioning);
   }
 
-  private static Collection<Arguments> parsePreferredAccountsTestData() {
-    return Arrays.asList(
-        Arguments.of("", null, new LinkedHashSet<>()),
-        Arguments.of(null, null, new LinkedHashSet<>()),
-        Arguments.of("1,2,3", "1", new LinkedHashSet<>(Arrays.asList("2", "3"))),
-        Arguments.of("abc,def,ghi", "abc", new LinkedHashSet<>(Arrays.asList("def", "ghi"))),
-        Arguments.of("123", "123", new LinkedHashSet<>()),
-        Arguments.of("123 , ,", "123", new LinkedHashSet<>()),
-        Arguments.of("123 , ", "123", new LinkedHashSet<>()),
-        Arguments.of(" 123, ", "123", new LinkedHashSet<>()),
-        Arguments.of(",123,", "123", new LinkedHashSet<>()),
-        Arguments.of("123,123,456,456,789", "123", new LinkedHashSet<>(Arrays.asList("456", "789")))
-    );
-  }
 
 
   @Test
-  void should_return_matches_from_authenticated_account_only() throws Exception {
-    String domain = "abc.com";
-    String searchTerm = "fac";
-    String contactEmail1 = searchTerm + UUID.randomUUID() + "@" + domain;
-    String contactEmail2 = searchTerm + UUID.randomUUID() + "@" + domain;
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2);
+  void shouldReturnContactsOfAuthenticatedUserOnly() throws Exception {
+    final String domain = "abc.com";
+    final String prefix = "test-";
+    final Account account = accountCreatorFactory.get().create();
+    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(prefix + UUID.randomUUID() + "@" + domain)));
+    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(prefix + UUID.randomUUID() + "@" + domain)));
+    final AutoCompleteRequest autoCompleteRequest = new AutoCompleteRequest(prefix);
+    final FullAutocompleteRequest fullAutocompleteRequest = new FullAutocompleteRequest(autoCompleteRequest);
 
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        new ArrayList<>());
-
-    assertEquals(2, fullAutocompleteResponse.getMatches().size());
+    final Element request = JaxbUtil.jaxbToElement(fullAutocompleteRequest);
+    final HttpResponse execute = getSoapClient().newRequest().setCaller(account).setSoapBody(request).execute();
+    Assertions.assertEquals(HttpStatus.SC_OK, execute.getStatusLine().getStatusCode());
+    final String responseBody = new String(execute.getEntity().getContent().readAllBytes(),
+        StandardCharsets.UTF_8);
+    final Element rootElement = Element.parseXML(responseBody).getElement("Body").getElement(
+        MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
+    final FullAutocompleteResponse fullAutocompleteResponse = JaxbUtil.elementToJaxb(rootElement,
+        FullAutocompleteResponse.class);
+    System.out.println("Received: " + responseBody);
+    Assertions.assertEquals(2, fullAutocompleteResponse.getMatches().size());
   }
 
   @Test
-  void should_return_matches_from_authenticated_account_respecting_COS_AutoCompleteMaxResultsLimit() throws Exception {
-    String searchTerm = "fac";
-    final String contactEmail1 = searchTerm + UUID.randomUUID() + "@something.com";
-    final String contactEmail2 = searchTerm + UUID.randomUUID() + "@something.com";
-    final String contactEmail3 = searchTerm + UUID.randomUUID() + "@something.com";
+  @DisplayName("Account has account 2, account 3 shared with it. "
+      + "Execute FullAutocomplete, get also matching contacts from account2 and 3. No duplicates.")
+  void shouldReturnContactsOfAuthenticatedUserAndRequestedAccounts() throws Exception {
 
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3);
-    Cos cos = Provisioning.getInstance().createCos(UUID.randomUUID().toString(), Map.of());
-    cos.setContactAutoCompleteMaxResults(1);
-    Provisioning.getInstance().setCOS(account, cos);
 
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        new ArrayList<>());
+    final String prefix = "test-";
+    final String commonMail = prefix + UUID.randomUUID() + "something.com";
+    final Account account = accountCreatorFactory.get().withUsername(prefix + "user1-" + UUID.randomUUID()).create();
+    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(commonMail)));
 
-    assertEquals(1, fullAutocompleteResponse.getMatches().size());
+    final Account account2 = accountCreatorFactory.get().withUsername(prefix + "user2-" + UUID.randomUUID()).create();
+    accountActionFactory.forAccount(account2).shareWith(account);
+    getSoapClient().executeSoap(account2, new CreateContactRequest(new ContactSpec().addEmail(commonMail)));
+    getSoapClient().executeSoap(account2, new CreateContactRequest(new ContactSpec().addEmail(prefix + UUID.randomUUID() + "something.com")));
+
+    final Account account3 = accountCreatorFactory.get().withUsername(prefix + "user3-" + UUID.randomUUID()).create();
+    accountActionFactory.forAccount(account3).shareWith(account);
+    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(prefix + UUID.randomUUID() + "something.com")));
+    getSoapClient().executeSoap(account3, new CreateContactRequest(new ContactSpec().addEmail(prefix + UUID.randomUUID() + "something.com")));
+
+    final AutoCompleteRequest autoCompleteRequest = new AutoCompleteRequest(prefix);
+
+    final FullAutocompleteRequest fullAutocompleteRequest = new FullAutocompleteRequest(autoCompleteRequest);
+    fullAutocompleteRequest.addAccount(account2.getId());
+    fullAutocompleteRequest.addAccount(account3.getId());
+
+    // make the call
+    final Element request = JaxbUtil.jaxbToElement(fullAutocompleteRequest);
+    final HttpResponse execute = getSoapClient().newRequest().setCaller(account).setSoapBody(request).execute();
+    final String responseBody = new String(execute.getEntity().getContent().readAllBytes(),
+        StandardCharsets.UTF_8);
+    System.out.println("Received: " + responseBody);
+    Assertions.assertEquals(HttpStatus.SC_OK, execute.getStatusLine().getStatusCode());
+    final Element rootElement = Element.parseXML(responseBody).getElement("Body").getElement(
+        MailConstants.FULL_AUTO_COMPLETE_RESPONSE);
+    final FullAutocompleteResponse fullAutocompleteResponse = JaxbUtil.elementToJaxb(rootElement,
+        FullAutocompleteResponse.class);
+    Assertions.assertEquals(4, fullAutocompleteResponse.getMatches().size());
   }
 
-  @Test
-  void should_return_matches_from_authenticated_account_respecting_account_AutoCompleteMaxResultsLimit()
-      throws Exception {
-    String searchTerm = "fac";
-    String contactEmail1 = searchTerm + UUID.randomUUID() + "@something.com";
-    String contactEmail2 = searchTerm + UUID.randomUUID() + "@something.com";
 
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2);
 
-    getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(contactEmail1)));
-    getSoapClient().executeSoap(account,
-        new CreateContactRequest(new ContactSpec().addEmail(searchTerm + UUID.randomUUID() + "@something.com")));
 
-    account.setContactAutoCompleteMaxResults(1);
-
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        new ArrayList<>());
-
-    assertEquals(1, fullAutocompleteResponse.getMatches().size());
-  }
-
-  @Test
-  void should_return_matches_from_other_preferred_accounts_respecting_account_AutoCompleteMaxResultsLimit()
-      throws Exception {
-    String searchTerm = "fac";
-    String domain = "something.com";
-    String contactEmail1 = searchTerm + "email1@" + domain;
-    String contactEmail2 = searchTerm + "email2@" + domain;
-    String contactEmail3 = searchTerm + "email3@" + domain;
-    String contactEmail4 = searchTerm + "email4@" + domain;
-
-    Account account = createRandomAccountWithContacts(contactEmail1);
-    Account account2 = createRandomAccountWithContacts(contactEmail1, contactEmail2);
-    Account account3 = createRandomAccountWithContacts(contactEmail3, contactEmail4);
-
-    shareAccountWithPrimary(account2, account);
-    shareAccountWithPrimary(account3, account);
-
-    account.setContactAutoCompleteMaxResults(3);
-
-    ArrayList<Account> preferredAccounts = new ArrayList<>(List.of(account2, account3));
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        preferredAccounts);
-
-    assertEquals(3, fullAutocompleteResponse.getMatches().size());
-  }
-
-  @Test
-  void should_return_matches_ordered_by_ranking_without_duplicates() throws Exception {
-    String searchTerm = "fac";
-    String domain = "something.com";
-    String userName = searchTerm + UUID.randomUUID();
-    String contactEmail1 = userName + "_email1@" + domain;
-    String contactEmail2 = userName + "_email2@" + domain;
-    String contactEmail3 = userName + "_email3@" + domain;
-    String contactEmail4 = userName + "_email4@" + domain;
-    String contactEmail5 = userName + "_email5@" + domain;
-
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3);
-    Account account2 = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3);
-    Account account3 = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4,
-        contactEmail5);
-
-    shareAccountWithPrimary(account2, account);
-    shareAccountWithPrimary(account3, account);
-
-    incrementRankings(account, contactEmail1, 2);
-    incrementRankings(account, contactEmail3, 3);
-    incrementRankings(account2, contactEmail2, 3);
-    incrementRankings(account2, contactEmail3, 2);
-    incrementRankings(account3, contactEmail1, 2);
-    incrementRankings(account3, contactEmail4, 4);
-
-    ArrayList<Account> preferredAccounts = new ArrayList<>(List.of(account, account2, account3));
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        preferredAccounts);
-
-    assertEquals(5, fullAutocompleteResponse.getMatches().size());
-
-    List<Integer> expectedRanking = List.of(3, 2, 0, 4, 0);
-    List<String> expectedMatchedEmailAddresses = List.of(contactEmail3, contactEmail1, contactEmail2, contactEmail4,
-        contactEmail5, contactEmail5);
-    for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
-      AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
-      assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
-      assertEquals("<" + expectedMatchedEmailAddresses.get(i) + ">", autoCompleteMatch.getEmail());
-    }
-  }
-
-  @Test
-  void should_return_matches()
-      throws Exception {
-    String searchTerm = "fac";
-    String domain = "something.com";
-
-    String contactEmail1 = searchTerm + "_email1@" + domain;
-    String contactEmail2 = searchTerm + "_email2@" + domain;
-    String contactEmail3 = searchTerm + "_email3@" + domain;
-    String contactEmail4 = searchTerm + "_email4@" + domain;
-
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
-    Account account2 = createRandomAccountWithContacts(contactEmail1, contactEmail4);
-
-    shareAccountWithPrimary(account2, account);
-
-    incrementRankings(account2, contactEmail1, 2);
-    incrementRankings(account2, contactEmail4, 2);
-
-    incrementRankings(account, contactEmail1, 3);
-    incrementRankings(account, contactEmail2, 6);
-    incrementRankings(account, contactEmail3, 3);
-    incrementRankings(account, contactEmail4, 6);
-
-    ArrayList<Account> preferredAccounts = new ArrayList<>(List.of(account2, account));
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        preferredAccounts);
-
-    assertEquals(4, fullAutocompleteResponse.getMatches().size());
-    List<Integer> expectedRanking = List.of(2, 2, 6, 3);
-    List<String> expectedMatchedEmailAddresses = Arrays.asList(contactEmail1, contactEmail4, contactEmail2,
-        contactEmail3);
-    for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
-      AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
-      assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
-      assertEquals("<" + expectedMatchedEmailAddresses.get(i) + ">", autoCompleteMatch.getEmail());
-    }
-  }
-
-  @Test
-  void should_return_matches_without_duplicates_ordered_by_ranking_and_alphabetically_when_matches_have_same_ranking()
-      throws Exception {
-    String searchTerm = "fac";
-    String domain = "something.com";
-
-    String contactEmail1 = searchTerm + "_email1@" + domain;
-    String contactEmail2 = searchTerm + "_email2@" + domain;
-    String contactEmail3 = searchTerm + "_email3@" + domain;
-    String contactEmail4 = searchTerm + "_email4@" + domain;
-    String contactEmail5 = searchTerm + "_email5@" + domain;
-    String contactEmail6 = searchTerm + "_email6@" + domain;
-    String contactEmail7 = searchTerm + "_email7@" + domain;
-
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
-    Account account2 = createRandomAccountWithContacts(contactEmail5);
-    Account account3 = createRandomAccountWithContacts(contactEmail5, contactEmail6, contactEmail7);
-
-    shareAccountWithPrimary(account2, account);
-    shareAccountWithPrimary(account3, account);
-
-    incrementRankings(account, contactEmail1, 2);
-    incrementRankings(account2, contactEmail5, 1);
-    incrementRankings(account3, contactEmail5, 4);
-    incrementRankings(account, contactEmail3, 2);
-    incrementRankings(account3, contactEmail6, 2);
-
-    ArrayList<Account> preferredAccounts = new ArrayList<>(List.of(account, account2, account3));
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        preferredAccounts);
-
-    assertEquals(7, fullAutocompleteResponse.getMatches().size());
-    List<Integer> expectedRanking = List.of(2, 2, 0, 0, 4, 2, 0);
-    List<String> expectedMatchedEmailAddresses = Arrays.asList(contactEmail1, contactEmail3, contactEmail2,
-        contactEmail4, contactEmail5, contactEmail6, contactEmail7);
-    for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
-      AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
-      assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
-      assertEquals("<" + expectedMatchedEmailAddresses.get(i) + ">", autoCompleteMatch.getEmail());
-    }
-  }
-
-  @Test
-  void should_return_matches_from_authenticated_account_when_request_misses_OrderedAccountIds()
-      throws Exception {
-    String searchTerm = "fac";
-    String domain = "something.com";
-
-    String contactEmail1 = searchTerm + "_email1@" + domain;
-    String contactEmail2 = searchTerm + "_email2@" + domain;
-    String contactEmail3 = searchTerm + "_email3@" + domain;
-    String contactEmail4 = searchTerm + "_email4@" + domain;
-
-    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
-
-    incrementRankings(account, contactEmail1, 2);
-    incrementRankings(account, contactEmail3, 2);
-
-    FullAutocompleteResponse fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account,
-        new ArrayList<>());
-
-    assertEquals(4, fullAutocompleteResponse.getMatches().size());
-    List<Integer> expectedRanking = List.of(2, 2, 0, 0, 2, 0, 0);
-    List<String> expectedMatchedEmailAddresses = Arrays.asList(contactEmail1, contactEmail3, contactEmail2,
-        contactEmail4);
-    for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
-      AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
-      assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
-      assertEquals("<" + expectedMatchedEmailAddresses.get(i) + ">", autoCompleteMatch.getEmail());
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("parsePreferredAccountsTestData")
-  void testParsePreferredAccountsFrom(String input, String expectedPreferredAccount,
-      LinkedHashSet<String> expectedOtherAccounts) {
-    FullAutoComplete fullAutoComplete = new FullAutoComplete();
-    Tuple2<String, LinkedHashSet<String>> result = fullAutoComplete.parsePreferredAccountsFrom(input);
-    assertEquals(expectedPreferredAccount, result._1());
-    assertEquals(expectedOtherAccounts, result._2());
-  }
-
-  private Account createRandomAccountWithContacts(String... emails) throws Exception {
-    Account account = accountCreatorFactory.get().create();
-    for (String contactEmail : emails) {
-      getSoapClient().executeSoap(account, new CreateContactRequest(new ContactSpec().addEmail(contactEmail)));
-    }
-    return account;
-  }
-
-  private void shareAccountWithPrimary(Account accountToShare, Account primaryAccount) {
-    try {
-      Mailbox mailboxOfTargetAccount = MailboxManager.getInstance().getMailboxByAccount(accountToShare);
-      int attempts = 0;
-      while (!mailboxOfTargetAccount.canAccessFolder(new OperationContext(primaryAccount),
-          Mailbox.ID_FOLDER_USER_ROOT) && attempts < 5) {
-        accountActionFactory.forAccount(accountToShare).shareWith(primaryAccount);
-        attempts++;
-      }
-    } catch (ServiceException ignored) {
-    }
-  }
-
-  private void incrementRankings(Account account, String targetEmailAddress, int times)
-      throws AddressException, ServiceException {
-    for (int i = 0; i < times; i++) {
-      ContactRankings.increment(account.getId(), Collections.singleton(new InternetAddress(targetEmailAddress)));
-    }
-  }
-
-  private FullAutocompleteResponse performFullAutocompleteRequest(String searchTerm, Account authenticatorAccount,
-      ArrayList<Account> orderedAccountIds) throws Exception {
-    String orderedAccountIdsStr = orderedAccountIds.stream().map(Account::getId).collect(Collectors.joining(","));
-    FullAutocompleteRequest request = new FullAutocompleteRequest(new AutoCompleteRequest(searchTerm));
-    request.setOrderedAccountIds(orderedAccountIdsStr);
-
-    return JaxbUtil.elementToJaxb(new FullAutoComplete().handle(JaxbUtil.jaxbToElement(request),
-        ServiceTestUtil.getRequestContext(authenticatorAccount)));
-  }
 }
-


### PR DESCRIPTION
This reverts commit f0481badaab31656ac0d72adee2041cce1808c62.

Revert "fix: [CO-1047] FullAutoComplete API response in JSON instead of wrapping xml in JSON object"

This reverts commit ed257d92f43d18dad9f6d2451a2d1767925092b5.

Revert "fix: [CO-1047] serialize matches also into JSON objects in FullAutoComplete (#492)"

This reverts commit a7867a447dea6e4d461fdcbda2f239195899330d.


**This feature is planned for next version (24.7.0)**

[CO-1047]: https://zextras.atlassian.net/browse/CO-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CO-1047]: https://zextras.atlassian.net/browse/CO-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ