### PR TITLE
fix: [CO-1358] Migrate the slapd PID file location to new one

### DIFF
--- a/packages/directory-server/PKGBUILD
+++ b/packages/directory-server/PKGBUILD
@@ -57,6 +57,8 @@ package() {
     "${pkgdir}/opt/zextras/libexec/scripts/migrate20230217-AddArgon2.pl"
   install -D store/ldap/src/migrations/migrate-23.5.0-01-COS-AddFeatures.pl \
     "${pkgdir}/opt/zextras/libexec/scripts/migrate-23.5.0-01-COS-AddFeatures.pl"
+  install -D store/ldap/src/migrations/migrate20240716-UpdatePidFilePath.pl \
+    "${pkgdir}/opt/zextras/libexec/scripts/migrate20240716-UpdatePidFilePath.pl"
 
   install -Ddm755 store/ldap/generated/ \
     "${pkgdir}/opt/zextras/common/etc/openldap/zimbra/"
@@ -85,6 +87,10 @@ postinst__apt() {
 
   if [ "$1" = "configure" ] && [ ! -z "$2" ]; then
     echo "*Starting LDAP upgrade..."
+    # this script will start LDAP to perform migration
+    su - zextras -c "/opt/zextras/libexec/scripts/migrate20240716-UpdatePidFilePath.pl"
+    # we need to stop LDAP to make sure the schema changes are loaded on next start this
+    # ensures zmldapupdateldif and ldapattributeupdate work
     su - zextras -c "/opt/zextras/bin/ldap stop"
     su - zextras -c "/opt/zextras/libexec/zmldapschema 2>/dev/null"
     su - zextras -c "/opt/zextras/libexec/zmldapupdateldif"
@@ -103,6 +109,10 @@ postinst__rocky_8() {
 
   if [ "$1" -eq 2 ]; then
     echo "*Starting LDAP upgrade..."
+    # this script will start LDAP to perform migration
+    su - zextras -c "/opt/zextras/libexec/scripts/migrate20240716-UpdatePidFilePath.pl"
+    # we need to stop LDAP to make sure the schema changes are loaded on next start this
+    # ensures zmldapupdateldif and ldapattributeupdate work
     su - zextras -c "/opt/zextras/bin/ldap stop"
     su - zextras -c "/opt/zextras/libexec/zmldapschema 2>/dev/null"
     su - zextras -c "/opt/zextras/libexec/zmldapupdateldif"
@@ -128,6 +138,11 @@ postinst__rocky_9() {
 
   if [ "$1" -eq 2 ]; then
     echo "* Starting LDAP upgrade..."
+    # this script will start LDAP to perform migration
+    su - zextras -c "/opt/zextras/libexec/scripts/migrate20240716-UpdatePidFilePath.pl"
+    # we need to stop LDAP to make sure the schema changes are loaded on next start this
+    # ensures zmldapupdateldif and ldapattributeupdate work
+    su - zextras -c "/opt/zextras/bin/ldap stop"
     su - zextras -c "/opt/zextras/libexec/zmldapschema 2>/dev/null"
     # zmldapupdateldif restart slapd out of systemdd domain...
     su - zextras -c "/opt/zextras/libexec/zmldapupdateldif"

--- a/store/ldap/src/migrations/migrate20240716-UpdatePidFilePath.pl
+++ b/store/ldap/src/migrations/migrate20240716-UpdatePidFilePath.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+use strict;
+use lib '/opt/zextras/common/lib/perl5';
+use Net::LDAP;
+use XML::Simple;
+
+if ( ! -d "/opt/zextras/common/etc/openldap/schema" ) {
+  print STDERR "ERROR: openldap does not appear to be installed - exiting\n";
+  exit(1);
+}
+
+my $id = getpwuid($<);
+chomp $id;
+if ($id ne "zextras") {
+    print STDERR "Error: must be run as zextras user\n";
+    exit (1);
+}
+
+my $ldap_status = qx(/opt/zextras/bin/ldap status);
+if ($ldap_status =~ /slapd running pid/) {
+    print "LDAP is already running.\n";
+} else {
+    my $rc = qx(/opt/zextras/bin/ldap start);
+    if ($? != 0) {
+        die "Failed to start LDAP, Exit status:" . ($? >> 8) . "\n";
+    }
+    print "LDAP started successfully.\n";
+}
+
+print "* Start applying 'olcPidFile' path migration..\n";
+my $localxml = XMLin("/opt/zextras/conf/localconfig.xml");
+my $ldap_root_password = $localxml->{key}->{ldap_root_password}->{value};
+chomp($ldap_root_password);
+
+my @known_ldap_socket_paths = (
+    'ldapi://%2frun%2fcarbonio%2frun%2fldapi/',
+    'ldapi://%2fopt%2fzextras%2fdata%2fldap%2fstate%2frun%2fldapi/'
+);
+
+my $ldap;
+
+foreach my $ldap_socket (@known_ldap_socket_paths) {
+    $ldap = Net::LDAP->new($ldap_socket);
+    last if $ldap;
+}
+
+unless ($ldap) {
+    die "Failed to connect to LDAP server using any of the provided LDPAI socket paths.";
+}
+
+my $mesg = $ldap->bind("cn=config", password=>"$ldap_root_password");
+
+$mesg->code && die "Bind: ". $mesg->error . "\n";
+
+my $dn = "cn=config";
+$mesg = $ldap->modify(
+    $dn,
+    replace => { olcPidFile => '/run/carbonio/slapd.pid' },
+);
+
+$mesg->code && die "Modify: ". $mesg->error . "\n";
+
+$ldap->unbind;
+
+my $rc = qx(/opt/zextras/bin/ldap restart);
+if ($? != 0) {
+    die "Failed to restart LDAP, Exit status:" . ($? >> 8) . "\n";
+}
+print "* Migration applied successfully.\n";


### PR DESCRIPTION
**What has changed:**
- add `migrate20240716-UpdatePidFilePath.pl` migration script to apply migration in carbonio-directory-server postinstall upgrade hook.
   - script migrates LDAP `olcPidFile` in conf database to `/run/carbonio/slapd.pid` from `/opt/zextras/data/ldap/state/run/slapd.pid`