### PR TITLE
chore: use new and builtin argon2 module included in 2.5.x

### DIFF
--- a/store/ldap/conf/ldap/config/cn=config/cn=module{0}.ldif
+++ b/store/ldap/conf/ldap/config/cn=config/cn=module{0}.ldif
@@ -10,7 +10,7 @@ olcModuleLoad: {4}dynlist.la
 olcModuleLoad: {5}unique.la
 olcModuleLoad: {6}noopsrch.la
 olcModuleLoad: {7}pw-sha2.la
-olcModuleLoad: {8}pw-argon2.la
+olcModuleLoad: {8}argon2
 structuralObjectClass: olcModuleList
 entryUUID: 1525c980-333e-102d-86f6-d562901af228
 creatorsName: cn=config


### PR DESCRIPTION
Seems that adding migrate file is not enough. So I replace the .la module entry directly within ldif file. Let me know if it's a good approach. I don't know ldap technicatlities

Same stuff for carbonio-advanced-lib occurrance
https://github.com/zextras/carbonio-advanced-lib/pull/119