### PR TITLE
fix: [CO-1249] Better handling of GalGroup type matches in FullAutoComplete API

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -120,33 +120,33 @@ public class FullAutoComplete extends MailDocumentHandler {
     return fullAutoCompleteMatches.stream().map(match -> {
       var matchElementBuilder = new AutoCompleteMatchElementBuilder(zsc);
 
-      matchElementBuilder.setIntegerAttribute(MailConstants.A_RANKING, match.getRanking(), 0)
-          .setStringAttribute(MailConstants.A_MATCH_TYPE, match.getMatchType(), null)
-          .setBooleanAttribute(MailConstants.A_IS_GROUP, match.getGroup(), Boolean.FALSE);
+      matchElementBuilder.addIntegerAttribute(MailConstants.A_RANKING, match.getRanking(), 0)
+          .addStringAttribute(MailConstants.A_MATCH_TYPE, match.getMatchType())
+          .addBooleanAttribute(MailConstants.A_IS_GROUP, match.getGroup(), Boolean.FALSE);
 
       if (Boolean.FALSE.equals(match.getGroup())) {
-        matchElementBuilder.setStringAttribute(MailConstants.A_EMAIL, match.getEmail(), null);
+        matchElementBuilder.addStringAttribute(MailConstants.A_EMAIL, match.getEmail());
       }
 
       if (Boolean.TRUE.equals(match.getGroup())) {
-        matchElementBuilder.setBooleanAttribute(MailConstants.A_EXP, match.getCanExpandGroupMembers(), Boolean.FALSE);
+        matchElementBuilder.addBooleanAttribute(MailConstants.A_EXP, match.getCanExpandGroupMembers(), Boolean.FALSE);
       }
 
-      matchElementBuilder.setStringAttribute(MailConstants.A_ID, match.getId(), null)
-          .setStringAttribute(MailConstants.A_FOLDER, match.getFolder(), null);
+      matchElementBuilder.addStringAttribute(MailConstants.A_ID, match.getId())
+          .addStringAttribute(MailConstants.A_FOLDER, match.getFolder());
 
       if (Boolean.TRUE.equals(match.getGroup()) || !Objects.equals(match.getMatchType(),
           ContactEntryType.GAL.getName())) {
-        matchElementBuilder.setStringAttribute(MailConstants.A_DISPLAYNAME, match.getDisplayName(), null);
+        matchElementBuilder.addStringAttribute(MailConstants.A_DISPLAYNAME, match.getDisplayName());
       }
 
-      matchElementBuilder.setStringAttribute(MailConstants.A_FIRSTNAME, match.getFirstName(), null)
-          .setStringAttribute(MailConstants.A_MIDDLENAME, match.getMiddleName(), null)
-          .setStringAttribute(MailConstants.A_LASTNAME, match.getLastName(), null)
-          .setStringAttribute(MailConstants.A_FULLNAME, match.getFullName(), null)
-          .setStringAttribute(MailConstants.A_NICKNAME, match.getNickname(), null)
-          .setStringAttribute(MailConstants.A_COMPANY, match.getCompany(), null)
-          .setStringAttribute(MailConstants.A_FILEAS, match.getFileAs(), null);
+      matchElementBuilder.addStringAttribute(MailConstants.A_FIRSTNAME, match.getFirstName())
+          .addStringAttribute(MailConstants.A_MIDDLENAME, match.getMiddleName())
+          .addStringAttribute(MailConstants.A_LASTNAME, match.getLastName())
+          .addStringAttribute(MailConstants.A_FULLNAME, match.getFullName())
+          .addStringAttribute(MailConstants.A_NICKNAME, match.getNickname())
+          .addStringAttribute(MailConstants.A_COMPANY, match.getCompany())
+          .addStringAttribute(MailConstants.A_FILEAS, match.getFileAs());
 
       return matchElementBuilder.build();
     }).collect(Collectors.toCollection(ArrayList::new));
@@ -233,7 +233,12 @@ public class FullAutoComplete extends MailDocumentHandler {
       this.element = zsc.createElement(MailConstants.E_MATCH);
     }
 
-    public AutoCompleteMatchElementBuilder setStringAttribute(String name, String value, String defaultValue) {
+    public AutoCompleteMatchElementBuilder addStringAttribute(String name, String value) {
+      addStringAttributeWithDefault(name, value, null);
+      return this;
+    }
+
+    public AutoCompleteMatchElementBuilder addStringAttributeWithDefault(String name, String value, String defaultValue) {
       if (value != null) {
         element.addAttribute(name, value);
       } else if (defaultValue != null) {
@@ -242,7 +247,7 @@ public class FullAutoComplete extends MailDocumentHandler {
       return this;
     }
 
-    public AutoCompleteMatchElementBuilder setBooleanAttribute(String name, Boolean value, Boolean defaultValue) {
+    public AutoCompleteMatchElementBuilder addBooleanAttribute(String name, Boolean value, Boolean defaultValue) {
       if (value != null) {
         element.addAttribute(name, value);
       } else if (defaultValue != null) {
@@ -251,7 +256,7 @@ public class FullAutoComplete extends MailDocumentHandler {
       return this;
     }
 
-    public AutoCompleteMatchElementBuilder setIntegerAttribute(String name, Integer value, Integer defaultValue) {
+    public AutoCompleteMatchElementBuilder addIntegerAttribute(String name, Integer value, Integer defaultValue) {
       if (value != null) {
         element.addAttribute(name, value);
       } else if (defaultValue != null) {

--- a/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FullAutoComplete.java
@@ -34,6 +34,17 @@ import java.util.stream.Collectors;
  */
 public class FullAutoComplete extends MailDocumentHandler {
 
+  /**
+   * Helper method that returns if the {@link AutoCompleteMatch} is a Contact group
+   *
+   * @return true if the {@link AutoCompleteMatch} is a Contact group false otherwise
+   */
+  private static Boolean isContactGroup(AutoCompleteMatch match) {
+    return match != null
+        && Boolean.TRUE.equals(match.getGroup())
+        && ContactEntryType.CONTACT.name().equalsIgnoreCase(match.getMatchType());
+  }
+
   @Override
   public Element handle(Element request, Map<String, Object> context) throws ServiceException {
     final var zsc = getZimbraSoapContext(context);
@@ -124,7 +135,7 @@ public class FullAutoComplete extends MailDocumentHandler {
           .addStringAttribute(MailConstants.A_MATCH_TYPE, match.getMatchType())
           .addBooleanAttribute(MailConstants.A_IS_GROUP, match.getGroup(), Boolean.FALSE);
 
-      if (Boolean.FALSE.equals(match.getGroup())) {
+      if (Boolean.FALSE.equals(isContactGroup(match))) {
         matchElementBuilder.addStringAttribute(MailConstants.A_EMAIL, match.getEmail());
       }
 
@@ -238,7 +249,8 @@ public class FullAutoComplete extends MailDocumentHandler {
       return this;
     }
 
-    public AutoCompleteMatchElementBuilder addStringAttributeWithDefault(String name, String value, String defaultValue) {
+    public AutoCompleteMatchElementBuilder addStringAttributeWithDefault(String name, String value,
+        String defaultValue) {
       if (value != null) {
         element.addAttribute(name, value);
       } else if (defaultValue != null) {

--- a/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
@@ -6,8 +6,11 @@ package com.zimbra.cs.service.mail;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.zextras.mailbox.soap.SoapTestSuite;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountAction;
@@ -25,6 +28,7 @@ import com.zimbra.cs.mailbox.ContactRankings;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.OperationContext;
+import com.zimbra.cs.service.mail.FullAutoComplete.AutoCompleteMatchElementBuilder;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.mail.message.AutoCompleteRequest;
 import com.zimbra.soap.mail.message.CreateContactRequest;
@@ -341,6 +345,45 @@ class FullAutoCompleteTest extends SoapTestSuite {
   }
 
   @Test
+  void should_return_matches_from_other_accounts_when_requested_account_not_found()
+      throws Exception {
+    String searchTerm = "fac";
+    String domain = UUID.randomUUID() + "something.com";
+
+    String contactEmail1 = searchTerm + "_email1@" + domain;
+    String contactEmail2 = searchTerm + "_email2@" + domain;
+    String contactEmail3 = searchTerm + "_email3@" + domain;
+    String contactEmail4 = searchTerm + "_email4@" + domain;
+
+    Account account = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
+    Account account2 = createRandomAccountWithContacts(contactEmail1, contactEmail2, contactEmail3, contactEmail4);
+
+    shareAccountWithPrimary(account2, account);
+
+    incrementRankings(account2, contactEmail1, 2);
+    incrementRankings(account2, contactEmail3, 2);
+
+    // create preferred account and delete it to simulate the corner case
+    var preferredAccount = createRandomAccountWithContacts();
+    Provisioning.getInstance().deleteAccount(preferredAccount.getId());
+
+    var orderedAccounts = new ArrayList<Account>();
+    orderedAccounts.add(preferredAccount);
+    orderedAccounts.add(account2);
+    var fullAutocompleteResponse = performFullAutocompleteRequest(searchTerm, account, orderedAccounts);
+
+    assertEquals(4, fullAutocompleteResponse.getMatches().size());
+    List<Integer> expectedRanking = List.of(2, 2, 0, 0, 2, 0, 0);
+    List<String> expectedMatchedEmailAddresses = Arrays.asList(contactEmail1, contactEmail3, contactEmail2,
+        contactEmail4);
+    for (int i = 0; i < fullAutocompleteResponse.getMatches().size(); i++) {
+      AutoCompleteMatch autoCompleteMatch = fullAutocompleteResponse.getMatches().get(i);
+      assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
+      assertEquals("<" + expectedMatchedEmailAddresses.get(i) + ">", autoCompleteMatch.getEmail());
+    }
+  }
+
+  @Test
   void should_return_contact_group_when_matches() throws Exception {
     String searchTerm = "my";
     String domain = UUID.randomUUID() + "something.com";
@@ -381,6 +424,73 @@ class FullAutoCompleteTest extends SoapTestSuite {
       }
       assertEquals(expectedRanking.get(i), autoCompleteMatch.getRanking());
     }
+  }
+
+  @Test
+  void autoCompleteMatchElementBuilder_should_omit_attributes_if_passed_values_are_null() throws Exception {
+    var searchTerm = "my";
+    var domain = UUID.randomUUID() + "something.com";
+    var contactEmail1 = searchTerm + "email1@" + domain;
+
+    var account = createRandomAccountWithContacts(contactEmail1);
+    var zsc = MailDocumentHandler.getZimbraSoapContext(ServiceTestUtil.getRequestContext(account));
+
+    var autoCompleteMatch = new AutoCompleteMatch();
+    autoCompleteMatch.setRanking(10);
+    autoCompleteMatch.setCompany("HellYeahInc");
+
+    var matchElementBuilder = new AutoCompleteMatchElementBuilder(zsc);
+    matchElementBuilder.setIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 0);
+    matchElementBuilder.setStringAttribute(MailConstants.A_COMPANY, autoCompleteMatch.getCompany(), null);
+    matchElementBuilder.setBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.FALSE);
+
+    matchElementBuilder.setStringAttribute(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), null);
+    matchElementBuilder.setBooleanAttribute(MailConstants.A_EXP, autoCompleteMatch.getCanExpandGroupMembers(), null);
+
+    var matchElement = matchElementBuilder.build();
+
+    assertEquals("<match ranking=\"10\" company=\"HellYeahInc\" isGroup=\"0\"/>", matchElement.toString(),
+        "if the passed values (value and default value) are null, the attribute should be omitted");
+  }
+
+  @Test
+  void autoCompleteMatchElementBuilder_should_add_attributes_with_defaultValues_if_passed_values_are_null()
+      throws Exception {
+    var searchTerm = "my";
+    var domain = UUID.randomUUID() + "something.com";
+    var contactEmail1 = searchTerm + "email1@" + domain;
+
+    var account = createRandomAccountWithContacts(contactEmail1);
+    var zsc = MailDocumentHandler.getZimbraSoapContext(ServiceTestUtil.getRequestContext(account));
+
+    var autoCompleteMatch = new AutoCompleteMatch();
+    var matchElementBuilder = new AutoCompleteMatchElementBuilder(zsc);
+
+    matchElementBuilder.setIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 20);
+    matchElementBuilder.setBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.TRUE);
+    matchElementBuilder.setStringAttribute(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), "myLastName");
+
+    var matchElement2 = matchElementBuilder.build();
+
+    assertEquals("<match last=\"myLastName\" ranking=\"20\" isGroup=\"1\"/>",
+        matchElement2.toString(),
+        "if the passed value is null and defaultValue is valid, the attribute should be added with the defaultValue passed");
+  }
+
+  @Test
+  void should_throw_exception_when_request_element_cannot_be_converted_to_fac_request_object() throws Exception {
+    var account = accountCreatorFactory.get().create();
+
+    var mockElement = mock(Element.class);
+    when(JaxbUtil.elementToJaxb(mockElement)).thenReturn(null);
+
+    var fullAutoComplete = Mockito.spy(FullAutoComplete.class);
+    var requestContext = ServiceTestUtil.getRequestContext(account);
+
+    var serviceException = assertThrows(ServiceException.class,
+        () -> fullAutoComplete.handle(mockElement, requestContext));
+
+    assertEquals(ServiceException.FAILURE, serviceException.getCode());
   }
 
   @ParameterizedTest

--- a/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/FullAutoCompleteTest.java
@@ -427,7 +427,7 @@ class FullAutoCompleteTest extends SoapTestSuite {
   }
 
   @Test
-  void autoCompleteMatchElementBuilder_should_omit_attributes_if_passed_values_are_null() throws Exception {
+  void autoCompleteMatchElementBuilder_should_omit_attributes_if_passed_value_and_default_are_null() throws Exception {
     var searchTerm = "my";
     var domain = UUID.randomUUID() + "something.com";
     var contactEmail1 = searchTerm + "email1@" + domain;
@@ -440,12 +440,12 @@ class FullAutoCompleteTest extends SoapTestSuite {
     autoCompleteMatch.setCompany("HellYeahInc");
 
     var matchElementBuilder = new AutoCompleteMatchElementBuilder(zsc);
-    matchElementBuilder.setIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 0);
-    matchElementBuilder.setStringAttribute(MailConstants.A_COMPANY, autoCompleteMatch.getCompany(), null);
-    matchElementBuilder.setBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.FALSE);
+    matchElementBuilder.addIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 0);
+    matchElementBuilder.addStringAttributeWithDefault(MailConstants.A_COMPANY, autoCompleteMatch.getCompany(), null);
+    matchElementBuilder.addBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.FALSE);
 
-    matchElementBuilder.setStringAttribute(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), null);
-    matchElementBuilder.setBooleanAttribute(MailConstants.A_EXP, autoCompleteMatch.getCanExpandGroupMembers(), null);
+    matchElementBuilder.addStringAttributeWithDefault(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), null);
+    matchElementBuilder.addBooleanAttribute(MailConstants.A_EXP, autoCompleteMatch.getCanExpandGroupMembers(), null);
 
     var matchElement = matchElementBuilder.build();
 
@@ -466,9 +466,9 @@ class FullAutoCompleteTest extends SoapTestSuite {
     var autoCompleteMatch = new AutoCompleteMatch();
     var matchElementBuilder = new AutoCompleteMatchElementBuilder(zsc);
 
-    matchElementBuilder.setIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 20);
-    matchElementBuilder.setBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.TRUE);
-    matchElementBuilder.setStringAttribute(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), "myLastName");
+    matchElementBuilder.addIntegerAttribute(MailConstants.A_RANKING, autoCompleteMatch.getRanking(), 20);
+    matchElementBuilder.addBooleanAttribute(MailConstants.A_IS_GROUP, autoCompleteMatch.getGroup(), Boolean.TRUE);
+    matchElementBuilder.addStringAttributeWithDefault(MailConstants.A_LASTNAME, autoCompleteMatch.getLastName(), "myLastName");
 
     var matchElement2 = matchElementBuilder.build();
 


### PR DESCRIPTION
**What's changed:**
- add a type-safe builder class `AutoCompleteMatchElementBuilder` to ensure null-safe handling when serializing `AutoCompleteMatch` back to the `Element` class. This prevents NullPointerExceptions (NPEs) in specific types of autocomplete matches, such as Distribution list (GalGroup Match type), which may have some fields uninitialized (null).
- enhanced API resilience: FAC API now returns matches from "other preferred accounts" if the passed "preferred account" does not exist, instead of failing.