### PR TITLE
feat(CO-1121): export account zimbraIsExternalVirtualAccount attribute in GetAccountInfo request

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/account/GetAccountInfo.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/GetAccountInfo.java
@@ -64,6 +64,11 @@ public class GetAccountInfo extends AccountDocumentHandler {
         account.getAttr(Provisioning.A_zimbraAccountStatus),
         AccountConstants.E_ATTR,
         AccountConstants.A_NAME);
+    response.addKeyValuePair(
+        Provisioning.A_zimbraIsExternalVirtualAccount,
+        Boolean.toString(account.getBooleanAttr(Provisioning.A_zimbraIsExternalVirtualAccount, false)).toUpperCase(),
+        AccountConstants.E_ATTR,
+        AccountConstants.A_NAME);
     addUrls(response, account);
     return response;
   }

--- a/store/src/main/java/com/zimbra/cs/service/admin/GetAccountInfo.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/GetAccountInfo.java
@@ -67,6 +67,7 @@ public class GetAccountInfo extends AdminDocumentHandler  {
         addAttr(response, Provisioning.A_zimbraId, account.getId());
         addAttr(response, Provisioning.A_zimbraMailHost, account.getAttr(Provisioning.A_zimbraMailHost));
         addAttr(response, Provisioning.A_zimbraAccountStatus, account.getAccountStatus(prov));
+        addAttr(response, Provisioning.A_zimbraIsExternalVirtualAccount, Boolean.toString(account.isIsExternalVirtualAccount()).toUpperCase());
 
         doCos(account, response);
         addUrls(response, account);

--- a/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
@@ -54,4 +54,26 @@ class GetAccountInfoTest {
         .collect(Collectors.toList());
     assertEquals(1, attributes.size());
   }
+
+  @Test
+  void shouldContainExternalVirtualInReturnedAttributes() throws Exception {
+    Provisioning prov = Provisioning.getInstance();
+    Domain domain = prov.createDomain(UUID.randomUUID().toString(), Maps.newHashMap());
+    Account account = prov.createAccount(UUID.randomUUID() + "@" + domain.getName(),
+        UUID.randomUUID().toString(), Maps.newHashMap());
+    GetAccountInfoRequest request = new GetAccountInfoRequest();
+    request.setAccount(AccountSelector.fromId(account.getId()));
+    Element requestElement = JaxbUtil.jaxbToElement(request);
+
+    Element handle = new GetAccountInfo()
+        .handle(requestElement, ServiceTestUtil.getRequestContext(account));
+    GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
+
+    List<NamedValue> attributes = Objects.requireNonNull(response).getAttrs()
+        .stream()
+        .filter(namedValue -> namedValue.getName().contains(Provisioning.A_zimbraIsExternalVirtualAccount))
+        .collect(Collectors.toList());
+    assertEquals(1, attributes.size());
+    assertEquals("FALSE", attributes.get(0).getValue());
+  }
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
@@ -63,6 +63,30 @@ class GetAccountInfoTest {
     assertEquals(1, attrs.size());
   }
 
+  @Test
+  void shouldContainExternalVirtualInReturnedAttributes() throws Exception {
+    Provisioning prov = Provisioning.getInstance();
+    Domain domain = prov.createDomain(UUID.randomUUID().toString(), Maps.newHashMap());
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put(Provisioning.A_zimbraIsAdminAccount, "TRUE");
+    attributes.put(Provisioning.A_zimbraIsExternalVirtualAccount, "TRUE");
+    Account adminAccount = prov.createAccount(UUID.randomUUID() + "@" + domain.getName(),
+        UUID.randomUUID().toString(), attributes);
+    GetAccountInfoRequest request = new GetAccountInfoRequest();
+    request.setAccount(AccountSelector.fromId(adminAccount.getId()));
+    Element requestElement = JaxbUtil.jaxbToElement(request);
+
+    Element handle = new GetAccountInfo().handle(requestElement, getAdminContext(adminAccount));
+    GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
+
+    List<Attr> attrs = Objects.requireNonNull(response).getAttrList()
+        .stream()
+        .filter(attr -> attr.getKey().equals(Provisioning.A_zimbraIsExternalVirtualAccount))
+        .collect(Collectors.toList());
+    assertEquals(1, attrs.size());
+    assertEquals("TRUE", attrs.get(0).getValue());
+  }
+
   Map<String, Object> getAdminContext(Account account) throws ServiceException {
     Map<String, Object> context = new HashMap<>();
     var zsc = new ZimbraSoapContext(


### PR DESCRIPTION
This attribute is needed by WSC so that guests account can be identified in meetings