### PR TITLE
fix: [CO-1239] always notify attendees when appointment is updated

### DIFF
--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -166,6 +166,7 @@ public final class MailConstants {
   public static final String E_CREATE_APPOINTMENT_EXCEPTION_REQUEST =
       "CreateAppointmentExceptionRequest";
   public static final String E_MODIFY_APPOINTMENT_REQUEST = "ModifyAppointmentRequest";
+  public static final String E_MODIFY_APPOINTMENT_RESPONSE = "ModifyAppointmentResponse";
   public static final String E_CANCEL_APPOINTMENT_REQUEST = "CancelAppointmentRequest";
   public static final String E_FORWARD_APPOINTMENT_REQUEST = "ForwardAppointmentRequest";
   public static final String E_FORWARD_APPOINTMENT_INVITE_REQUEST =

--- a/soap/src/main/java/com/zimbra/soap/mail/type/EmailAddrInfo.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/EmailAddrInfo.java
@@ -51,6 +51,11 @@ public class EmailAddrInfo {
         this.address = address;
     }
 
+    public EmailAddrInfo(String address, String type) {
+        this.address = address;
+        this.addressType = type;
+    }
+
     public static EmailAddrInfo createForAddressPersonalAndAddressType(String address,
             String personalName, String addressType) {
         final EmailAddrInfo eai = new EmailAddrInfo(address);

--- a/store/src/test/java/com/zextras/mailbox/soap/SoapUtils.java
+++ b/store/src/test/java/com/zextras/mailbox/soap/SoapUtils.java
@@ -4,11 +4,25 @@
 
 package com.zextras.mailbox.soap;
 
+import com.zimbra.common.soap.Element;
+import com.zimbra.soap.JaxbUtil;
 import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
 
 public class SoapUtils {
 
   public static String getResponse(HttpResponse response) throws Exception {
-    return new String (response.getEntity().getContent().readAllBytes());
+    return EntityUtils.toString(response.getEntity());
+  }
+
+  public static <T> T getSoapResponse(HttpResponse response, String bodyKey, Class<T> expected) throws Exception {
+    final String soapResponse = getResponse(response);
+    return JaxbUtil.elementToJaxb(Element.parseXML(soapResponse).getElement("Body").getElement(
+        bodyKey), expected);
+  }
+
+  public static <T> T getSoapResponse(String response, String bodyKey, Class<T> expected) throws Exception {
+    return JaxbUtil.elementToJaxb(Element.parseXML(response).getElement("Body").getElement(
+        bodyKey), expected);
   }
 }

--- a/store/src/test/java/com/zextras/mailbox/soap/utils/CreateMountpoint.java
+++ b/store/src/test/java/com/zextras/mailbox/soap/utils/CreateMountpoint.java
@@ -1,0 +1,26 @@
+package com.zextras.mailbox.soap.utils;
+
+import com.zimbra.cs.account.Account;
+import com.zimbra.soap.mail.message.CreateMountpointRequest;
+import com.zimbra.soap.mail.type.NewMountpointSpec;
+
+public class CreateMountpoint {
+
+  private final Account owner;
+  private final Integer remoteId;
+
+  public CreateMountpoint(Account owner, Integer remoteId) {
+    this.owner = owner;
+    this.remoteId = remoteId;
+  }
+
+  public CreateMountpointRequest createCalendarMountpoint() {
+    final NewMountpointSpec newMountpointSpec = new NewMountpointSpec("test shared calendar");
+    newMountpointSpec.setDefaultView("appointment");
+    newMountpointSpec.setRemoteId(remoteId);
+    newMountpointSpec.setOwnerId(owner.getId());
+    newMountpointSpec.setFolderId("1");
+    return new CreateMountpointRequest(newMountpointSpec);
+  }
+
+}

--- a/store/src/test/java/com/zimbra/cs/service/mail/ModifyAppointmentApiTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/ModifyAppointmentApiTest.java
@@ -39,10 +39,9 @@ import javax.mail.internet.MimeMessage;
 import org.apache.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ModifyCalendarItemApiTest extends SoapTestSuite {
+class ModifyAppointmentApiTest extends SoapTestSuite {
 
   private static MailboxManager mailboxManager;
   private static AccountCreator.Factory accountCreatorFactory;

--- a/store/src/test/java/com/zimbra/cs/service/mail/ModifyAppointmentApiTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/ModifyAppointmentApiTest.java
@@ -35,12 +35,13 @@ import com.zimbra.soap.mail.type.Msg;
 import com.zimbra.soap.mail.type.NewMountpointSpec;
 import com.zimbra.soap.type.Id;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import javax.mail.Address;
 import javax.mail.internet.MimeMessage;
 import org.apache.http.HttpResponse;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -162,9 +163,8 @@ class ModifyAppointmentApiTest extends SoapTestSuite {
   }
 
   private static String nextWeek() {
-    final int secondsInAWeek = 7 * 24 * 60 * 60;
-    final long startDateMillis = (Instant.now().getEpochSecond() + secondsInAWeek)*1000;
-    return new DateTime(startDateMillis).toString("YMMdd") + "T120000";
+    final LocalDateTime now = LocalDateTime.now();
+    return now.plusDays(7L).format(DateTimeFormatter.ofPattern("yMMdd"));
   }
 
   private ModifyAppointmentResponse modifyAppointment(String appointmentId, Account authenticatedAccount, Msg msg)

--- a/store/src/test/java/com/zimbra/cs/service/mail/ModifyCalendarItemApiTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/ModifyCalendarItemApiTest.java
@@ -1,0 +1,233 @@
+package com.zimbra.cs.service.mail;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.zextras.mailbox.soap.SoapTestSuite;
+import com.zextras.mailbox.soap.SoapUtils;
+import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.index.SortBy;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailclient.smtp.SmtpConfig;
+import com.zimbra.soap.mail.message.CreateAppointmentRequest;
+import com.zimbra.soap.mail.message.CreateAppointmentResponse;
+import com.zimbra.soap.mail.message.CreateMountpointRequest;
+import com.zimbra.soap.mail.message.CreateMountpointResponse;
+import com.zimbra.soap.mail.message.FolderActionRequest;
+import com.zimbra.soap.mail.message.ModifyAppointmentRequest;
+import com.zimbra.soap.mail.message.SendShareNotificationRequest;
+import com.zimbra.soap.mail.type.ActionGrantSelector;
+import com.zimbra.soap.mail.type.CalOrganizer;
+import com.zimbra.soap.mail.type.CalendarAttendee;
+import com.zimbra.soap.mail.type.DtTimeInfo;
+import com.zimbra.soap.mail.type.EmailAddrInfo;
+import com.zimbra.soap.mail.type.FolderActionSelector;
+import com.zimbra.soap.mail.type.InvitationInfo;
+import com.zimbra.soap.mail.type.Msg;
+import com.zimbra.soap.mail.type.NewMountpointSpec;
+import com.zimbra.soap.type.Id;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+import org.apache.http.HttpResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ModifyCalendarItemApiTest extends SoapTestSuite {
+
+  private static MailboxManager mailboxManager;
+  private static AccountCreator.Factory accountCreatorFactory;
+  private static GreenMail greenMail;
+
+  @BeforeAll
+  static void setUpClass() throws Exception {
+    greenMail =
+        new GreenMail(
+            new ServerSetup[] {
+                new ServerSetup(
+                    SmtpConfig.DEFAULT_PORT, SmtpConfig.DEFAULT_HOST, ServerSetup.PROTOCOL_SMTP)
+            });
+    greenMail.start();
+    Provisioning provisioning = Provisioning.getInstance();
+    mailboxManager = MailboxManager.getInstance();
+    accountCreatorFactory = new AccountCreator.Factory(provisioning);
+  }
+
+  @Test
+  void shouldNotifyAllAttendees_WhenUpdatingAppointment_OnASharedCalendar() throws Exception {
+    final Account userA = accountCreatorFactory.get().withUsername("userA").create();
+    final Account userB = accountCreatorFactory.get().withUsername("userB").create();
+    final String userC = "userC@test.com";
+
+    final Folder calendarToShare = getCalendarToShare(userA);
+    shareCalendar(userA, userB, calendarToShare);
+    Assertions.assertEquals(1, greenMail.getReceivedMessages().length);
+    greenMail.reset();
+
+    final CreateMountpointResponse mountpointResponse = createMountpointForSharedCalendar(
+        userA, userB, calendarToShare);
+
+    final Msg msgWithInvitation = createMsgOnSharedCalendar(mountpointResponse, userA, userB,
+        List.of(userC));
+
+    final CreateAppointmentResponse appointment = createAppointment(userB, msgWithInvitation);
+    Assertions.assertEquals(1, greenMail.getReceivedMessages().length);
+    final MimeMessage receivedMessage = greenMail.getReceivedMessages()[0];
+    final Address[] allRecipients = receivedMessage.getAllRecipients();
+    Assertions.assertEquals(1, allRecipients.length);
+    Assertions.assertEquals(userC, allRecipients[0].toString());
+    greenMail.reset();
+
+    msgWithInvitation.setSubject("Modified subject");
+    final String calInvId = appointment.getCalInvId();
+    final String[] userIdAndInviteId = calInvId.split(":");
+    Assertions.assertEquals(userA.getId(), userIdAndInviteId[0]);
+    modifyAppointment(calInvId, userB, msgWithInvitation);
+    Assertions.assertEquals(1, greenMail.getReceivedMessages().length);
+    Assertions.assertEquals(1, allRecipients.length);
+    Assertions.assertEquals(userC, allRecipients[0].toString());
+    greenMail.reset();
+  }
+
+  private CreateMountpointResponse createMountpointForSharedCalendar(Account userA, Account userB, Folder calendarToShare)
+      throws Exception {
+    final NewMountpointSpec newMountpointSpec = new NewMountpointSpec("test shared calendar");
+    newMountpointSpec.setDefaultView("appointment");
+    newMountpointSpec.setRemoteId(calendarToShare.getId());
+    newMountpointSpec.setOwnerId(userA.getId());
+    newMountpointSpec.setFolderId("1");
+    CreateMountpointRequest createMountpointRequest = new CreateMountpointRequest(newMountpointSpec);
+    final HttpResponse response = getSoapClient().executeSoap(userB,
+        createMountpointRequest);
+    Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+    return SoapUtils.getSoapResponse(response, MailConstants.E_CREATE_MOUNTPOINT_RESPONSE,
+        CreateMountpointResponse.class);
+  }
+
+  private CreateAppointmentResponse createAppointment(Account authenticatedAccount, Msg msg)
+      throws Exception {
+    final CreateAppointmentRequest createAppointmentRequest = new CreateAppointmentRequest();
+    createAppointmentRequest.setMsg(msg);
+    final HttpResponse response = getSoapClient().executeSoap(authenticatedAccount,
+        createAppointmentRequest);
+    String soapResponse = SoapUtils.getResponse(response);
+    Assertions.assertEquals(200, response.getStatusLine().getStatusCode(), "Create appointment failed with:\n" + soapResponse);
+    return SoapUtils.getSoapResponse(soapResponse, MailConstants.E_CREATE_APPOINTMENT_RESPONSE,
+        CreateAppointmentResponse.class);
+  }
+
+  private Msg createMsgOnSharedCalendar(CreateMountpointResponse mountpointResponse, Account userA, Account userB, List<String> attendees) {
+    Msg msg = new Msg();
+    InvitationInfo invitationInfo = new InvitationInfo();
+
+    final List<CalendarAttendee> calendarAttendees = populateCalendarAttendees(
+        attendees);
+    invitationInfo.setAttendees(calendarAttendees);
+    final CalOrganizer calOrganizer = new CalOrganizer();
+    calOrganizer.setAddress(userA.getName());
+    calOrganizer.setSentBy(userB.getName());
+    invitationInfo.setOrganizer(calOrganizer);
+    final long nowMillis = Instant.now().toEpochMilli();
+    invitationInfo.setDateTime(nowMillis);
+    invitationInfo.setDtStart(new DtTimeInfo("20250702T120000"));
+    final List<EmailAddrInfo> emailAddrInfos = sendAppointmentTo(attendees);
+
+    final EmailAddrInfo from = new EmailAddrInfo(userA.getName());
+    from.setAddressType("f");
+    emailAddrInfos.add(from);
+    final EmailAddrInfo emailAddrInfo = new EmailAddrInfo(userB.getName());
+    emailAddrInfo.setAddressType("s");
+    emailAddrInfos.add(emailAddrInfo);
+
+    msg.setEmailAddresses(emailAddrInfos);
+    msg.setInvite(invitationInfo);
+    msg.setFolderId(String.valueOf(mountpointResponse.getMount().getId()));
+    msg.setSubject("Test appointment");
+    return msg;
+  }
+
+  private static List<CalendarAttendee> populateCalendarAttendees(List<String> attendees) {
+    final List<CalendarAttendee> calendarAttendees = new ArrayList<>();
+    for (String address : attendees) {
+      final CalendarAttendee calendarAttendee = new CalendarAttendee();
+      calendarAttendee.setAddress(address);
+      calendarAttendee.setDisplayName(address);
+      calendarAttendee.setRsvp(true);
+      calendarAttendee.setRole("REQ");
+      calendarAttendees.add(calendarAttendee);
+    }
+    return calendarAttendees;
+  }
+
+  private static List<EmailAddrInfo> sendAppointmentTo(List<String> attendees) {
+    final List<EmailAddrInfo> emailAddrInfos = new ArrayList<>();
+    for (String address : attendees) {
+      final EmailAddrInfo emailTo = new EmailAddrInfo(address);
+      emailTo.setAddressType("t");
+      emailAddrInfos.add(emailTo);
+    }
+    return emailAddrInfos;
+  }
+
+  private void modifyAppointment(String appointmentId, Account authenticatedAccount, Msg msg)
+      throws Exception {
+    final ModifyAppointmentRequest modifyAppointmentRequest = new ModifyAppointmentRequest();
+    modifyAppointmentRequest.setId(appointmentId);
+    modifyAppointmentRequest.setMsg(msg);
+
+    final HttpResponse response = getSoapClient().executeSoap(authenticatedAccount,
+        modifyAppointmentRequest);
+    final String soapResponse = SoapUtils.getResponse(response);
+    Assertions.assertEquals(200, response.getStatusLine().getStatusCode(), "ModifyAppointment failed with: \n" + soapResponse);
+  }
+
+  private void shareCalendar(Account authenticatedAccount, Account sharedAccount, Folder calendar)
+      throws Exception {
+
+    shareFolderAsManager(authenticatedAccount, sharedAccount, calendar.getFolderId());
+    final SendShareNotificationRequest shareNotificationRequest = new SendShareNotificationRequest();
+    shareNotificationRequest.setItem(new Id(calendar.getId()));
+    shareNotificationRequest.setEmailAddresses(new ArrayList<>() {{
+      add(new EmailAddrInfo(
+          sharedAccount.getName()));
+    }});
+
+    final HttpResponse response = getSoapClient().executeSoap(authenticatedAccount,
+        shareNotificationRequest);
+    Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  private void shareFolderAsManager(Account authenticatedAccount, Account sharedAccount, int folderId)
+      throws Exception {
+    final FolderActionSelector grantRequest = new FolderActionSelector( String.valueOf(folderId), "grant");
+    final ActionGrantSelector grant = new ActionGrantSelector("rwidx", "usr");
+    grant.setDisplayName(sharedAccount.getName());
+    grant.setPassword("");
+    grantRequest.setGrant(grant);
+    final FolderActionRequest folderActionRequest = new FolderActionRequest(grantRequest);
+
+    final HttpResponse response = getSoapClient().executeSoap(authenticatedAccount,
+        folderActionRequest);
+    Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  private static Folder getCalendarToShare(Account user) throws ServiceException {
+    final List<Folder> calendarFolders = getAllCalendars(
+        user);
+    return calendarFolders.get(0);
+  }
+
+  private static List<Folder> getAllCalendars(Account authenticatedAccount) throws ServiceException {
+    final Mailbox mailbox = mailboxManager.getMailboxByAccount(authenticatedAccount);
+    return mailbox.getCalendarFolders(null, SortBy.DATE_DESC);
+  }
+}


### PR DESCRIPTION
This bug causes the attendees to not be notified whenever an appointment is updated on a shared calendar.

That are some inner logics that caused this behavior, like trying to detect if the inviteId and the folderId (calendar id) are on the requested mailbox.
However when working on a shared calendar, by referencing a mountpoint, the mailbox proxies the call to the mailbox of the User's shared calendar and fails to correctly identify the folderId is on the correct mailbox. This causes the variable interMboxMove to be updated and in the end the notification is not sent.

Instead of updating the interMboxMove variable we decided to always notify whenever an appointment changes (this design was shared internally)