### PR TITLE
fix: versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,11 +9,8 @@ def mvnCmd(String cmd) {
     sh 'mvn -B -s settings-jenkins.xml ' + profile + ' ' + cmd
 }
 def isBuildingTag() {
-    def changeSet = currentBuild.changeSets[0]
-    if (changeSet != null) {
-        return changeSet.getItems().any { item ->
-            item.comment.contains('refs/tags/')
-        }
+    if (env.TAG_NAME) {
+        return true
     }
     return false
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,9 @@ pipeline {
         }
         stage('Publish to maven') {
             when {
-                isBuildingTag()
+                expression {
+                    return isBuildingTag()
+                }
             }
             steps {
                 mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
@@ -342,9 +344,8 @@ pipeline {
         }
         stage('Upload & Promotion Config') {
             when {
-                anyOf {
-                    branch 'release/*'
-                    isBuildingTag()
+                expression {
+                    return isBuildingTag()
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,7 @@ pipeline {
         }
         stage('Publish to maven') {
             when {
-                buildingTag()
+                isBuildingTag()
             }
             steps {
                 mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
@@ -344,7 +344,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'release/*'
-                    buildingTag()
+                    isBuildingTag()
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,13 +9,7 @@ def mvnCmd(String cmd) {
     sh 'mvn -B -s settings-jenkins.xml ' + profile + ' ' + cmd
 }
 def isBuildingTag() {
-    def changeSet = currentBuild.changeSets[0]
-    if (changeSet != null) {
-        return changeSet.getItems().any { item ->
-            item.comment.contains('refs/tags/')
-        }
-    }
-    return false
+    return buildingTag()
 }
 
 def buildDebPackages(String flavor) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,13 @@ def mvnCmd(String cmd) {
     sh 'mvn -B -s settings-jenkins.xml ' + profile + ' ' + cmd
 }
 def isBuildingTag() {
-    return buildingTag()
+    def changeSet = currentBuild.changeSets[0]
+    if (changeSet != null) {
+        return changeSet.getItems().any { item ->
+            item.comment.contains('refs/tags/')
+        }
+    }
+    return false
 }
 
 def buildDebPackages(String flavor) {
@@ -158,7 +164,7 @@ pipeline {
                 branch 'devel';
             }
             steps {
-                mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true -Pdev')
+                mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
             }
         }
         stage('Publish to maven') {
@@ -166,7 +172,7 @@ pipeline {
                 buildingTag()
             }
             steps {
-                mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true -Pprod')
+                mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
             }
         }
         stage('Build deb/rpm') {

--- a/jython-libs/pom.xml
+++ b/jython-libs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zm-mailbox</artifactId>
     <groupId>zextras</groupId>
-    <version>24.7.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -370,45 +370,45 @@
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-common</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-client</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-soap</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-native</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-store</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>zm-store</artifactId>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
         <classifier>classes</classifier>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>store-extra-runtime-dependencies</artifactId>
         <type>pom</type>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>zextras</groupId>
         <artifactId>carbonio-jetty-libs</artifactId>
         <type>pom</type>
-        <version>${revision}${changelist}</version>
+        <version>${project.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>
@@ -820,7 +820,7 @@
     <system-lambda.version>1.2.1</system-lambda.version>
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <changelist>-SNAPSHOT</changelist>
-    <revision>24.9.1</revision>
+    <revision>24.12.0</revision>
     <mockserver.version>5.13.0</mockserver.version>
     <mariadb-java-client.version>2.7.3</mariadb-java-client.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -820,7 +820,7 @@
     <system-lambda.version>1.2.1</system-lambda.version>
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <changelist>-SNAPSHOT</changelist>
-    <revision>24.12.0</revision>
+    <revision>24.9.1</revision>
     <mockserver.version>5.13.0</mockserver.version>
     <mariadb-java-client.version>2.7.3</mariadb-java-client.version>
   </properties>


### PR DESCRIPTION
These changes address three issues:
- alignment of jython-libraries module version
- set of profile -pProd or default (devel) depending if building tag or not
- Fix dependencies version using project.version variable, according to: https://maven.apache.org/maven-ci-friendly.html

We noticed that releasing a non SNAPSHOT version produces a pom with SNAPSHOT dependencies, for example zm-mailbox-24.9.1.pom contains zm-common-24.9.1-SNAPSHOT. 
This causes projects using mailbox as dependency will fail downloading transitive dependencies (zm-store-24.9.1-SNAPSHOT does not exist).
Using ${project.version} seems to be the supported way by Maven.