### PR TITLE
fix: fixed PreviewServlet package name in web.xml

### DIFF
--- a/store/conf/web.xml
+++ b/store/conf/web.xml
@@ -288,7 +288,7 @@
 
   <servlet>
     <servlet-name>PreviewServlet</servlet-name>
-    <servlet-class>com.zimbra.cs.service.PreviewServlet</servlet-class>
+    <servlet-class>com.zimbra.cs.service.servlet.preview.PreviewServlet</servlet-class>
     <async-supported>true</async-supported>
     <init-param>
       <param-name>allowed.ports</param-name>


### PR DESCRIPTION
package name in web.xml was not aligned with actual PreviewServlet package name. This makes PreviewServlet fail when deploying from devel