### PR TITLE
fix: jar version bump 24.9.1

### DIFF
--- a/jython-libs/pom.xml
+++ b/jython-libs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zm-mailbox</artifactId>
     <groupId>zextras</groupId>
-    <version>24.7.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -820,7 +820,7 @@
     <system-lambda.version>1.2.1</system-lambda.version>
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <changelist>-SNAPSHOT</changelist>
-    <revision>24.9.0</revision>
+    <revision>24.9.1</revision>
     <mockserver.version>5.13.0</mockserver.version>
     <mariadb-java-client.version>2.7.3</mariadb-java-client.version>
   </properties>


### PR DESCRIPTION
- forgot to bump packages version to 24.9.1
- align jython module