### PR TITLE
fix: [CO-1179] UserServlet to properly return XML and scriptable attachments without defanging

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/UserServlet.java
@@ -442,7 +442,6 @@ public class UserServlet extends ZimbraServlet {
    * Constructs the exteral url for a mount point. This gets the link back to the correct server
    * without need for proxying it
    *
-   * @param authToken
    * @param mpt The mount point to create the url for
    * @return The url for the mountpoint/share that goes back to the original user/share/server
    * @throws ServiceException
@@ -514,8 +513,6 @@ public class UserServlet extends ZimbraServlet {
    * Constructs the exteral url for a mount point. This gets the link back to the correct server
    * without need for proxying it
    *
-   * @param authToken
-   * @param mpt The mount point to create the url for
    * @return The url for the mountpoint/share that goes back to the original user/share/server
    * @throws ServiceException
    */

--- a/store/src/main/java/com/zimbra/cs/service/formatter/NativeFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/NativeFormatter.java
@@ -6,6 +6,7 @@
 package com.zimbra.cs.service.formatter;
 
 import com.google.common.base.Strings;
+import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.mime.MimeDetect;
@@ -17,7 +18,6 @@ import com.zimbra.common.util.Log;
 import com.zimbra.common.util.LogFactory;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.mailbox.CalendarItem;
 import com.zimbra.cs.mailbox.Contact;
@@ -55,6 +55,8 @@ import java.util.Set;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import javax.mail.MessagingException;
@@ -81,7 +83,7 @@ public final class NativeFormatter extends Formatter {
 
     private static final Log log = LogFactory.getLog(NativeFormatter.class);
 
-    private final Set<String> SCRIPTABLE_CONTENT_TYPES = Set.of(MimeConstants.CT_TEXT_HTML,
+    private final Set<String> scriptableContentTypes = Set.of(MimeConstants.CT_TEXT_HTML,
         MimeConstants.CT_APPLICATION_XHTML,
         MimeConstants.CT_TEXT_XML,
         MimeConstants.CT_APPLICATION_ZIMBRA_DOC,
@@ -98,7 +100,6 @@ public final class NativeFormatter extends Formatter {
 
     @Override
     public Set<MailItem.Type> getDefaultSearchTypes() {
-        // TODO: all?
         return EnumSet.of(MailItem.Type.MESSAGE);
     }
 
@@ -216,7 +217,7 @@ public final class NativeFormatter extends Formatter {
             if (simpleText) {
                 contentType = MimeConstants.CT_TEXT_PLAIN;
             }
-            boolean html = checkGlobalOverride(Provisioning.A_zimbraAttachmentsViewInHtmlOnly,
+            boolean html = checkGlobalOverride(ZAttrProvisioning.A_zimbraAttachmentsViewInHtmlOnly,
                     context.getAuthAccount()) || (context.hasView() && context.getView().equals(HTML_VIEW));
             InputStream in = null;
             try {
@@ -241,9 +242,9 @@ public final class NativeFormatter extends Formatter {
                     String returnCode = null;
                     if (data != null) {
                         returnCode = new String(Arrays.copyOfRange(data, 0,
-                            NativeFormatter.RETURN_CODE_NO_RESIZE.length()), StandardCharsets.UTF_8);
+                            RETURN_CODE_NO_RESIZE.length()), StandardCharsets.UTF_8);
                     }
-                    if (data != null && !NativeFormatter.RETURN_CODE_NO_RESIZE.equals(returnCode)) {
+                    if (data != null && !RETURN_CODE_NO_RESIZE.equals(returnCode)) {
                         in = new ByteArrayInputStream(data);
                         size = data.length;
                     } else {
@@ -252,14 +253,13 @@ public final class NativeFormatter extends Formatter {
                         if (enc != null) {
                             enc = enc.toLowerCase();
                         }
-                        size = enc == null || enc.equals("7bit") || enc.equals("8bit") || enc.equals("binary") ? mp.getSize() : 0;
+                        size = enc == null || "7bit".equals(enc) || "8bit".equals(enc) || "binary".equals(enc) ? mp.getSize() : 0;
                     }
-                    String defaultCharset = context.targetAccount.getAttr(Provisioning.A_zimbraPrefMailDefaultCharset, null);
                     if (simpleText) {
                         sendBackBinaryData(context.req, context.resp, in, contentType, Part.INLINE,
-                                null /* filename */, size, true);
+                                null, size, true);
                     } else {
-                        sendBackOriginalDoc(in, contentType, defaultCharset, Mime.getFilename(mp), mp.getDescription(),
+                        sendBackOriginalDoc(in, contentType, Mime.getFilename(mp), mp.getDescription(),
                                 size, context.req, context.resp);
                     }
                 } else {
@@ -279,66 +279,61 @@ public final class NativeFormatter extends Formatter {
      * returns {@code null}.
      */
     public static byte[] getResizedImageData(InputStream in, String contentType, String fileName, Integer maxWidth, Integer maxHeight)
-    throws IOException {
-        ImageReader reader = null;
-        ImageWriter writer = null;
+        throws IOException {
 
-        if (maxWidth == null)
+        if (maxWidth == null) {
             maxWidth = LC.max_image_size_to_resize.intValue();
+        }
 
-        if (maxHeight == null)
+        if (maxHeight == null) {
             maxHeight = LC.max_image_size_to_resize.intValue();
+        }
 
-        try {
-            // Get ImageReader for stream content.
-            reader = ImageUtil.getImageReader(contentType, fileName);
+        try (ImageInputStream iis = new MemoryCacheImageInputStream(in);
+            ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+
+            ImageReader reader = ImageUtil.getImageReader(contentType, fileName);
             if (reader == null) {
                 log.debug("No ImageReader available.");
                 return null;
             }
 
-            // Read message content.
-            reader.setInput(new MemoryCacheImageInputStream(in));
+            reader.setInput(iis);
             BufferedImage img = reader.read(0);
-            int width = img.getWidth(), height = img.getHeight();
+            int width = img.getWidth();
+            int height = img.getHeight();
 
             if (width <= maxWidth && height <= maxHeight) {
                 log.debug("Image %dx%d is less than max %dx%d.  Not resizing.",
-                          width, height, maxWidth, maxHeight);
+                    width, height, maxWidth, maxHeight);
                 return RETURN_CODE_NO_RESIZE.getBytes();
             }
 
-            // Resize.
-            writer = ImageIO.getImageWriter(reader);
+            double ratio = Math.min((double) maxWidth / width, (double) maxHeight / height);
+            width *= ratio;
+            height *= ratio;
+
+            BufferedImage small = ImageUtil.resize(img, width, height);
+
+            ImageWriter writer = ImageIO.getImageWriter(reader);
             if (writer == null) {
                 log.debug("No ImageWriter available.");
                 return null;
             }
 
-            double ratio =
-                Math.min((double) maxWidth / width,
-                         (double) maxHeight / height);
+            try (ImageOutputStream ios = new MemoryCacheImageOutputStream(out)) {
+                writer.setOutput(ios);
+                writer.write(small);
+            } finally {
+                writer.dispose();
+            }
 
-            width *= ratio;
-            height *= ratio;
-
-            BufferedImage small = ImageUtil.resize(img, width, height);
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            writer.setOutput(new MemoryCacheImageOutputStream(out));
-            writer.write(small);
             return out.toByteArray();
         } finally {
             ByteUtil.closeStream(in);
-            if (reader != null) {
-                reader.dispose();
-            }
-            if (writer != null) {
-                writer.dispose();
-            }
         }
-
-
     }
+
 
     private void handleConversion(UserServletContext ctxt, InputStream is, String filename, String ct, String digest, long length) throws IOException, ServletException {
         try {
@@ -370,13 +365,13 @@ public final class NativeFormatter extends Formatter {
         return Mime.getMimePart(msg.getMimeMessage(), part);
     }
 
-    public void sendBackOriginalDoc(InputStream is, String contentType, String defaultCharset, String filename,
-            String desc, HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        sendBackOriginalDoc(is, contentType, defaultCharset, filename, desc, 0, req, resp);
+    public void sendBackOriginalDoc(InputStream is, String contentType, String filename,
+        String desc, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        sendBackOriginalDoc(is, contentType, filename, desc, 0, req, resp);
     }
 
-    private void sendBackOriginalDoc(InputStream is, String contentType, String defaultCharset, String filename,
-            String desc, long size, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    private void sendBackOriginalDoc(InputStream is, String contentType, String filename,
+        String desc, long size, HttpServletRequest req, HttpServletResponse resp) throws IOException {
         String disp = req.getParameter(UserServlet.QP_DISP);
         disp = (disp == null || disp.toLowerCase().startsWith("i")) ? Part.INLINE : Part.ATTACHMENT;
         if (desc != null && desc.length() <= 2048) { // do not return ridiculously long header.
@@ -422,8 +417,7 @@ public final class NativeFormatter extends Formatter {
     }
 
     private void saveDocument(Blob blob, UserServletContext context, String contentType, Folder folder, String filename, InputStream is)
-        throws IOException, ServiceException, UserServletException
-    {
+        throws IOException, ServiceException {
         Mailbox mbox = folder.getMailbox();
         MailItem item = null;
 
@@ -450,20 +444,13 @@ public final class NativeFormatter extends Formatter {
             if (result == UploadScanner.ERROR)
                 throw MailServiceException.SCAN_ERROR(filename);
 
-        } catch (NoSuchItemException nsie) {
+        } catch (NoSuchItemException ignored) {
         }
 
         sendZimbraHeaders(context, context.resp, item);
     }
 
-    private static long getContentLength(HttpServletRequest req)
-    {
-        // note HttpServletRequest.getContentLength() returns int, that's
-        // why we parse it ourselves
-        final String contentLengthStr = req.getHeader("Content-Length");
-        return contentLengthStr != null ? Long.parseLong(contentLengthStr) : -1;
-    }
-
+    @SuppressWarnings("UastIncorrectHttpHeaderInspection")
     public static void sendZimbraHeaders(UserServletContext context, HttpServletResponse resp, MailItem item) {
         if (resp == null || item == null)
             return;
@@ -486,7 +473,7 @@ public final class NativeFormatter extends Formatter {
                     val = MimeUtility.encodeText(val, "utf-8", "B");
                 }
                 resp.addHeader("X-Zimbra-ItemPath", val);
-            } catch (UnsupportedEncodingException | ServiceException e1) {
+            } catch (UnsupportedEncodingException | ServiceException ignored) {
             }
         }
 
@@ -526,6 +513,7 @@ public final class NativeFormatter extends Formatter {
         } else if (disposition.equals(Part.ATTACHMENT)) {
             isSafe = true;
             if (isScriptableContent(contentType)) {
+                //noinspection UastIncorrectHttpHeaderInspection
                 resp.addHeader("X-Download-Options", "noopen"); // ask it to save the file
             }
         }
@@ -563,18 +551,17 @@ public final class NativeFormatter extends Formatter {
         ByteUtil.copy(pis, true, resp.getOutputStream(), false);
     }
     /**
-     * Determines whether or not the contentType passed might contain script or other unsavory tags.
+     * Determines whether the contentType passed might contain script or other unsavory tags.
      * @param contentType The content type to check
-     * @return true if there's a possiblilty that <script> is valid, false if not
+     * @return true if there's a possibility that <script> is valid, false if not
      */
     private boolean isScriptableContent(String contentType) {
-        // Make sure we don't have to worry about a null content type;
         if (Strings.isNullOrEmpty(contentType)) {
             return false;
         }
         contentType = Mime.getContentType(contentType).toLowerCase();
         // only set no-open for 'script type content'
-        return SCRIPTABLE_CONTENT_TYPES.contains(contentType);
+        return scriptableContentTypes.contains(contentType);
 
     }
 }

--- a/store/src/test/java/com/zimbra/cs/mailbox/MailboxTestUtil.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/MailboxTestUtil.java
@@ -42,6 +42,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import javax.activation.DataHandler;
+import javax.activation.DataSource;
 import javax.mail.MessagingException;
 import javax.mail.Part;
 import javax.mail.internet.MimeMessage;
@@ -293,6 +294,38 @@ public final class MailboxTestUtil {
     }
     bp.addHeader("Content-Disposition", cdisp.toString());
     bp.addHeader("Content-Type", "text/plain");
+    bp.addHeader("Content-Transfer-Encoding", MimeConstants.ET_8BIT);
+    multi.addBodyPart(bp);
+
+    mm.setContent(multi);
+    mm.saveChanges();
+
+    return new ParsedMessage(mm, false);
+  }
+
+  public static ParsedMessage generateMessageWithXmlAttachment(String subject) throws Exception {
+    MimeMessage mm = new Mime.FixedMimeMessage(JMSession.getSession());
+    mm.setHeader("From", "Vera Oliphant <oli@example.com>");
+    mm.setHeader("To", "Jimmy Dean <jdean@example.com>");
+    mm.setHeader("Subject", subject);
+    mm.setText("Good as gold");
+
+    MimeMultipart multi = new ZMimeMultipart("mixed");
+    ContentDisposition cdisp = new ContentDisposition(Part.ATTACHMENT);
+    cdisp.setParameter("filename", "data.xml");
+
+    ZMimeBodyPart bp = new ZMimeBodyPart();
+    // MimeBodyPart.setDataHandler() invalidates Content-Type and CTE if there is any, so make sure
+    // it gets called before setting Content-Type and CTE headers.
+    try {
+      String xmlContent = "<root><message>Feeling attached.</message></root>";
+      DataSource ds = new ByteArrayDataSource(xmlContent, "text/xml");
+      bp.setDataHandler(new DataHandler(ds));
+    } catch (IOException e) {
+      throw new MessagingException("could not generate mime part content", e);
+    }
+    bp.addHeader("Content-Disposition", cdisp.toString());
+    bp.addHeader("Content-Type", "text/xml");
     bp.addHeader("Content-Transfer-Encoding", MimeConstants.ET_8BIT);
     multi.addBodyPart(bp);
 

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -20,6 +20,7 @@ import com.zimbra.common.util.L10nUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTest;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
@@ -254,7 +255,21 @@ class UserServletTest {
 
   @Test
   void should_return404_when_asked_attachment_does_not_exits() throws Exception {
-    var httpResponse = getUserServletRequest(server.getURI().toString() + "~/?auth=co&id=257&part=1");
+    var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+
+    // add message
+    var textAttachmentMsgId = testAccountMailbox.addMessage(null,
+        MailboxTestUtil.generateMessageWithAttachment("find text attachment"),
+        MailboxTest.STANDARD_DELIVERY_OPTIONS, null).getId();
+
+    var part1TextAttachmentHttpResponse = getUserServletRequest(server.getURI()
+        .toString() + "~/?auth=co&id=" + textAttachmentMsgId + "&part=1");
+    assertEquals(HttpStatus.SC_OK, part1TextAttachmentHttpResponse.getStatusLine().getStatusCode());
+
+    // delete message
+    testAccountMailbox.delete(null, textAttachmentMsgId, Type.MESSAGE);
+    var httpResponse = getUserServletRequest(
+        server.getURI().toString() + "~/?auth=co&id=" + textAttachmentMsgId + "&part=1");
 
     assertEquals(HttpStatus.SC_NOT_FOUND, httpResponse.getStatusLine().getStatusCode());
   }

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -20,6 +20,8 @@ import com.zimbra.common.util.L10nUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTest;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.mail.CreateAppointment;
 import com.zimbra.cs.servlet.ZimbraServlet;
@@ -83,7 +85,7 @@ class UserServletTest {
     server.setConnectors(new ServerConnector[] {serverConnector});
     server.start();
     Provisioning prov = Provisioning.getInstance();
-    HashMap<String, Object> attrs = new HashMap<String, Object>();
+    HashMap<String, Object> attrs = new HashMap<>();
     attrs.put(Provisioning.A_zimbraAccountStatus, "pending");
     prov.createAccount("testbug39481@zimbra.com", "secret", attrs);
     testAccount =
@@ -99,13 +101,9 @@ class UserServletTest {
   }
 
   @AfterEach
-  public void tearDown() {
-    try {
+  public void tearDown() throws Exception {
       MailboxTestUtil.clearData();
       server.stop();
-    } catch (Exception e) {
-
-    }
   }
 
   /**
@@ -144,10 +142,7 @@ class UserServletTest {
 
   /**
    * Make a Calendar call to {@link UserServlet} endpoint using {@link #testAccount}
-   *
-   * @return
-   * @throws Exception
-   */
+   **/
   private HttpResponse defaultUserCalendarRequest() throws Exception {
     return getUserServletRequest(server.getURI().toString() + "~/Calendar.json?auth=co");
   }
@@ -168,6 +163,7 @@ class UserServletTest {
     }
   }
 
+  @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
   private HttpResponse postUserServletRequest(String userServletEndpoint, String fileToUpload)
       throws Exception {
     final AuthToken authToken = AuthProvider.getAuthToken(testAccount);
@@ -192,7 +188,7 @@ class UserServletTest {
   /** Adds an appointment for {@link #testAccount} */
   private void createDefaultCalendarAppointmentForTestUser() throws Exception {
     final AuthToken authToken = AuthProvider.getAuthToken(testAccount);
-    Map<String, Object> context = new HashMap<String, Object>();
+    Map<String, Object> context = new HashMap<>();
     ZimbraSoapContext zsc =
         new ZimbraSoapContext(
             authToken, testAccount.getId(), SoapProtocol.Soap12, SoapProtocol.Soap12);
@@ -214,10 +210,10 @@ class UserServletTest {
   @DisplayName("User has no appointments, UserServlet should return an empty JSON.")
   void shouldReturnEmptyJsonIfUserHasNoItemsInCalendar() throws Exception {
     final HttpResponse httpCalendarResponse = this.defaultUserCalendarRequest();
-    Assertions.assertEquals(HttpStatus.SC_OK, httpCalendarResponse.getStatusLine().getStatusCode());
+    assertEquals(HttpStatus.SC_OK, httpCalendarResponse.getStatusLine().getStatusCode());
     final String calendarResponse =
         new String(httpCalendarResponse.getEntity().getContent().readAllBytes());
-    Assertions.assertEquals("{}", calendarResponse);
+    assertEquals("{}", calendarResponse);
   }
 
   @Test
@@ -227,7 +223,7 @@ class UserServletTest {
     this.createDefaultCalendarAppointmentForTestUser();
 
     final HttpResponse httpUserServletCalResponse = this.defaultUserCalendarRequest();
-    Assertions.assertEquals(
+    assertEquals(
         HttpStatus.SC_OK, httpUserServletCalResponse.getStatusLine().getStatusCode());
 
     final String calendarResponse =
@@ -236,7 +232,7 @@ class UserServletTest {
     Assertions.assertNotEquals("{}", calendarResponse);
     final CalendarJson calendarResponseMap =
         new ObjectMapper().readValue(calendarResponse, CalendarJson.class);
-    Assertions.assertEquals(2, calendarResponseMap.getAppt().size());
+    assertEquals(2, calendarResponseMap.getAppt().size());
   }
 
   @Test
@@ -246,28 +242,99 @@ class UserServletTest {
         server.getURI().toString() + "~/calendar?auth=co&fmt=zip", "UploadCalendar.zip");
 
     final HttpResponse getCalendarsResponse = this.defaultUserCalendarRequest();
-    Assertions.assertEquals(HttpStatus.SC_OK, getCalendarsResponse.getStatusLine().getStatusCode());
+    assertEquals(HttpStatus.SC_OK, getCalendarsResponse.getStatusLine().getStatusCode());
     final String calendarResponse =
         new String(getCalendarsResponse.getEntity().getContent().readAllBytes());
     Assertions.assertNotEquals("{}", calendarResponse);
     final CalendarJson calendarResponseMap =
         new ObjectMapper().readValue(calendarResponse, CalendarJson.class);
 
-    Assertions.assertEquals(1, calendarResponseMap.getAppt().size());
+    assertEquals(1, calendarResponseMap.getAppt().size());
+  }
+
+  @Test
+  void should_return404_when_asked_attachment_does_not_exits() throws Exception {
+    var httpResponse = getUserServletRequest(server.getURI().toString() + "~/?auth=co&id=257&part=1");
+
+    assertEquals(HttpStatus.SC_NOT_FOUND, httpResponse.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  void should_return_attachment_when_asked() throws Exception {
+    var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+
+    var textAttachmentMsgId = testAccountMailbox.addMessage(null,
+        MailboxTestUtil.generateMessageWithAttachment("find text attachment"),
+        MailboxTest.STANDARD_DELIVERY_OPTIONS, null).getId();
+
+    var part1TextAttachmentHttpResponse = getUserServletRequest(server.getURI()
+        .toString() + "~/?auth=co&id=" + textAttachmentMsgId + "&part=1");
+    assertEquals(HttpStatus.SC_OK, part1TextAttachmentHttpResponse.getStatusLine().getStatusCode());
+    assertEquals("Feeling attached.",
+        new String(part1TextAttachmentHttpResponse.getEntity().getContent().readAllBytes()));
+  }
+
+  @Test
+  void should_return_attachment_with_asked_disposition_type_when_asked() throws Exception {
+    var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+
+    var textAttachmentMsgId = testAccountMailbox.addMessage(null,
+        MailboxTestUtil.generateMessageWithAttachment("find text attachment"),
+        MailboxTest.STANDARD_DELIVERY_OPTIONS, null).getId();
+
+    // ask disp=i i.e, inline
+    var part1TextAttachmentHttpResponse = getUserServletRequest(server.getURI()
+        .toString() + "~/?auth=co&id=" + textAttachmentMsgId + "&part=1&disp=i");
+
+    assertEquals(HttpStatus.SC_OK, part1TextAttachmentHttpResponse.getStatusLine().getStatusCode());
+    assertEquals("Feeling attached.",
+        new String(part1TextAttachmentHttpResponse.getEntity().getContent().readAllBytes()));
+    assertEquals("inline; filename=\"fun.txt\"",
+        part1TextAttachmentHttpResponse.getFirstHeader("Content-Disposition").getValue(),
+        "content-disposition should be inline when disp=i or disp=inline");
+
+    // ask disp=a i.e, attachment
+    var part1TextAttachmentHttpResponse2 = getUserServletRequest(server.getURI()
+        .toString() + "~/?auth=co&id=" + textAttachmentMsgId + "&part=1&disp=a");
+
+    assertEquals("attachment; filename=\"fun.txt\"",
+        part1TextAttachmentHttpResponse2.getFirstHeader("Content-Disposition").getValue(),
+        "content-disposition should be attachment when disp=a or disp=attachment");
+  }
+
+  @Test
+  void should_override_content_disposition_for_scriptable_attachment_types() throws Exception {
+    var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+
+    var xmlAttachmentMsgId = testAccountMailbox.addMessage(null,
+        MailboxTestUtil.generateMessageWithXmlAttachment("find xml attachment"),
+        MailboxTest.STANDARD_DELIVERY_OPTIONS, null).getId();
+
+    // ask disp=i i.e, inline
+    var part1XmlAttachmentHttpResponse = getUserServletRequest(server.getURI()
+        .toString() + "~/?auth=co&id=" + xmlAttachmentMsgId + "&part=1&disp=i");
+
+    assertEquals(HttpStatus.SC_OK, part1XmlAttachmentHttpResponse.getStatusLine().getStatusCode());
+    assertEquals("<root><message>Feeling attached.</message></root>",
+        new String(part1XmlAttachmentHttpResponse.getEntity().getContent().readAllBytes()));
+    assertEquals("attachment; filename=\"data.xml\"",
+        part1XmlAttachmentHttpResponse.getFirstHeader("Content-Disposition").getValue(),
+        "content-disposition should be 'attachment' for scriptable mime-types even if disp=i or disp=inline is passed");
   }
 
   /** DTO class for {@link UserServlet} Calendar response */
   private static class CalendarJson {
 
     @JsonProperty("appt")
-    public List<LinkedHashMap> appt;
+    public List<LinkedHashMap<?,?>> appt;
 
-    public List<LinkedHashMap> getAppt() {
+    public List<LinkedHashMap<?,?>> getAppt() {
       return appt;
     }
   }
 
-  public class MockHttpServletResponse implements HttpServletResponse {
+  @SuppressWarnings("RedundantThrows")
+  public static class MockHttpServletResponse implements HttpServletResponse {
 
     private int status = 0;
     private String msg = null;

--- a/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
@@ -45,16 +45,16 @@ class NativeFormatterTest {
   }
 
   @Test
-  void should_return_original_doc_with_requested_content_disposition_when_content_is_not_scriptable() throws IOException {
+  void should_return_original_doc_with_requested_content_disposition_when_content_is_not_scriptable()
+      throws IOException {
     InputStream is = new ByteArrayInputStream("Test data".getBytes());
     var contentType = "text/plain";
-    var defaultCharset = "UTF-8";
     var filename = "test.txt";
     var desc = "Test description";
 
     when(req.getParameter("disp")).thenReturn("i");
 
-    new NativeFormatter().sendBackOriginalDoc(is, contentType, defaultCharset, filename, desc, req, resp);
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, req, resp);
 
     verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
 
@@ -71,20 +71,19 @@ class NativeFormatterTest {
   @Test
   void should_return_original_doc_with_content_disposition_attachment_when_content_is_scriptable() throws IOException {
     var xmlContent = "<?xml version=\"1.0\"?>\n"
-        + "<Tests xmlns=\"http://www.adatum.com\">\n"
+        + "<Tests xmlns=\"https://www.example.com\">\n"
         + "  <Test TestId=\"0001\" TestType=\"CMD\">\n"
         + "    <Name>Convert number to string</Name>\n"
         + "  </Test>\n"
         + "</Tests>";
     InputStream is = new ByteArrayInputStream(xmlContent.getBytes());
     var contentType = "text/xml";
-    var defaultCharset = "UTF-8";
     var filename = "test.xml";
     var desc = "Test description";
 
     when(req.getParameter("disp")).thenReturn("i");
 
-    new NativeFormatter().sendBackOriginalDoc(is, contentType, defaultCharset, filename, desc, req, resp);
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, req, resp);
 
     verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
 

--- a/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
@@ -65,8 +65,6 @@ class NativeFormatterTest {
     if (contentDispositionIndex != -1) {
       assertTrue(capturedValues.get(contentDispositionIndex).contains("inline"));
     }
-
-    verify(resp, times(2)).setContentType(contentType);
     verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
   }
 
@@ -97,8 +95,6 @@ class NativeFormatterTest {
     if (contentDispositionIndex != -1) {
       assertTrue(capturedValues.get(contentDispositionIndex).contains("attachment"));
     }
-
-    verify(resp, times(2)).setContentType(contentType);
     verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
   }
 

--- a/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
@@ -1,0 +1,105 @@
+package com.zimbra.cs.service.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class NativeFormatterTest {
+
+  @Mock
+  private HttpServletRequest req;
+
+  @Mock
+  private HttpServletResponse resp;
+
+  @Mock
+  private ServletOutputStream servletOutputStream;
+
+  @Captor
+  private ArgumentCaptor<String> headerCaptor;
+
+  @Captor
+  private ArgumentCaptor<String> valueCaptor;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(resp.getOutputStream()).thenReturn(servletOutputStream);
+  }
+
+  @Test
+  void testSendBackOriginalDoc() throws IOException {
+    InputStream is = new ByteArrayInputStream("Test data".getBytes());
+    var contentType = "text/plain";
+    var defaultCharset = "UTF-8";
+    var filename = "test.txt";
+    var desc = "Test description";
+
+    when(req.getParameter("disp")).thenReturn("i");
+
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, defaultCharset, filename, desc, req, resp);
+
+    verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
+
+    var capturedHeaders = headerCaptor.getAllValues();
+    var capturedValues = valueCaptor.getAllValues();
+
+    var contentDispositionIndex = capturedHeaders.indexOf("Content-Disposition");
+    if (contentDispositionIndex != -1) {
+      assertTrue(capturedValues.get(contentDispositionIndex).contains("inline"));
+    }
+
+    verify(resp, times(2)).setContentType(contentType);
+    verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void should_return_original_doc_with_content_disposition_attachment_when_content_is_scriptable() throws IOException {
+    var xmlContent = "<?xml version=\"1.0\"?>\n"
+        + "<Tests xmlns=\"http://www.adatum.com\">\n"
+        + "  <Test TestId=\"0001\" TestType=\"CMD\">\n"
+        + "    <Name>Convert number to string</Name>\n"
+        + "  </Test>\n"
+        + "</Tests>";
+    InputStream is = new ByteArrayInputStream(xmlContent.getBytes());
+    var contentType = "text/xml";
+    var defaultCharset = "UTF-8";
+    var filename = "test.xml";
+    var desc = "Test description";
+
+    when(req.getParameter("disp")).thenReturn("i");
+
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, defaultCharset, filename, desc, req, resp);
+
+    verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
+
+    var capturedHeaders = headerCaptor.getAllValues();
+    var capturedValues = valueCaptor.getAllValues();
+
+    var contentDispositionIndex = capturedHeaders.indexOf("Content-Disposition");
+    if (contentDispositionIndex != -1) {
+      assertTrue(capturedValues.get(contentDispositionIndex).contains("attachment"));
+    }
+
+    verify(resp, times(2)).setContentType(contentType);
+    verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
+  }
+
+}

--- a/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
@@ -45,7 +45,7 @@ class NativeFormatterTest {
   }
 
   @Test
-  void testSendBackOriginalDoc() throws IOException {
+  void should_return_original_doc_with_requested_content_disposition_when_content_is_not_scriptable() throws IOException {
     InputStream is = new ByteArrayInputStream("Test data".getBytes());
     var contentType = "text/plain";
     var defaultCharset = "UTF-8";

--- a/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/formatter/NativeFormatterTest.java
@@ -24,24 +24,24 @@ import org.mockito.MockitoAnnotations;
 class NativeFormatterTest {
 
   @Mock
-  private HttpServletRequest req;
+  private HttpServletRequest servletRequestMock;
 
   @Mock
-  private HttpServletResponse resp;
+  private HttpServletResponse servletResponseMock;
 
   @Mock
-  private ServletOutputStream servletOutputStream;
+  private ServletOutputStream servletOutputStreamMock;
 
   @Captor
-  private ArgumentCaptor<String> headerCaptor;
+  private ArgumentCaptor<String> headerNameCaptor;
 
   @Captor
-  private ArgumentCaptor<String> valueCaptor;
+  private ArgumentCaptor<String> headerValueCaptor;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this);
-    when(resp.getOutputStream()).thenReturn(servletOutputStream);
+    when(servletResponseMock.getOutputStream()).thenReturn(servletOutputStreamMock);
   }
 
   @Test
@@ -52,20 +52,20 @@ class NativeFormatterTest {
     var filename = "test.txt";
     var desc = "Test description";
 
-    when(req.getParameter("disp")).thenReturn("i");
+    when(servletRequestMock.getParameter("disp")).thenReturn("i");
 
-    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, req, resp);
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, servletRequestMock, servletResponseMock);
 
-    verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
+    verify(servletResponseMock, times(2)).addHeader(headerNameCaptor.capture(), headerValueCaptor.capture());
 
-    var capturedHeaders = headerCaptor.getAllValues();
-    var capturedValues = valueCaptor.getAllValues();
+    var capturedHeaders = headerNameCaptor.getAllValues();
+    var capturedValues = headerValueCaptor.getAllValues();
 
     var contentDispositionIndex = capturedHeaders.indexOf("Content-Disposition");
     if (contentDispositionIndex != -1) {
       assertTrue(capturedValues.get(contentDispositionIndex).contains("inline"));
     }
-    verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
+    verify(servletOutputStreamMock, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
   }
 
   @Test
@@ -81,20 +81,20 @@ class NativeFormatterTest {
     var filename = "test.xml";
     var desc = "Test description";
 
-    when(req.getParameter("disp")).thenReturn("i");
+    when(servletRequestMock.getParameter("disp")).thenReturn("i");
 
-    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, req, resp);
+    new NativeFormatter().sendBackOriginalDoc(is, contentType, filename, desc, servletRequestMock, servletResponseMock);
 
-    verify(resp, times(2)).addHeader(headerCaptor.capture(), valueCaptor.capture());
+    verify(servletResponseMock, times(2)).addHeader(headerNameCaptor.capture(), headerValueCaptor.capture());
 
-    var capturedHeaders = headerCaptor.getAllValues();
-    var capturedValues = valueCaptor.getAllValues();
+    var capturedHeaders = headerNameCaptor.getAllValues();
+    var capturedValues = headerValueCaptor.getAllValues();
 
     var contentDispositionIndex = capturedHeaders.indexOf("Content-Disposition");
     if (contentDispositionIndex != -1) {
       assertTrue(capturedValues.get(contentDispositionIndex).contains("attachment"));
     }
-    verify(servletOutputStream, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
+    verify(servletOutputStreamMock, atLeastOnce()).write(any(byte[].class), anyInt(), anyInt());
   }
 
 }


### PR DESCRIPTION
**What has changed:**

- The UserServlet, which handles `/service/home` requests, now correctly returns XML and various other scriptable attachment MIME parts.
    - Scriptable attachments are now dispatched with `content-disposition` of `attachment` header even if requested as `inline`.
    - To avoid breaking the content, the defanging logic was removed, so scriptable attachments are no longer defanged before dispatching.