### PR TITLE
feat: [CO-985] Enhance recovery code based Auth handling when carbonio auth is registered

### DIFF
--- a/store/src/main/java/com/zimbra/cs/account/AccountServiceException.java
+++ b/store/src/main/java/com/zimbra/cs/account/AccountServiceException.java
@@ -148,7 +148,7 @@ public class AccountServiceException extends ServiceException {
       return AUTH_FAILED(acctName, namePassedIn, null, null);
     }
 
-    public static AuthFailedServiceException CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED(
+    public static AuthFailedServiceException cannotPerformAuthWhenAdvancedAuthIsEnabled(
         String accId, String acctName) {
       return new AuthFailedServiceException(accId, acctName,
           "Cannot handle recovery token based Authentication request when carbonioAdvanced auth mech is enabled.",

--- a/store/src/main/java/com/zimbra/cs/account/AccountServiceException.java
+++ b/store/src/main/java/com/zimbra/cs/account/AccountServiceException.java
@@ -20,6 +20,7 @@ import com.zimbra.common.util.Constants;
 public class AccountServiceException extends ServiceException {
 
   public static final String AUTH_FAILED = "account.AUTH_FAILED";
+  public static final String CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED_CODE = "account.CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED";
   public static final String CHANGE_PASSWORD = "account.CHANGE_PASSWORD";
   public static final String RESET_PASSWORD = "account.RESET_PASSWORD";
   public static final String PASSWORD_LOCKED = "account.PASSWORD_LOCKED";
@@ -145,6 +146,13 @@ public class AccountServiceException extends ServiceException {
 
     public static AuthFailedServiceException AUTH_FAILED(String acctName, String namePassedIn) {
       return AUTH_FAILED(acctName, namePassedIn, null, null);
+    }
+
+    public static AuthFailedServiceException CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED(
+        String accId, String acctName) {
+      return new AuthFailedServiceException(accId, acctName,
+          "Cannot handle recovery token based Authentication request when carbonioAdvanced auth mech is enabled.",
+          CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED_CODE, false, null);
     }
 
     public static AuthFailedServiceException AUTH_FAILED(

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5990,10 +5990,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     if (isRecoveryCodeBasedAuth(context)) {
       if(ZimbraCustomAuth.handlerIsRegistered(AuthMech.carbonioAdvanced.name())
           && !recoveryCodeBasedAuthRequestFromAdvanced(context)){
-        throw AuthFailedServiceException.AUTH_FAILED(acct.getName(),
-            String.format("Cannot handle recovery token based Authentication request when %s auth mech is enabled.",
-                AuthMech.carbonioAdvanced.name()),
-            (Throwable) null);
+        throw AuthFailedServiceException.CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED(acct.getId(), acct.getName());
       }
       verifyRecoveryCode(acct, password, context);
     } else {

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -5990,7 +5990,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     if (isRecoveryCodeBasedAuth(context)) {
       if(ZimbraCustomAuth.handlerIsRegistered(AuthMech.carbonioAdvanced.name())
           && !recoveryCodeBasedAuthRequestFromAdvanced(context)){
-        throw AuthFailedServiceException.CANNOT_PERFORM_AUTH_WHEN_ADVANCED_AUTH_IS_ENABLED(acct.getId(), acct.getName());
+        throw AuthFailedServiceException.cannotPerformAuthWhenAdvancedAuthIsEnabled(acct.getId(), acct.getName());
       }
       verifyRecoveryCode(acct, password, context);
     } else {

--- a/store/src/test/java/com/zimbra/cs/account/auth/ZimbraCustomAuthTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/auth/ZimbraCustomAuthTest.java
@@ -9,13 +9,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.annotations.VisibleForTesting;
 
 public class ZimbraCustomAuthTest {
 
   /**
    * A Custom Auth class for testing purposes.
    */
-  private class TestCustomAuth extends ZimbraCustomAuth {
+  @VisibleForTesting
+  public static class TestCustomAuth extends ZimbraCustomAuth {
 
     @Override
     public void authenticate(Account acct, String password, Map<String, Object> context,


### PR DESCRIPTION
**What has changed:**

- Prevent the CE Auth SOAP API handle recovery token based authentications when Carbonio Auth Mech is enabled. 

    - recovery token based authentication can no more allow the user to bypass 2FA or any Auth mechanism enforced by Carbonio auth

    - if Carbonio Auth is not registered as Authentication mechanism, i.e Carbonio CE, the Auth API will process recovery token based authentication as usual. 

Depends on: https://github.com/zextras/carbonio-auth/pull/75