### PR TITLE
feat: [CO-1023] add ability to empty folder by item type

### DIFF
--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -161,6 +161,8 @@ public final class MailConstants {
   public static final String E_GET_APPOINTMENT_REQUEST = "GetAppointmentRequest";
   public static final String E_SET_APPOINTMENT_REQUEST = "SetAppointmentRequest";
   public static final String E_CREATE_APPOINTMENT_REQUEST = "CreateAppointmentRequest";
+  public static final String E_CREATE_APPOINTMENT_RESPONSE = "CreateAppointmentResponse";
+
   public static final String E_CREATE_APPOINTMENT_EXCEPTION_REQUEST =
       "CreateAppointmentExceptionRequest";
   public static final String E_MODIFY_APPOINTMENT_REQUEST = "ModifyAppointmentRequest";
@@ -447,8 +449,11 @@ public final class MailConstants {
       QName.get(E_GET_APPOINTMENT_REQUEST, NAMESPACE);
   public static final QName SET_APPOINTMENT_REQUEST =
       QName.get(E_SET_APPOINTMENT_REQUEST, NAMESPACE);
+
   public static final QName CREATE_APPOINTMENT_REQUEST =
       QName.get(E_CREATE_APPOINTMENT_REQUEST, NAMESPACE);
+  public static final QName CREATE_APPOINTMENT_RESPONSE =
+      QName.get(E_CREATE_APPOINTMENT_RESPONSE, NAMESPACE);
   public static final QName CREATE_APPOINTMENT_EXCEPTION_REQUEST =
       QName.get(E_CREATE_APPOINTMENT_EXCEPTION_REQUEST, NAMESPACE);
   public static final QName MODIFY_APPOINTMENT_REQUEST =

--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -887,6 +887,8 @@ public final class MailConstants {
   public static final String A_NEWLY_CREATED_IDS = "nci";
   public static final String E_CONTACT_MEMBER_OF = "memberOf";
 
+  public static final String A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE = "type";
+
   // contact group
   public static final String E_CONTACT_GROUP_MEMBER = "m";
   public static final String E_CONTACT_GROUP_MEMBER_ATTRIBUTE = "ma";

--- a/soap/src/main/java/com/zimbra/soap/mail/type/FolderActionSelector.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/FolderActionSelector.java
@@ -99,6 +99,14 @@ public class FolderActionSelector extends ActionSelector {
     @XmlAttribute(name=MailConstants.A_NUM_DAYS /* numDays */, required=false)
     private Integer numDays;
 
+    /**
+     * @zm-api-field-tag empty-folder-op-type
+     * @zm-api-field-description Match type for folder action "op":"empty" <br>
+     *     Legal values are: <b>emails|contacts|appointments</b> <br>
+     */
+    @XmlAttribute(name = MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE /* type */, required = false)
+    private String type;
+
     public FolderActionSelector() {
         this(null, null);
     }
@@ -131,6 +139,9 @@ public class FolderActionSelector extends ActionSelector {
 
     public void setRetentionPolicy(RetentionPolicy retentionPolicy) { this.retentionPolicy = retentionPolicy; }
     public void setNumDays(Integer numDays) { this.numDays = numDays; }
+    public void setType(final String type) {
+        this.type = type;
+    }
     public Boolean getRecursive() { return ZmBoolean.toBool(recursive); }
     public String getUrl() { return url; }
     public Boolean getExcludeFreebusy() { return ZmBoolean.toBool(excludeFreebusy); }
@@ -143,6 +154,9 @@ public class FolderActionSelector extends ActionSelector {
     }
     public RetentionPolicy getRetentionPolicy() { return retentionPolicy; }
     public Integer getNumDays() { return numDays; }
+    public String getType() {
+        return type;
+    }
 
     @Override
     public MoreObjects.ToStringHelper addToStringInfo(MoreObjects.ToStringHelper helper) {

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -26,6 +26,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <artifactId>mina-core</artifactId>
       <groupId>org.apache.mina</groupId>
     </dependency>

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -1,8 +1,10 @@
 package com.zimbra.cs.mailbox;
 
 import com.zimbra.cs.mailbox.MailItem.Type;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 //Todo add java docs
 public enum FolderActionEmptyOpTypes {
@@ -32,5 +34,13 @@ public enum FolderActionEmptyOpTypes {
       default:
         return Collections.emptyList();
     }
+  }
+
+  /**
+   * @return String of comma separated list of types
+   */
+  public static String valueToString() {
+    return Arrays.stream(
+        values()).map(type -> type.name().toLowerCase()).collect(Collectors.joining(", "));
   }
 }

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -1,23 +1,13 @@
 package com.zimbra.cs.mailbox;
 
 public enum FolderActionEmptyOpTypes {
-  EMAILS("emails"),
-  CONTACTS("contacts"),
-  APPOINTMENTS("appointments");
-
-  private final String name;
-
-  FolderActionEmptyOpTypes(String name) {
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
+  EMAILS,
+  CONTACTS,
+  APPOINTMENTS;
 
   public static boolean contains(String name) {
     for (FolderActionEmptyOpTypes type : FolderActionEmptyOpTypes.values()) {
-      if (type.getName().equalsIgnoreCase(name)) {
+      if (type.name().equalsIgnoreCase(name)) {
         return true;
       }
     }

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -1,0 +1,17 @@
+package com.zimbra.cs.mailbox;
+
+public enum FolderActionEmptyOpTypes {
+  EMAILS("emails"),
+  CONTACTS("contacts"),
+  APPOINTMENTS("appointments");
+
+  private final String name;
+
+  FolderActionEmptyOpTypes(final String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 /**
  * Enum representing different types supported by the empty operation in
- * {@link com.zimbra.cs.service.mail.FolderAction}.
+ * {@link com.zimbra.soap.mail.type.FolderActionSelector}.
  */
 public enum FolderActionEmptyOpTypes {
   EMAILS,

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -7,11 +7,20 @@ public enum FolderActionEmptyOpTypes {
 
   private final String name;
 
-  FolderActionEmptyOpTypes(final String name) {
+  FolderActionEmptyOpTypes(String name) {
     this.name = name;
   }
 
   public String getName() {
     return name;
+  }
+
+  public static boolean contains(String name) {
+    for (FolderActionEmptyOpTypes type : FolderActionEmptyOpTypes.values()) {
+      if (type.getName().equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -1,16 +1,36 @@
 package com.zimbra.cs.mailbox;
 
+import com.zimbra.cs.mailbox.MailItem.Type;
+import java.util.Collections;
+import java.util.List;
+
+//Todo add java docs
 public enum FolderActionEmptyOpTypes {
   EMAILS,
   CONTACTS,
   APPOINTMENTS;
 
+  //Todo add java docs
   public static boolean contains(String name) {
-    for (FolderActionEmptyOpTypes type : FolderActionEmptyOpTypes.values()) {
+    for (FolderActionEmptyOpTypes type : values()) {
       if (type.name().equalsIgnoreCase(name)) {
         return true;
       }
     }
     return false;
+  }
+
+  //Todo add java docs
+  public static List<Type> getIncludedTypesFor(FolderActionEmptyOpTypes type) {
+    switch (type) {
+      case EMAILS:
+        return List.of(Type.MESSAGE, Type.CONVERSATION);
+      case CONTACTS:
+        return List.of(Type.CONTACT);
+      case APPOINTMENTS:
+        return List.of(Type.APPOINTMENT);
+      default:
+        return Collections.emptyList();
+    }
   }
 }

--- a/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/FolderActionEmptyOpTypes.java
@@ -6,13 +6,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-//Todo add java docs
+/**
+ * Enum representing different types supported by the empty operation in
+ * {@link com.zimbra.cs.service.mail.FolderAction}.
+ */
 public enum FolderActionEmptyOpTypes {
   EMAILS,
   CONTACTS,
   APPOINTMENTS;
 
-  //Todo add java docs
+  /**
+   * Checks if the enum contains a type with the specified name.
+   *
+   * @param name the name of the type to check
+   * @return true if the enum contains the specified type, false otherwise
+   */
   public static boolean contains(String name) {
     for (FolderActionEmptyOpTypes type : values()) {
       if (type.name().equalsIgnoreCase(name)) {
@@ -22,7 +30,12 @@ public enum FolderActionEmptyOpTypes {
     return false;
   }
 
-  //Todo add java docs
+  /**
+   * Gets the list of included types for a specified folder action type.
+   *
+   * @param type the folder action type
+   * @return a list of included types for the specified folder action type
+   */
   public static List<Type> getIncludedTypesFor(FolderActionEmptyOpTypes type) {
     switch (type) {
       case EMAILS:
@@ -37,7 +50,9 @@ public enum FolderActionEmptyOpTypes {
   }
 
   /**
-   * @return String of comma separated list of types
+   * Converts the enum values to a comma-separated string.
+   *
+   * @return a string representation of the enum values, separated by commas
    */
   public static String valueToString() {
     return Arrays.stream(

--- a/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9625,6 +9625,7 @@ public class Mailbox implements MailboxStore {
         // Delete the items in batches.  (1000 items by default)
         QueryParams params = new QueryParams();
         params
+            //.retvieve only emails message + conver
             .setFolderIds(folderIds)
             .setModifiedSequenceBefore(lastChangeID + 1)
             .setRowLimit(batchSize);
@@ -9679,6 +9680,10 @@ public class Mailbox implements MailboxStore {
         emptyFolderOpLock.unlock();
       }
     }
+  }
+
+  public void emptyFolder(OperationContext octxt, int folderId, boolean removeSubfolders, FolderActionEmptyOpTypes matchType) {
+
   }
 
   public void emptyFolder(OperationContext octxt, int folderId, boolean removeSubfolders)

--- a/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9611,11 +9611,10 @@ public class Mailbox implements MailboxStore {
         } else {
           List<Folder> folders = getFolderById(octxt, folderId).getSubfolderHierarchy();
           for (Folder folder : folders) {
-            if (itemsType == null) {
+            if (itemsType == null || FolderActionEmptyOpTypes.getIncludedTypesFor(itemsType)
+                .contains(folder.getDefaultView())
+                || folder.getId() == FolderConstants.ID_FOLDER_TRASH) {
               folderIds.add(folder.getId());
-            } else if (FolderActionEmptyOpTypes.getIncludedTypesFor(itemsType).contains(folder.getDefaultView())
-                  || folder.getId() == FolderConstants.ID_FOLDER_TRASH) {
-                folderIds.add(folder.getId());
             }
           }
         }

--- a/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/Mailbox.java
@@ -9611,13 +9611,11 @@ public class Mailbox implements MailboxStore {
         } else {
           List<Folder> folders = getFolderById(octxt, folderId).getSubfolderHierarchy();
           for (Folder folder : folders) {
-            if (itemsType != null) {
-              if (FolderActionEmptyOpTypes.getIncludedTypesFor(itemsType).contains(folder.getDefaultView())
+            if (itemsType == null) {
+              folderIds.add(folder.getId());
+            } else if (FolderActionEmptyOpTypes.getIncludedTypesFor(itemsType).contains(folder.getDefaultView())
                   || folder.getId() == FolderConstants.ID_FOLDER_TRASH) {
                 folderIds.add(folder.getId());
-              }
-            } else {
-              folderIds.add(folder.getId());
             }
           }
         }

--- a/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -128,15 +128,15 @@ public class FolderAction extends ItemAction {
         if (operation.equals(OP_EMPTY)) {
             boolean subfolders = action.getAttributeBool(MailConstants.A_RECURSIVE, true);
             String emptyOpMatchType = action.getAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE);
-            if(emptyOpMatchType == null
-                || emptyOpMatchType.isEmpty()
-                || !FolderActionEmptyOpTypes.contains(emptyOpMatchType)) {
+            if(!FolderActionEmptyOpTypes.contains(emptyOpMatchType)) {
                 throw ServiceException.INVALID_REQUEST("Missing or invalid 'type' parameter", null);
             }
-            mbox.emptyFolder(octxt, iid.getId(), subfolders);
+            final FolderActionEmptyOpTypes matchType = FolderActionEmptyOpTypes.valueOf(
+                emptyOpMatchType.toUpperCase());
+            mbox.emptyFolder(octxt, iid.getId(), subfolders, matchType);
             // empty trash means also to purge all IMAP \Deleted messages
             if (iid.getId() == Mailbox.ID_FOLDER_TRASH
-                && FolderActionEmptyOpTypes.EMAILS.getName().equalsIgnoreCase(emptyOpMatchType)) {
+                && FolderActionEmptyOpTypes.EMAILS.equals(matchType)) {
                 mbox.purgeImapDeleted(octxt);
             }
         } else if (operation.equals(OP_REFRESH)) {

--- a/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -41,7 +41,6 @@ import com.zimbra.cs.service.util.ItemIdFormatter;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.type.RetentionPolicy;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,8 +127,10 @@ public class FolderAction extends ItemAction {
         if (operation.equals(OP_EMPTY)) {
             boolean subfolders = action.getAttributeBool(MailConstants.A_RECURSIVE, true);
             String emptyOpMatchType = action.getAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE);
-            if(!FolderActionEmptyOpTypes.contains(emptyOpMatchType)) {
-                throw ServiceException.INVALID_REQUEST("Missing or invalid 'type' parameter", null);
+            if (!FolderActionEmptyOpTypes.contains(emptyOpMatchType)) {
+                throw ServiceException.INVALID_REQUEST(
+                    "Missing or invalid 'type' parameter. Supported parameters are: "
+                        + FolderActionEmptyOpTypes.valueToString(), null);
             }
             final FolderActionEmptyOpTypes matchType = FolderActionEmptyOpTypes.valueOf(
                 emptyOpMatchType.toUpperCase());

--- a/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -30,6 +30,7 @@ import com.zimbra.cs.fb.FreeBusyProvider;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.FolderActionEmptyOpTypes;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -126,10 +127,16 @@ public class FolderAction extends ItemAction {
 
         if (operation.equals(OP_EMPTY)) {
             boolean subfolders = action.getAttributeBool(MailConstants.A_RECURSIVE, true);
+            String emptyOpMatchType = action.getAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE);
+            if(emptyOpMatchType == null || emptyOpMatchType.isEmpty()) {
+                throw ServiceException.INVALID_REQUEST("Missing 'type' parameter", null);
+            }
             mbox.emptyFolder(octxt, iid.getId(), subfolders);
             // empty trash means also to purge all IMAP \Deleted messages
-            if (iid.getId() == Mailbox.ID_FOLDER_TRASH)
+            if (iid.getId() == Mailbox.ID_FOLDER_TRASH
+                && FolderActionEmptyOpTypes.EMAILS.getName().equalsIgnoreCase(emptyOpMatchType)) {
                 mbox.purgeImapDeleted(octxt);
+            }
         } else if (operation.equals(OP_REFRESH)) {
             mbox.synchronizeFolder(octxt, iid.getId());
         } else if (operation.equals(OP_IMPORT)) {

--- a/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -128,8 +128,10 @@ public class FolderAction extends ItemAction {
         if (operation.equals(OP_EMPTY)) {
             boolean subfolders = action.getAttributeBool(MailConstants.A_RECURSIVE, true);
             String emptyOpMatchType = action.getAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE);
-            if(emptyOpMatchType == null || emptyOpMatchType.isEmpty()) {
-                throw ServiceException.INVALID_REQUEST("Missing 'type' parameter", null);
+            if(emptyOpMatchType == null
+                || emptyOpMatchType.isEmpty()
+                || !FolderActionEmptyOpTypes.contains(emptyOpMatchType)) {
+                throw ServiceException.INVALID_REQUEST("Missing or invalid 'type' parameter", null);
             }
             mbox.emptyFolder(octxt, iid.getId(), subfolders);
             // empty trash means also to purge all IMAP \Deleted messages

--- a/store/src/test/java/com/zextras/mailbox/soap/SoapTestSuite.java
+++ b/store/src/test/java/com/zextras/mailbox/soap/SoapTestSuite.java
@@ -5,6 +5,13 @@
 package com.zextras.mailbox.soap;
 
 import com.zextras.mailbox.util.SoapClient;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import java.util.HashMap;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -20,8 +27,32 @@ public class SoapTestSuite {
       .addEngineHandler("com.zimbra.cs.service.mail.MailServiceWithoutTracking")
       .create();
 
+  /**
+   * @return {@link SoapClient} that can execute SOAP http requests
+   */
   public SoapClient getSoapClient() {
     return soapExtension.getSoapClient();
+  }
+
+  /**
+   * @param account {@link Account} who will make the SOAP request using the returned {@link ZimbraSoapContext}
+   * @param isAdmin whether the account is admin or not
+   * @return  {@code HashMap<String, Object>} holding {@link ZimbraSoapContext} as item
+   * @throws ServiceException if context creation fails
+   */
+  public static HashMap<String, Object> getSoapContextForAccount(Account account, boolean isAdmin)
+      throws ServiceException {
+    return new HashMap<>() {
+      {
+        put(
+            SoapEngine.ZIMBRA_CONTEXT,
+            new ZimbraSoapContext(
+                AuthProvider.getAuthToken(account, isAdmin),
+                account.getId(),
+                SoapProtocol.Soap12,
+                SoapProtocol.Soap12));
+      }
+    };
   }
 
 }

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -21,6 +21,7 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.mail.CreateAppointment;
 import com.zimbra.cs.service.mail.CreateCalendarItem;
 import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.soap.SoapEngine;
@@ -205,9 +206,9 @@ class UserServletTest {
                     .readAllBytes()),
             MailConstants.CREATE_APPOINTMENT_REQUEST,
             JSONElement.mFactory);
-    final CreateCalendarItem createCalendarItem = new CreateCalendarItem();
-    createCalendarItem.setResponseQName(MailConstants.CREATE_APPOINTMENT_REQUEST);
-    createCalendarItem.handle(createAppointmentElement, context);
+    final CreateAppointment createAppointment = new CreateAppointment();
+    createAppointment.setResponseQName(MailConstants.CREATE_APPOINTMENT_RESPONSE);
+    createAppointment.handle(createAppointmentElement, context);
   }
 
   @Test

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -22,7 +22,6 @@ import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.mail.CreateAppointment;
-import com.zimbra.cs.service.mail.CreateCalendarItem;
 import com.zimbra.cs.servlet.ZimbraServlet;
 import com.zimbra.soap.SoapEngine;
 import com.zimbra.soap.ZimbraSoapContext;

--- a/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
@@ -64,6 +64,29 @@ class FolderActionTest extends SoapTestSuite {
   }
 
   @Test
+  void empty_op_folder_action_request_should_fail_when_wrong_type_attribute_in_action_selector()
+      throws ServiceException {
+    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
+    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
+    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
+    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, Boolean.valueOf(true).toString());
+    actionSelectorElement.addAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE, "wrongType");
+
+    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
+    folderActionRequestElement.addUniqueElement(actionSelectorElement);
+
+    var folderActionHandler = new FolderAction();
+    var soapContextForAccount = getSoapContextForAccount(defaultAccount, false);
+
+    var serviceException = assertThrows(ServiceException.class,
+        () -> folderActionHandler.handle(folderActionRequestElement, soapContextForAccount));
+    assertEquals(
+        String.format("invalid request: Missing or invalid 'type' parameter. Supported parameters are: %s",
+            FolderActionEmptyOpTypes.valueToString()),
+        serviceException.getMessage());
+  }
+
+  @Test
   void empty_op_folder_action_request_should_only_delete_items_specified_by_type_attribute_in_action_selector()
       throws Exception {
     // create and move contacts to trash folder

--- a/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
@@ -12,18 +12,15 @@ import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.Element.JSONElement;
 import com.zimbra.common.soap.Element.XMLElement;
 import com.zimbra.common.soap.MailConstants;
-import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.FolderActionEmptyOpTypes;
-import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.soap.JaxbUtil;
-import com.zimbra.soap.SoapEngine;
-import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.message.CreateAppointmentResponse;
 import com.zimbra.soap.mail.message.CreateContactRequest;
 import com.zimbra.soap.mail.message.CreateContactResponse;
+import com.zimbra.soap.mail.message.FolderActionResponse;
 import com.zimbra.soap.mail.message.GetFolderRequest;
 import com.zimbra.soap.mail.message.GetFolderResponse;
 import com.zimbra.soap.mail.type.ContactSpec;
@@ -32,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,37 +51,10 @@ class FolderActionTest extends SoapTestSuite {
         new HashMap<>());
   }
 
-  private static HashMap<String, Object> getSoapContextFromAccount(Account account)
-      throws ServiceException {
-    return new HashMap<>() {
-      {
-        put(
-            SoapEngine.ZIMBRA_CONTEXT,
-            new ZimbraSoapContext(
-                AuthProvider.getAuthToken(account, false),
-                account.getId(),
-                SoapProtocol.Soap12,
-                SoapProtocol.Soap12));
-      }
-    };
-  }
-
   @Test
-  void empty_op_folder_action_request_should_fail_when_misses_type_attribute_in_action_selector()
-      throws ServiceException {
-
-    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
-    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
-    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
-    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, "true");
-
-    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
-    folderActionRequestElement.addUniqueElement(actionSelectorElement);
-
-    var folderActionHandler = new FolderAction();
-    var soapContextForAccount = getSoapContextFromAccount(defaultAccount);
+  void empty_op_folder_action_request_should_fail_when_misses_type_attribute_in_action_selector() {
     var serviceException = assertThrows(ServiceException.class,
-        () -> folderActionHandler.handle(folderActionRequestElement, soapContextForAccount));
+        () -> folderActionEmptyTrashForAccount(defaultAccount, true, null));
 
     assertEquals(ServiceException.INVALID_REQUEST, serviceException.getCode());
     assertEquals("invalid request: missing required attribute: type", serviceException.getMessage());
@@ -93,37 +64,49 @@ class FolderActionTest extends SoapTestSuite {
   void empty_op_folder_action_request_should_only_delete_items_specified_by_type_attribute_in_action_selector()
       throws Exception {
 
-    var contactsInAccount = createContactsInAccount(defaultAccount, "heelo@demo.com",
+    //create contacts and move to trash
+    var contactsInAccount = createContactsForAccount(defaultAccount, "heelo@demo.com",
         "heelo2@demo.com", "heelo3@demo.com");
-    moveContactsToTrash(defaultAccount, contactsInAccount);
+    moveContactsToTrashForAccount(defaultAccount, contactsInAccount);
 
-    var appointmentId = createAppointment(defaultAccount);
-    moveAppointmentToTrash(defaultAccount, appointmentId);
+    //create appointments and move them to trash
+    var appointmentId = createAppointmentForAccount(defaultAccount);
+    moveAppointmentToTrashForAccount(defaultAccount, appointmentId);
 
-    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
-    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
-    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
-    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, Boolean.TRUE.toString());
-    actionSelectorElement.addAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE,
-        FolderActionEmptyOpTypes.CONTACTS.name());
+    // empty trash (only items specified by type)
+    folderActionEmptyTrashForAccount(defaultAccount, true, FolderActionEmptyOpTypes.CONTACTS);
 
-    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
-    folderActionRequestElement.addUniqueElement(actionSelectorElement);
-
-    var folderActionHandler = new FolderAction();
-    folderActionHandler.handle(folderActionRequestElement, getSoapContextFromAccount(defaultAccount));
-
-    var getFolderResponse = getFolder(defaultAccount,
+    // verify
+    var getFolderResponse = getFolderForAccount(defaultAccount,
         String.valueOf(FolderConstants.ID_FOLDER_TRASH));
-
     // will fail right now
     if (getFolderResponse.getFolder().getItemCount() != 0) {
       fail("deletes all items in the trash folder right now");
     }
   }
 
+  @SuppressWarnings({"SameParameterValue", "UnusedReturnValue"})
+  private FolderActionResponse folderActionEmptyTrashForAccount(Account targetAccount, boolean recursively,
+      @Nullable FolderActionEmptyOpTypes itemsType) throws ServiceException {
+    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
+    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
+    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
+    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, Boolean.valueOf(recursively).toString());
+    actionSelectorElement.addAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE,
+        itemsType != null ? itemsType.name() : null);
 
-  private void moveContactsToTrash(Account targetAccount, ArrayList<String> contactIds) throws ServiceException {
+    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
+    folderActionRequestElement.addUniqueElement(actionSelectorElement);
+
+    var folderActionHandler = new FolderAction();
+    var response = folderActionHandler.handle(folderActionRequestElement,
+        getSoapContextForAccount(targetAccount, false));
+
+    return JaxbUtil.elementToJaxb(response);
+  }
+
+  private void moveContactsToTrashForAccount(Account targetAccount, ArrayList<String> contactIds)
+      throws ServiceException {
     for (var contactId : contactIds) {
       Element contactActionSelectorElement = new XMLElement(MailConstants.E_ACTION);
       contactActionSelectorElement.addAttribute(MailConstants.A_ID, contactId);
@@ -134,11 +117,11 @@ class FolderActionTest extends SoapTestSuite {
       contactActionRequestElement.addUniqueElement(contactActionSelectorElement);
 
       var contactActionHandler = new ContactAction();
-      contactActionHandler.handle(contactActionRequestElement, getSoapContextFromAccount(targetAccount));
+      contactActionHandler.handle(contactActionRequestElement, getSoapContextForAccount(targetAccount, false));
     }
   }
 
-  private ArrayList<String> createContactsInAccount(Account targetAccount, String... emails) throws Exception {
+  private ArrayList<String> createContactsForAccount(Account targetAccount, String... emails) throws Exception {
     var contactIds = new ArrayList<String>();
     for (var contactEmail : emails) {
       var createContactRequestElement = JaxbUtil.jaxbToElement(
@@ -146,7 +129,7 @@ class FolderActionTest extends SoapTestSuite {
 
       var createContactHandler = new CreateContact();
       var response = createContactHandler.handle(createContactRequestElement,
-          getSoapContextFromAccount(targetAccount));
+          getSoapContextForAccount(targetAccount, false));
 
       CreateContactResponse createContactResponse = JaxbUtil.elementToJaxb(response);
       contactIds.add(Objects.requireNonNull(createContactResponse).getContact().getId());
@@ -155,7 +138,7 @@ class FolderActionTest extends SoapTestSuite {
     return contactIds;
   }
 
-  private String createAppointment(Account targetAccount) throws Exception {
+  private String createAppointmentForAccount(Account targetAccount) throws Exception {
     var createAppointmentElement =
         Element.parseJSON(
             new String(
@@ -166,13 +149,13 @@ class FolderActionTest extends SoapTestSuite {
     var createAppointmentHandler = new CreateAppointment();
     createAppointmentHandler.setResponseQName(MailConstants.CREATE_APPOINTMENT_RESPONSE);
     var response = createAppointmentHandler.handle(createAppointmentElement,
-        getSoapContextFromAccount(targetAccount));
+        getSoapContextForAccount(targetAccount, false));
 
     CreateAppointmentResponse createCalendarItemResponse = JaxbUtil.elementToJaxb(response);
     return Objects.requireNonNull(createCalendarItemResponse).getCalItemId();
   }
 
-  private void moveAppointmentToTrash(Account targetAccount, String appointmentId) throws ServiceException {
+  private void moveAppointmentToTrashForAccount(Account targetAccount, String appointmentId) throws ServiceException {
 
     Element itemActionSelectorElement = new XMLElement(MailConstants.E_ACTION);
     itemActionSelectorElement.addAttribute(MailConstants.A_ID, appointmentId);
@@ -183,10 +166,10 @@ class FolderActionTest extends SoapTestSuite {
     itemActionRequestElement.addUniqueElement(itemActionSelectorElement);
 
     var itemActionHandler = new ItemAction();
-    itemActionHandler.handle(itemActionRequestElement, getSoapContextFromAccount(targetAccount));
+    itemActionHandler.handle(itemActionRequestElement, getSoapContextForAccount(targetAccount, false));
   }
 
-  private GetFolderResponse getFolder(Account targetAccount, String folderId) throws Exception {
+  private GetFolderResponse getFolderForAccount(Account targetAccount, String folderId) throws Exception {
     var getFolderSpec = new GetFolderSpec();
     getFolderSpec.setFolderId(folderId);
     var getFolderRequest = new GetFolderRequest();
@@ -196,7 +179,7 @@ class FolderActionTest extends SoapTestSuite {
 
     var getFolderHandler = new GetFolder();
     var response = getFolderHandler.handle(getFolderElement,
-        getSoapContextFromAccount(targetAccount));
+        getSoapContextForAccount(targetAccount, false));
 
     return JaxbUtil.elementToJaxb(response);
   }

--- a/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FolderActionTest.java
@@ -1,0 +1,169 @@
+package com.zimbra.cs.service.mail;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.zextras.mailbox.soap.SoapTestSuite;
+import com.zimbra.common.mailbox.FolderConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.XMLElement;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.FolderActionEmptyOpTypes;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.CreateContactRequest;
+import com.zimbra.soap.mail.message.CreateContactResponse;
+import com.zimbra.soap.mail.message.GetFolderRequest;
+import com.zimbra.soap.mail.message.GetFolderResponse;
+import com.zimbra.soap.mail.type.ContactSpec;
+import com.zimbra.soap.mail.type.GetFolderSpec;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("api")
+class FolderActionTest extends SoapTestSuite {
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private static Provisioning provisioning;
+  @SuppressWarnings("FieldCanBeLocal")
+  private static Domain defaultDomain;
+  private static Account defaultAccount;
+
+  private static HashMap<String, Object> defaultAccountSoapContext;
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    provisioning = Provisioning.getInstance();
+    defaultDomain = provisioning.createDomain(UUID.randomUUID() + ".com", new HashMap<>());
+    defaultAccount = provisioning.createAccount(UUID.randomUUID() + "@" + defaultDomain.getName(), "password",
+        new HashMap<>());
+    defaultAccountSoapContext = getSoapContextFromAccount(defaultAccount);
+  }
+
+  private static HashMap<String, Object> getSoapContextFromAccount(Account account)
+      throws ServiceException {
+    return new HashMap<>() {
+      {
+        put(
+            SoapEngine.ZIMBRA_CONTEXT,
+            new ZimbraSoapContext(
+                AuthProvider.getAuthToken(account, false),
+                account.getId(),
+                SoapProtocol.Soap12,
+                SoapProtocol.Soap12));
+      }
+    };
+  }
+
+  @Test
+  void emptyFolderActionRequestShouldFailWhenMissesType() {
+
+    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
+    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
+    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
+    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, "true");
+
+    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
+    folderActionRequestElement.addUniqueElement(actionSelectorElement);
+
+    var folderActionHandler = new FolderAction();
+    var serviceException = assertThrows(ServiceException.class,
+        () -> folderActionHandler.handle(folderActionRequestElement, defaultAccountSoapContext));
+
+    assertEquals(ServiceException.INVALID_REQUEST, serviceException.getCode());
+    assertEquals("invalid request: missing required attribute: type", serviceException.getMessage());
+  }
+
+  @Test
+  void emptyFolderRequestShouldDeleteOnlySpecifiedItemsByType() throws Exception {
+
+    var contactsInAccount = createContactsInAccount(defaultAccount, "heelo@demo.com",
+        "heelo2@demo.com", "heelo3@demo.com");
+    moveContactsToTrash(defaultAccount, contactsInAccount);
+
+    Element actionSelectorElement = new XMLElement(MailConstants.E_ACTION);
+    actionSelectorElement.addAttribute(MailConstants.A_ID, FolderConstants.ID_FOLDER_TRASH);
+    actionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_EMPTY);
+    actionSelectorElement.addAttribute(MailConstants.A_RECURSIVE, "true");
+    actionSelectorElement.addAttribute(MailConstants.A_FOLDER_ACTION_EMPTY_OP_MATCH_TYPE,
+        FolderActionEmptyOpTypes.EMAILS.name());
+
+    Element folderActionRequestElement = new XMLElement(MailConstants.E_FOLDER_ACTION_REQUEST);
+    folderActionRequestElement.addUniqueElement(actionSelectorElement);
+
+    var folderActionHandler = new FolderAction();
+    folderActionHandler.handle(folderActionRequestElement, defaultAccountSoapContext);
+
+    var getFolderResponse = getFolder(defaultAccount,
+        String.valueOf(FolderConstants.ID_FOLDER_TRASH));
+
+    if (getFolderResponse.getFolder().getItemCount() == 0) {
+      fail("deletes all items in the trash folder right now");
+    }
+  }
+
+
+  private void moveContactsToTrash(Account targetAccount, ArrayList<String> contactIds) throws ServiceException {
+
+    for (var contactId : contactIds) {
+      Element contactActionSelectorElement = new XMLElement(MailConstants.E_ACTION);
+      contactActionSelectorElement.addAttribute(MailConstants.A_ID, contactId);
+      contactActionSelectorElement.addAttribute(MailConstants.A_OPERATION, FolderAction.OP_MOVE);
+      contactActionSelectorElement.addAttribute(MailConstants.A_FOLDER, FolderConstants.ID_FOLDER_TRASH);
+
+      Element contactActionRequestElement = new XMLElement(MailConstants.E_CONTACT_ACTION_REQUEST);
+      contactActionRequestElement.addUniqueElement(contactActionSelectorElement);
+
+      var contactActionHandler = new ContactAction();
+      contactActionHandler.handle(contactActionRequestElement, getSoapContextFromAccount(targetAccount));
+    }
+
+  }
+
+  private ArrayList<String> createContactsInAccount(Account targetAccount, String... emails) throws Exception {
+    var contactIds = new ArrayList<String>();
+    for (var contactEmail : emails) {
+      var createContactRequestElement = JaxbUtil.jaxbToElement(
+          new CreateContactRequest(new ContactSpec().addEmail(contactEmail)));
+
+      var createContactHandler = new CreateContact();
+      var response = createContactHandler.handle(createContactRequestElement,
+          getSoapContextFromAccount(targetAccount));
+
+      CreateContactResponse createContactResponse = JaxbUtil.elementToJaxb(response);
+      contactIds.add(Objects.requireNonNull(createContactResponse).getContact().getId());
+    }
+
+    return contactIds;
+  }
+
+
+  private GetFolderResponse getFolder(Account targetAccount, String folderId) throws Exception {
+    var getFolderSpec = new GetFolderSpec();
+    getFolderSpec.setFolderId(folderId);
+    var getFolderRequest = new GetFolderRequest();
+    getFolderRequest.setFolder(getFolderSpec);
+
+    var getFolderElement = JaxbUtil.jaxbToElement(getFolderRequest);
+
+    var getFolderHandler = new GetFolder();
+    var response = getFolderHandler.handle(getFolderElement,
+        getSoapContextFromAccount(targetAccount));
+
+    return JaxbUtil.elementToJaxb(response);
+  }
+}

--- a/store/src/test/resources/com/zimbra/cs/service/mail/SampleAppointmentRequest.json
+++ b/store/src/test/resources/com/zimbra/cs/service/mail/SampleAppointmentRequest.json
@@ -1,0 +1,65 @@
+{
+  "echo": "1",
+  "comp": "0",
+  "m": {
+    "e": [
+      {
+        "a": "test@test.com",
+        "p": "Test User",
+        "t": "f"
+      }
+    ],
+    "inv": {
+      "comp": [
+        {
+          "alarm": [
+            {
+              "action": "DISPLAY",
+              "trigger": {
+                "rel": {
+                  "m": "5",
+                  "related": "START",
+                  "neg": "1"
+                }
+              }
+            }
+          ],
+          "at": [],
+          "allDay": "0",
+          "fb": "B",
+          "loc": "",
+          "name": "New appointment",
+          "or": {
+            "a": "test@test.com"
+          },
+          "status": "CONF",
+          "s": {
+            "d": "20230907T110000",
+            "tz": "Europe/Rome"
+          },
+          "e": {
+            "d": "20230907T113000",
+            "tz": "Europe/Rome"
+          },
+          "class": "PUB",
+          "draft": 0
+        }
+      ]
+    },
+    "l": "10",
+    "mp": {
+      "ct": "multipart/alternative",
+      "mp": [
+        {
+          "ct": "text/html",
+          "content": "<html><body id='htmlmode'>-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-<h3>Test User have invited you to a new meeting!</h3><p>Subject: New appointment</p><p>Organizer: Test User</p><p>Location: </p><p>Time: Thursday, September 7, 2023 11:00 AM - 11:30 AM</p><p>Invitees: </p><br/>-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-"
+        },
+        {
+          "ct": "text/plain",
+          "content": "-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-\nTest User have invited you to a new meeting!\n\nSubject: New appointment \nOrganizer: \"Test User \n\nTime: Thursday, September 7, 2023 11:00 AM - 11:30 AM\n \nInvitees:  \n\n\n-:::_::_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_:_::_:_::-\n"
+        }
+      ]
+    },
+    "su": "New appointment"
+  }
+}


### PR DESCRIPTION
**What has changed:**
- add new optional attribtute `type` in `FolderActionSelector` for `empty` operation.
This attribute can be passed to the FolderActionRequest.
- add support accepting `type` in emptyFolder to perform empty folder by specified type of item
- minor cleanup and fixes
    - add helper method `getSoapContextForAccount` in `SoapTestSuite`