### PR TITLE
Revert "refactor: remove mailboxd_directory (#549)"

### DIFF
--- a/common/src/main/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/main/java/com/zimbra/common/localconfig/LC.java
@@ -117,6 +117,14 @@ public final class LC {
   public static final KnownKey localized_msgs_directory =
       KnownKey.newKey("${zimbra_home}/conf/msgs");
 
+  @Supported
+  public static final KnownKey localized_client_msgs_directory =
+      KnownKey.newKey("${mailboxd_directory}/webapps/zimbraAdmin/WEB-INF/classes/messages");
+
+  @Supported
+  public static final KnownKey skins_directory =
+      KnownKey.newKey("${mailboxd_directory}/webapps/zimbra/skins");
+
   public static final KnownKey zimbra_disk_cache_servlet_flush = KnownKey.newKey(true);
   public static final KnownKey zimbra_disk_cache_servlet_size = KnownKey.newKey(1000);
 
@@ -466,7 +474,9 @@ public final class LC {
   public static final KnownKey sqlite_page_size = KnownKey.newKey(4096);
   public static final KnownKey sqlite_sync_mode = KnownKey.newKey("NORMAL");
 
-  public static final KnownKey create_db_sql_file = KnownKey.newKey("${zimbra_home}/db/create_database.sql");
+  @Supported
+  public static final KnownKey mailboxd_directory = KnownKey.newKey("${zimbra_home}/mailboxd");
+  public static final KnownKey create_db_sql_file = KnownKey.newKey("${mailboxd_directory}/../db/create_database.sql");
 
   @Supported public static final KnownKey mailboxd_java_heap_size = KnownKey.newKey(null);
 
@@ -494,7 +504,7 @@ public final class LC {
 
   @Supported
   public static final KnownKey mailboxd_keystore =
-      KnownKey.newKey("${zimbra_home}/conf/keystore");
+      KnownKey.newKey("${mailboxd_directory}/etc/keystore");
 
   @Supported public static final KnownKey mailboxd_keystore_password = KnownKey.newKey("zimbra");
 
@@ -577,6 +587,11 @@ public final class LC {
   public static final KnownKey calendar_item_get_max_retries = KnownKey.newKey(100);
   public static final KnownKey zimbraPrefCalenderScaling = KnownKey.newKey(false);
 
+  public static final KnownKey spnego_java_options =
+      KnownKey.newKey(
+          "-Djava.security.krb5.conf=${mailboxd_directory}/etc/krb5.ini "
+              + "-Djava.security.auth.login.config=${mailboxd_directory}/etc/spnego.conf "
+              + "-Djavax.security.auth.useSubjectCredsOnly=false");
 
   public static final KnownKey text_attachments_base64 = KnownKey.newKey(true);
 
@@ -1443,5 +1458,4 @@ public final class LC {
   @Target({ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Supported {}
-
 }

--- a/packages/mailbox-jar/PKGBUILD
+++ b/packages/mailbox-jar/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-mailbox-jar"
-pkgver="4.16.0"
+pkgver="4.16.2"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Jars"
 arch=('x86_64')

--- a/store/src/main/java/com/zimbra/cs/service/account/AccountService.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/AccountService.java
@@ -53,6 +53,10 @@ public class AccountService implements DocumentService {
     dispatcher.registerHandler(AccountConstants.MODIFY_PROPERTIES_REQUEST, new ModifyProperties());
     dispatcher.registerHandler(
         AccountConstants.MODIFY_ZIMLET_PREFS_REQUEST, new ModifyZimletPrefs());
+
+    dispatcher.registerHandler(AccountConstants.GET_ALL_LOCALES_REQUEST, new GetAllLocales());
+    dispatcher.registerHandler(
+        AccountConstants.GET_AVAILABLE_LOCALES_REQUEST, new GetAvailableLocales());
     dispatcher.registerHandler(
         AccountConstants.GET_AVAILABLE_CSV_FORMATS_REQUEST, new GetAvailableCsvFormats());
 

--- a/store/src/main/java/com/zimbra/cs/service/account/GetAllLocales.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/GetAllLocales.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2022 Synacor, Inc.
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.service.account;
+
+import java.util.Locale;
+import java.util.Map;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.util.WebClientL10nUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class GetAllLocales extends AccountDocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+
+        Locale[] locales = WebClientL10nUtil.getAllLocalesSorted();
+        Element response = zsc.createElement(AccountConstants.GET_ALL_LOCALES_RESPONSE);
+        for (Locale locale : locales) {
+            ToXML.encodeLocale(response, locale, Locale.US);
+        }
+        return response;
+    }
+}

--- a/store/src/main/java/com/zimbra/cs/service/account/GetAvailableLocales.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/GetAvailableLocales.java
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2022 Synacor, Inc.
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.service.account;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.util.WebClientL10nUtil;
+import com.zimbra.soap.SoapServlet;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class GetAvailableLocales extends AccountDocumentHandler {
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+        Account account = getRequestedAccount(zsc);
+
+        if (!canAccessAccount(zsc, account)) {
+            throw ServiceException.PERM_DENIED("can not access account");
+        }
+
+        Locale displayLocale = getDisplayLocale(account, context);
+
+        // get installed locales, sorted
+        Locale[] installedLocales = WebClientL10nUtil.getLocales(displayLocale);
+
+        // get avail locales for this account/COS
+        Set<String> allowedLocales = account.getMultiAttrSet(Provisioning.A_zimbraAvailableLocale);
+
+        Locale[] availLocales = null;
+        if (allowedLocales.size() > 0) {
+            availLocales = computeAvailLocales(installedLocales, allowedLocales);
+        } else {
+            availLocales = installedLocales;
+        }
+
+        Element response = zsc.createElement(AccountConstants.GET_AVAILABLE_LOCALES_RESPONSE);
+        for (Locale locale : availLocales) {
+            if (locale != null) {
+                ToXML.encodeLocale(response, locale, displayLocale);
+            } else {
+                break;
+            }
+        }
+        return response;
+    }
+
+    private Locale getDisplayLocale(Account acct, Map<String, Object> context) throws ServiceException {
+        // use zimbraPrefLocale is it is present
+        String locale = acct.getAttr(Provisioning.A_zimbraPrefLocale, false);
+
+        // otherwise use Accept-Language header
+        if (StringUtil.isNullOrEmpty(locale)) {
+            HttpServletRequest req = (HttpServletRequest)context.get(SoapServlet.SERVLET_REQUEST);
+            if (req != null) {
+                locale = req.getHeader("Accept-Language");
+            //TODO need to handle multiple languages with quality value and use the one with the highest quality value
+            }
+        }
+
+        // otherwise use Provisioning.getLocale();
+        if (StringUtil.isNullOrEmpty(locale)) {
+            return Provisioning.getInstance().getLocale(acct);
+        } else {
+            return L10nUtil.lookupLocale(locale);
+        }
+    }
+
+    private Locale[] computeAvailLocales(Locale[] installedLocales, Set<String> allowedLocales) {
+        /*
+         * available locales is the intersection of installedLocales and allowedLocales
+         *
+         * for a locale in allowedLocales, we include all the sub locales, but not the more "generic" locales in the family
+         * e.g. - if allowedLocales is fr, all the fr_* in installedLocales will be included
+         *      - if allowedLocales is fr_CA, all the fr_CA_* in installedLocales will be included,
+         *        but not any of the fr_[non CA] or fr.
+         */
+
+        Locale[] availLocales = new Locale[installedLocales.length];
+        int i = 0;
+        for (Locale locale : installedLocales) {
+            // locale ids are in language[_country[_variant]] format
+            // include it if it allows a more generic locale in the family
+            String localeId = locale.toString();
+            String language = locale.getLanguage();
+            String country = locale.getCountry();
+            String variant = locale.getVariant();
+
+            if (!StringUtil.isNullOrEmpty(variant)) {
+                if (allowedLocales.contains(language) || allowedLocales.contains(language+"_"+country) || allowedLocales.contains(localeId)) {
+                    availLocales[i++] = locale;
+                }
+            } else if (!StringUtil.isNullOrEmpty(country)) {
+                if (allowedLocales.contains(language) || allowedLocales.contains(localeId)) {
+                    availLocales[i++] = locale;
+                }
+            } else {
+                if (allowedLocales.contains(localeId)) {
+                    availLocales[i++] = locale;
+                }
+            }
+        }
+
+        return availLocales;
+    }
+}

--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
@@ -30,6 +30,7 @@ public class AdminService implements DocumentService {
   public void registerHandlers(DocumentDispatcher dispatcher) throws ServiceException {
     dispatcher.registerHandler(AdminConstants.PING_REQUEST, new Ping());
     dispatcher.registerHandler(AdminConstants.CHECK_HEALTH_REQUEST, new CheckHealth());
+    dispatcher.registerHandler(AdminConstants.GET_ALL_LOCALES_REQUEST, new GetAllLocales());
 
     dispatcher.registerHandler(AdminConstants.AUTH_REQUEST, new Auth());
     dispatcher.registerHandler(AdminConstants.CREATE_ACCOUNT_REQUEST, new CreateAccount());

--- a/store/src/main/java/com/zimbra/cs/service/admin/FlushCache.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/FlushCache.java
@@ -19,6 +19,7 @@ import com.zimbra.cs.account.accesscontrol.PermissionCache;
 import com.zimbra.cs.account.accesscontrol.Rights.Admin;
 import com.zimbra.cs.gal.GalGroup;
 import com.zimbra.cs.httpclient.URLUtil;
+import com.zimbra.cs.util.WebClientL10nUtil;
 import com.zimbra.cs.util.WebClientServiceUtil;
 import com.zimbra.cs.zimlet.ZimletUtil;
 import com.zimbra.soap.SoapServlet;
@@ -114,6 +115,7 @@ public class FlushCache extends AdminDocumentHandler {
         }
         break;
       case locale:
+        WebClientL10nUtil.flushCache();
         break;
       case license:
         flushLdapCache(

--- a/store/src/main/java/com/zimbra/cs/service/admin/GetAllLocales.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/GetAllLocales.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2022 Synacor, Inc.
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.service.admin;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.accesscontrol.AdminRight;
+import com.zimbra.cs.util.WebClientL10nUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class GetAllLocales extends AdminDocumentHandler {
+
+    @Override
+    public boolean domainAuthSufficient(Map<String, Object> context) {
+        return true;
+    }
+
+    @Override
+    public Element handle(Element request, Map<String, Object> context) {
+        ZimbraSoapContext zsc = getZimbraSoapContext(context);
+
+        Locale[] locales = WebClientL10nUtil.getAllLocalesSorted();
+        Element response = zsc.createElement(AdminConstants.GET_ALL_LOCALES_RESPONSE);
+        for (Locale locale : locales) {
+            com.zimbra.cs.service.account.ToXML.encodeLocale(response, locale, Locale.US);
+        }
+        return response;
+    }
+
+    @Override
+    public void docRights(List<AdminRight> relatedRights, List<String> notes) {
+        notes.add("Allow all admins");
+    }
+}

--- a/store/src/main/java/com/zimbra/cs/util/WebClientL10nUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/WebClientL10nUtil.java
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2022 Synacor, Inc.
+// SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.util;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.zimbra.common.localconfig.LC;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.L10nUtil.MatchingPropertiesFilter;
+import com.zimbra.common.util.SetUtil;
+import com.zimbra.common.util.ZimbraLog;
+
+public class WebClientL10nUtil {
+
+    private static final String LOAD_LOCALES_ON_UI_NODE = "/fromservice/loadlocales";
+
+    /**
+     * Return all known locales sorted by their US English display name.
+     * @return
+     */
+    public static Locale[] getAllLocalesSorted() {
+        Locale[] locales = Locale.getAvailableLocales();
+        Arrays.sort(locales, new LocaleComparatorByDisplayName(Locale.US));
+        return locales;
+    }
+
+    private static class LocaleComparatorByDisplayName implements Comparator<Locale> {
+        private final Locale mInLocale;
+
+        LocaleComparatorByDisplayName(Locale inLocale) {
+            mInLocale = inLocale;
+        }
+
+        @Override
+        public int compare(Locale a, Locale b) {
+            String da = a.getDisplayName(mInLocale);
+            String db = b.getDisplayName(mInLocale);
+            return da.compareTo(db);
+        }
+    }
+
+    public static synchronized Set<Locale> getAvailableLocales() throws ServiceException {
+        if (locales == null) {
+            loadBundles();
+        }
+        return locales;
+    }
+
+    enum ClientResource {
+        // I18nMsg,  // generated, all locales are there, so we don't count this resource
+        AjxMsg,
+        ZMsg,
+        ZaMsg,
+        ZhMsg,
+        ZmMsg
+    }
+
+    // set of localized(translated) locales
+    static Set<Locale> locales = null;
+
+    // we cache the sorted list per display locale to avoid the array copy
+    // and sorting each time for a GetLocale request
+    static Map<Locale, Locale[]> sortedLocalesMap = null;
+
+    public static void loadBundlesByDiskScan() {
+        String msgsDir = LC.localized_client_msgs_directory.value();
+        ZimbraLog.misc.info("Scanning installed locales from %s", msgsDir);
+        locales = new HashSet<>();
+
+        // the en_US locale is always available
+        ZimbraLog.misc.info("Adding locale " + Locale.US.toString() + " (always added)");
+        locales.add(Locale.US);
+        File dir = new File(msgsDir);
+        if (!dir.exists()) {
+            ZimbraLog.misc.info("message directory does not exist: %s", msgsDir);
+            return;
+        }
+        if (!dir.isDirectory()) {
+            ZimbraLog.misc.info("message directory is not a directory: %s", msgsDir);
+            return;
+        }
+
+        for (File file : dir.listFiles(new MatchingPropertiesFilter(ClientResource.values()))) {
+            ZimbraLog.misc.debug("loadBundlesByDiskScan processing file: %s", file.getName());
+            Locale locale = L10nUtil.getLocaleForPropertiesFile(file, true);
+            if (locale != null && !locales.contains(locale)) {
+                ZimbraLog.misc.info("Adding locale: %s", locale);
+                locales.add(locale);
+            }
+        }
+    }
+
+    private static void loadBundles() throws ServiceException {
+        ZimbraLog.webclient.debug("Loading locales...");
+        locales = new HashSet<>();
+
+        if (WebClientServiceUtil.isServerInSplitMode()) {
+            String localesStr = WebClientServiceUtil.sendServiceRequestToOneRandomUiNode(LOAD_LOCALES_ON_UI_NODE);
+            for (String str : localesStr.split(",")) {
+                String[] parts = str.split("_");
+                switch (parts.length) {
+                    case 1:
+                        locales.add(new Locale(parts[0]));
+                        break;
+                    case 2:
+                        locales.add(new Locale(parts[0], parts[1]));
+                        break;
+                    case 3:
+                        locales.add(new Locale(parts[0], parts[1], parts[2]));
+                        break;
+                    default:
+                        ZimbraLog.misc.warn("unsupported locale %s", str);
+                }
+            }
+        } else {
+            loadBundlesByDiskScan();
+        }
+
+        /*
+         * UI displays locales with country in sub menus.
+         *
+         * E.g. if there are:
+         *      id: "zh_CN", name: "Chinese (China)"
+         *      id: "zh_HK", name: "Chinese (Hong Kong)"
+         *
+         *      then the menu looks like:
+         *          Chinese
+         *                   Chinese (China)
+         *                   Chinese (Hong Kong)
+         *
+         *      UI relies on the presence of a "language only" entry
+         *      for the top level label "Chinese".
+         *      i.e. id: "zh", name: "Chinese"
+         *
+         *      Thus we need to add a "language only" pseudo entry for locales that have
+         *      a country part but the "language only" entry is not already there.
+         */
+        Set<Locale> pseudoLocales = new HashSet<>();
+        for (Locale lc : locales) {
+            String language = lc.getLanguage();
+            Locale lcLang = new Locale(language);
+            if (!locales.contains(lcLang) && !pseudoLocales.contains(lcLang)) {
+                ZimbraLog.misc.info("Adding locale " + lcLang + " (pseudo)");
+                pseudoLocales.add(lcLang);
+            }
+        }
+        if (pseudoLocales.size() > 0) {
+            locales = SetUtil.union(locales, pseudoLocales);
+        }
+        ZimbraLog.webclient.debug("Locale loading complete.");
+    }
+
+    public static synchronized Locale[] getLocales(Locale inLocale) throws ServiceException {
+        if (locales == null) {
+            loadBundles();
+        }
+
+        Locale[] sortedLocales = null;
+        if (sortedLocalesMap == null) {
+            sortedLocalesMap = new HashMap<>();
+        } else {
+            sortedLocales = sortedLocalesMap.get(inLocale);
+        }
+
+        if (sortedLocales == null) {
+            // cache the sorted list per display locale
+            sortedLocales = locales.toArray(new Locale[0]);
+            Arrays.sort(sortedLocales, new LocaleComparatorByDisplayName(inLocale));
+            sortedLocalesMap.put(inLocale, sortedLocales);
+        }
+        return sortedLocales;
+    }
+
+    public static synchronized void flushCache() throws ServiceException {
+        ZimbraLog.misc.debug("WebClientL10nUtil: flushing locale cache");
+        locales = null;
+        sortedLocalesMap = null;
+    }
+}

--- a/store/src/main/java/com/zimbra/cs/zimlet/ZimletException.java
+++ b/store/src/main/java/com/zimbra/cs/zimlet/ZimletException.java
@@ -13,7 +13,7 @@ package com.zimbra.cs.zimlet;
 @SuppressWarnings("serial")
 public class ZimletException extends Exception {
 
-    public ZimletException(String msg) {
+    private ZimletException(String msg) {
         super(msg);
     }
 

--- a/store/src/main/java/com/zimbra/cs/zimlet/ZimletUtil.java
+++ b/store/src/main/java/com/zimbra/cs/zimlet/ZimletUtil.java
@@ -647,7 +647,46 @@ public class ZimletUtil {
      * @throws ZimletException
      */
     public static void installZimletLocally(ZimletFile zf) throws IOException, ZimletException {
-        throw new ZimletException("zimlets are not supported anymore");
+        ZimletDescription zd = zf.getZimletDescription();
+        String zimletName = zd.getName();
+        ZimbraLog.zimlet.info("Installing Zimlet " + zimletName + " on this host.");
+
+        // location for the jar files
+        File libDir = new File(LC.mailboxd_directory.value() + File.separator +
+                                    "webapps" + File.separator +
+                                    "zimlet" + File.separator +
+                                    "WEB-INF" + File.separator +
+                                    "lib");
+        // location for the rest of the files
+        File zimlet = getZimletRootDir(zimletName);
+        String zimletsRootPath = new File(LC.zimlet_directory.value()).getCanonicalPath();
+        zimlet.getParentFile().mkdirs();
+        if (zimlet.exists()) {
+            deleteFile(zimlet);
+        }
+
+        for (ZimletFile.ZimletEntry entry : zf.getAllEntries()) {
+            String fname = entry.getName();
+            File file;
+            if (fname.endsWith(".jar")) {
+                file = new File(libDir, fname);
+                if(!file.getCanonicalPath().startsWith(libDir.getCanonicalPath())) {
+                    ZimbraLog.zimlet.error(String.format("Zimlet %s has an invalid file path %s", zimletName, fname));
+                    throw ZimletException.CANNOT_DEPLOY(zimletName, "Invalid file path " + fname, null);
+                }
+            } else {
+                file = new File(zimlet, fname);
+                if(!file.getCanonicalPath().startsWith(zimletsRootPath)) {
+                    ZimbraLog.zimlet.error(String.format("Zimlet %s has an invalid file path %s", zimletName, fname));
+                    throw ZimletException.CANNOT_DEPLOY(zimletName, "Invalid file path " + fname, null);
+                }
+            }
+
+            file.getParentFile().mkdirs();
+            writeFile(entry.getContents(), file);
+        }
+
+        flushCache();
     }
 
     /**


### PR DESCRIPTION
This reverts commit 7dcd4193241090dea92ea65c635c63cb5ccc4b29.

We found out that actually mailboxd directory still exists, and it is  a symbolic link to /opt/zextras/jetty_base, which is created by the package carbonio-appserver.

We plan to further clean it up in the future as there are still many references to it and in carbonio-bootstrap logic.