### PR TITLE
feat: [CO-1040] make account status accessible via GetAccountInfo SOAP API

### DIFF
--- a/soap/src/main/java/com/zimbra/soap/account/message/GetAccountInfoRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/account/message/GetAccountInfoRequest.java
@@ -27,17 +27,14 @@ public class GetAccountInfoRequest {
      * @zm-api-field-description Use to identify the account
      */
     @XmlElement(name=AccountConstants.E_ACCOUNT, required=true)
-    private final AccountSelector account;
+    private AccountSelector account;
 
     /**
      * no-argument constructor wanted by JAXB
      */
-    @SuppressWarnings("unused")
-    private GetAccountInfoRequest() {
-        this(null);
-    }
+    public GetAccountInfoRequest() {}
 
-    public GetAccountInfoRequest(AccountSelector account) {
+    public void setAccount(AccountSelector account) {
         this.account = account;
     }
 

--- a/soap/src/main/java/com/zimbra/soap/admin/message/GetAccountInfoRequest.java
+++ b/soap/src/main/java/com/zimbra/soap/admin/message/GetAccountInfoRequest.java
@@ -31,11 +31,10 @@ public class GetAccountInfoRequest {
     /**
      * no-argument constructor wanted by JAXB
      */
-    @SuppressWarnings("unused")
-    private GetAccountInfoRequest() {
+    public GetAccountInfoRequest() {
     }
 
-    public GetAccountInfoRequest(AccountSelector account) {
+    public void setAccount(AccountSelector account) {
         this.account = account;
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/soap/SoapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/soap/SoapProvisioning.java
@@ -1075,9 +1075,9 @@ public class SoapProvisioning extends Provisioning {
   }
 
   public SoapAccountInfo getAccountInfo(AccountBy keyType, String key) throws ServiceException {
-    GetAccountInfoResponse resp =
-        invokeJaxb(
-            new GetAccountInfoRequest(new AccountSelector(SoapProvisioning.toJaxb(keyType), key)));
+    GetAccountInfoRequest request = new GetAccountInfoRequest();
+    request.setAccount(new AccountSelector(SoapProvisioning.toJaxb(keyType), key));
+    GetAccountInfoResponse resp = invokeJaxb(request);
     return new SoapAccountInfo(resp);
   }
 

--- a/store/src/main/java/com/zimbra/cs/service/account/GetAccountInfo.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/GetAccountInfo.java
@@ -59,6 +59,11 @@ public class GetAccountInfo extends AccountDocumentHandler {
         account.getAttr(Provisioning.A_displayName),
         AccountConstants.E_ATTR,
         AccountConstants.A_NAME);
+    response.addKeyValuePair(
+        Provisioning.A_zimbraAccountStatus,
+        account.getAttr(Provisioning.A_zimbraAccountStatus),
+        AccountConstants.E_ATTR,
+        AccountConstants.A_NAME);
     addUrls(response, account);
     return response;
   }

--- a/store/src/main/java/com/zimbra/cs/service/admin/GetAccountInfo.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/GetAccountInfo.java
@@ -66,6 +66,7 @@ public class GetAccountInfo extends AdminDocumentHandler  {
         response.addNonUniqueElement(AdminConstants.E_NAME).setText(account.getName());
         addAttr(response, Provisioning.A_zimbraId, account.getId());
         addAttr(response, Provisioning.A_zimbraMailHost, account.getAttr(Provisioning.A_zimbraMailHost));
+        addAttr(response, Provisioning.A_zimbraAccountStatus, account.getAccountStatus(prov));
 
         doCos(account, response);
         addUrls(response, account);

--- a/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
@@ -1,0 +1,57 @@
+package com.zimbra.cs.service.account;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.account.message.GetAccountInfoRequest;
+import com.zimbra.soap.account.message.GetAccountInfoResponse;
+import com.zimbra.soap.type.AccountSelector;
+import com.zimbra.soap.type.NamedValue;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class GetAccountInfoTest {
+
+  @BeforeAll
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  @Test
+  void shouldContainAccountStatusInReturnedAttributes() throws Exception {
+    Provisioning prov = Provisioning.getInstance();
+    Domain domain = prov.createDomain(UUID.randomUUID().toString(), Maps.newHashMap());
+    Account account = prov.createAccount(UUID.randomUUID() + "@" + domain.getName(),
+        UUID.randomUUID().toString(), Maps.newHashMap());
+    GetAccountInfoRequest request = new GetAccountInfoRequest();
+    request.setAccount(AccountSelector.fromId(account.getId()));
+    Element requestElement = JaxbUtil.jaxbToElement(request);
+
+    Element handle = new GetAccountInfo()
+        .handle(requestElement, ServiceTestUtil.getRequestContext(account));
+    GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
+
+    List<NamedValue> attributes = Objects.requireNonNull(response).getAttrs()
+        .stream()
+        .filter(namedValue -> namedValue.getName().contains(Provisioning.A_zimbraAccountStatus))
+        .collect(Collectors.toList());
+    assertEquals(1, attributes.size());
+  }
+}

--- a/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
@@ -1,0 +1,76 @@
+package com.zimbra.cs.service.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Maps;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.accesscontrol.RightManager;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.GetAccountInfoRequest;
+import com.zimbra.soap.admin.message.GetAccountInfoResponse;
+import com.zimbra.soap.admin.type.Attr;
+import com.zimbra.soap.type.AccountSelector;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class GetAccountInfoTest {
+  @BeforeAll
+  public static void init() throws Exception {
+    MailboxTestUtil.initServer();
+    RightManager.getInstance();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    MailboxTestUtil.clearData();
+  }
+
+  @Test
+  void shouldContainAccountStatusInReturnedAttributes() throws Exception {
+    Provisioning prov = Provisioning.getInstance();
+    Domain domain = prov.createDomain(UUID.randomUUID().toString(), Maps.newHashMap());
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
+    Account adminAccount = prov.createAccount(UUID.randomUUID() + "@" + domain.getName(),
+        UUID.randomUUID().toString(), attributes);
+    GetAccountInfoRequest request = new GetAccountInfoRequest();
+    request.setAccount(AccountSelector.fromId(adminAccount.getId()));
+    Element requestElement = JaxbUtil.jaxbToElement(request);
+
+    Element handle = new GetAccountInfo().handle(requestElement, getAdminContext(adminAccount));
+    GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
+
+    List<Attr> attrs = Objects.requireNonNull(response).getAttrList()
+        .stream()
+        .filter(attr -> attr.getKey().equals(Provisioning.A_zimbraAccountStatus))
+        .collect(Collectors.toList());
+    assertEquals(1, attrs.size());
+  }
+
+  Map<String, Object> getAdminContext(Account account) throws ServiceException {
+    Map<String, Object> context = new HashMap<>();
+    var zsc = new ZimbraSoapContext(
+            AuthProvider.getAuthToken(account, true),
+            account.getId(),
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+    return context;
+  }
+}


### PR DESCRIPTION
**What has changed:**
`GetAccountInfo` APIs (admin, user) start returning account status.