### PR TITLE
feat: [CO-1481] FileUploadServlet, Align maxSize calculation 

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -7747,7 +7747,8 @@ public class ZAttrProvisioning {
     public static final String A_zimbraFileUploadMaxSize = "zimbraFileUploadMaxSize";
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @since ZCS 8.0.0
      */

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrAccount.java
@@ -22169,7 +22169,8 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -22181,7 +22182,8 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -22196,7 +22198,8 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -22212,7 +22215,8 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -22226,7 +22230,8 @@ public abstract class ZAttrAccount extends MailTarget {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrConfig.java
@@ -19508,7 +19508,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -19520,7 +19521,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -19535,7 +19537,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -19551,7 +19554,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -19565,7 +19569,8 @@ public abstract class ZAttrConfig extends Entry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrCos.java
@@ -16820,7 +16820,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -16832,7 +16833,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -16847,7 +16849,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -16863,7 +16866,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -16877,7 +16881,8 @@ public abstract class ZAttrCos extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -12216,7 +12216,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @return zimbraFileUploadMaxSizePerFile, or 2147483648 if unset
      *
@@ -12228,7 +12229,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @throws com.zimbra.common.service.ServiceException if error during update
@@ -12243,7 +12245,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param zimbraFileUploadMaxSizePerFile new value
      * @param attrs existing map to populate, or null to create a new map
@@ -12259,7 +12262,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @throws com.zimbra.common.service.ServiceException if error during update
      *
@@ -12273,7 +12277,8 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
-     * Maximum size in bytes for each attachment.
+     * The maximum size for each attachment, in bytes. A value of 0 indicates
+     * no size limit.
      *
      * @param attrs existing map to populate, or null to create a new map
      * @return populated map to pass into Provisioning.modifyAttrs

--- a/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -467,7 +467,7 @@ public class FileUploadServlet extends ZimbraServlet {
         maxSize = Provisioning.getInstance().getConfig().getMtaMaxMessageSize();
       }
       if (maxSize == 0) {
-        /* zimbraMtaMaxMessageSize=0 means "no limit".  The return value from this function gets used
+        /* zimbraFileUploadMaxSizePerFile=0 & zimbraMtaMaxMessageSize=0 means "no limit".  The return value from this function gets used
          * by FileUploadBase "sizeMax" where "-1" means "no limit"
          */
         maxSize = -1;

--- a/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -465,12 +465,12 @@ public class FileUploadServlet extends ZimbraServlet {
         }
       } else {
         maxSize = Provisioning.getInstance().getConfig().getMtaMaxMessageSize();
-        if (maxSize == 0) {
-          /* zimbraMtaMaxMessageSize=0 means "no limit".  The return value from this function gets used
-           * by FileUploadBase "sizeMax" where "-1" means "no limit"
-           */
-          maxSize = -1;
-        }
+      }
+      if (maxSize == 0) {
+        /* zimbraMtaMaxMessageSize=0 means "no limit".  The return value from this function gets used
+         * by FileUploadBase "sizeMax" where "-1" means "no limit"
+         */
+        maxSize = -1;
       }
     } catch (ServiceException e) {
       mLog.error(

--- a/store/src/main/resources/conf/attrs/attrs.xml
+++ b/store/src/main/resources/conf/attrs/attrs.xml
@@ -6814,7 +6814,7 @@ TODO: delete them permanently from here
 <attr id="1350" name="zimbraFileUploadMaxSizePerFile" type="long" cardinality="single" optionalIn="account,cos,domain,globalConfig" flags="accountInfo,domainInfo,accountCosDomainInherited,domainInherited,domainAdminModifiable" since="8.0.0">
   <globalConfigValue>2147483648</globalConfigValue>
   <defaultCOSValue>2147483648</defaultCOSValue>
-  <desc>Maximum size in bytes for each attachment.</desc>
+  <desc>The maximum size for each attachment, in bytes. A value of 0 indicates no size limit.</desc>
 </attr>
 
 <attr id="1351" name="zimbraPublicSharingEnabled" type="boolean" cardinality="single" optionalIn="account,cos,domain" flags="accountInfo,accountCosDomainInherited,domainAdminModifiable" since="8.0.0">

--- a/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Maps;
+import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.localconfig.LC;
@@ -90,7 +91,7 @@ public class FileUploadServletTest {
           + " 0120-801-471";
   private static FileUploadServlet servlet;
   private static Account testAccount;
-
+  private static AccountCreator.Factory accountCreatorFactory;
   private Server server;
 
   @BeforeAll
@@ -101,15 +102,17 @@ public class FileUploadServletTest {
     servlet = new FileUploadServlet();
 
     MailboxTestUtil.initServer();
-    var prov = Provisioning.getInstance();
+    var provisioning = Provisioning.getInstance();
+
+    accountCreatorFactory = new AccountCreator.Factory(provisioning);
 
     Map<String, Object> attrs = Maps.newHashMap();
-    prov.createAccount("test@zimbra.com", "secret", attrs);
-    testAccount = prov.get(Key.AccountBy.name, "test@zimbra.com");
+    provisioning.createAccount("test@zimbra.com", "secret", attrs);
+    testAccount = provisioning.get(Key.AccountBy.name, "test@zimbra.com");
 
     attrs = Maps.newHashMap();
     attrs.put(Provisioning.A_zimbraId, UUID.randomUUID().toString());
-    prov.createAccount("test2@zimbra.com", "secret", attrs);
+    provisioning.createAccount("test2@zimbra.com", "secret", attrs);
   }
 
   @SuppressWarnings("UnusedReturnValue")
@@ -166,6 +169,7 @@ public class FileUploadServletTest {
 
   @AfterEach
   public void tearDown() throws Exception {
+    Provisioning.getInstance().getConfig().setMtaMaxMessageSize(10240000L);
     MailboxTestUtil.clearData();
     server.stop();
   }
@@ -457,7 +461,8 @@ public class FileUploadServletTest {
       "Extended filename should be preferred if the multipart upload request contains "
           + "Content-Disposition header with extended filename param as defined in RFC-6266")
   void handleMultipartUpload_should_parseExtendedFileNameFromContentDisposition() throws Exception {
-    var authToken = AuthProvider.getAuthToken(testAccount);
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
     var filePath = Paths.get(
         Objects.requireNonNull(getClass().getResource("\u0421\u043e\u0431\u044b\u0442\u0438\u044f.txt")).toURI());
     var fileName = Paths.get(filePath.toUri()).getFileName().toString();
@@ -499,7 +504,8 @@ public class FileUploadServletTest {
       "Filename should be parsed correctly when multipart upload is composed with "
           + "MultipartEntityBuilder and charset set to UTF-8")
   void handleMultipartUpload_should_parseFileNameFromContentDisposition() throws Exception {
-    var authToken = AuthProvider.getAuthToken(testAccount);
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
     var filePath = Paths.get(
         Objects.requireNonNull(getClass().getResource("\u0421\u043e\u0431\u044b\u0442\u0438\u044f.txt")).toURI());
     var fileName = Paths.get(filePath.toUri()).getFileName().toString();
@@ -520,7 +526,8 @@ public class FileUploadServletTest {
       "Extended filename should be preferred if the plain upload request contains "
           + "Content-Disposition header with extended filename param as defined in RFC-6266")
   void handlePlainUpload_should_parseExtendedFileNameFromContentDisposition() throws Exception {
-    var authToken = AuthProvider.getAuthToken(testAccount);
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
     var filePath =
         Paths.get(
             Objects.requireNonNull(
@@ -550,7 +557,8 @@ public class FileUploadServletTest {
   @Test
   void handlePlainUpload_should_ignore_zimbraMtaMaxSIze_when_lbfums_param_in_request_url()
       throws Exception {
-    var authToken = AuthProvider.getAuthToken(testAccount);
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
     var fileSize = 30 * 1024 * 1024;
     var asciiFileName = "Events.txt";
     var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
@@ -570,12 +578,107 @@ public class FileUploadServletTest {
   }
 
   @Test
+  void should_be_able_upload_unlimited_when_zimbraMtaMaxMessageSize()
+      throws Exception {
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
+    var fileSize = 1024 * 1024;
+    var asciiFileName = "Events.txt";
+    var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
+
+    Provisioning.getInstance().getConfig().setMtaMaxMessageSize(0);
+
+    //note that lbfums is false
+    var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
+    var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
+    var jsonArray = new JSONArray("[" + responseContent + "]");
+
+    assertEquals(HttpServletResponse.SC_OK, jsonArray.getInt(0));
+    assertEquals("null", jsonArray.getString(1));
+
+    var responseDataArray = jsonArray.getJSONArray(2);
+    assertTrue(responseDataArray.length() > 0);
+
+    var firstItem = responseDataArray.getJSONObject(0);
+    assertNotNull(firstItem.getString("aid"));
+  }
+
+  @Test
+  void should_be_able_upload_unlimited_when_FileUploadMaxSizePerFile_is_zero()
+      throws Exception {
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
+    var fileSize = 1024 * 1024;
+    var asciiFileName = "Events.txt";
+    var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
+
+    account.setFileUploadMaxSizePerFile(0);
+
+    //note that lbfums is true
+    var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, true);
+    var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
+    var jsonArray = new JSONArray("[" + responseContent + "]");
+
+    assertEquals(HttpServletResponse.SC_OK, jsonArray.getInt(0));
+    assertEquals("null", jsonArray.getString(1));
+
+    var responseDataArray = jsonArray.getJSONArray(2);
+    assertTrue(responseDataArray.length() > 0);
+
+    var firstItem = responseDataArray.getJSONObject(0);
+    assertNotNull(firstItem.getString("aid"));
+  }
+
+  @Test
+  void should_not_be_able_upload_file_greater_then_limit_set_by_zimbraMtaMaxMessageSize()
+      throws Exception {
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
+    var fileSize = 1024 * 1024;
+    var asciiFileName = "Events.txt";
+    var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
+
+    Provisioning.getInstance().getConfig().setMtaMaxMessageSize(10);
+
+    //note that lbfums is false
+    var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
+    var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
+    var jsonArray = new JSONArray("[" + responseContent + "]");
+
+    assertEquals(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, jsonArray.getInt(0));
+    assertEquals("null", jsonArray.getString(1));
+  }
+
+  @Test
+  void should_not_be_able_upload_file_greater_then_limit_set_by_zimbraFileUploadMaxSizePerFile()
+      throws Exception {
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
+    var fileSize = 1024 * 1024;
+    var asciiFileName = "Events.txt";
+    var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
+
+    account.setFileUploadMaxSizePerFile(10);
+
+    //note that lbfums is true
+    var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, true);
+    var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
+    var jsonArray = new JSONArray("[" + responseContent + "]");
+
+    assertEquals(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, jsonArray.getInt(0));
+    assertEquals("null", jsonArray.getString(1));
+  }
+
+  @Test
   void handlePlainUpload_should_return_413_when_upload_file_size_is_greater_then_zimbraMtaMaxSIze()
       throws Exception {
-    var authToken = AuthProvider.getAuthToken(testAccount);
+    var account = accountCreatorFactory.get().create();
+    var authToken = AuthProvider.getAuthToken(account);
     var fileSize = 30 * 1024 * 1024;
     var asciiFileName = "Events.txt";
     var utf8EncodeFileName = URLEncoder.encode(asciiFileName, StandardCharsets.UTF_8);
+
+    Provisioning.getInstance().getConfig().setMtaMaxMessageSize(10);
 
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);

--- a/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
@@ -578,7 +578,7 @@ public class FileUploadServletTest {
   }
 
   @Test
-  void should_be_able_upload_unlimited_when_zimbraMtaMaxMessageSize()
+  void should_be_able_upload_unlimited_when_zimbraMtaMaxMessageSize_is_set_to_zero()
       throws Exception {
     var account = accountCreatorFactory.get().create();
     var authToken = AuthProvider.getAuthToken(account);
@@ -604,7 +604,7 @@ public class FileUploadServletTest {
   }
 
   @Test
-  void should_be_able_upload_unlimited_when_FileUploadMaxSizePerFile_is_zero()
+  void should_be_able_upload_unlimited_when_FileUploadMaxSizePerFile_is_set_to_zero()
       throws Exception {
     var account = accountCreatorFactory.get().create();
     var authToken = AuthProvider.getAuthToken(account);

--- a/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/FileUploadServletTest.java
@@ -588,7 +588,7 @@ public class FileUploadServletTest {
 
     Provisioning.getInstance().getConfig().setMtaMaxMessageSize(0);
 
-    //note that lbfums is false
+    //set lbfums to false to enforce limit using zimbraMtaMaxMessageSize
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
     var jsonArray = new JSONArray("[" + responseContent + "]");
@@ -614,7 +614,7 @@ public class FileUploadServletTest {
 
     account.setFileUploadMaxSizePerFile(0);
 
-    //note that lbfums is true
+    //set lbfums to true to enforce limit using zimbraFileUploadMaxSizePerFile
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, true);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
     var jsonArray = new JSONArray("[" + responseContent + "]");
@@ -640,7 +640,7 @@ public class FileUploadServletTest {
 
     Provisioning.getInstance().getConfig().setMtaMaxMessageSize(10);
 
-    //note that lbfums is false
+    //set lbfums to false to enforce limit using zimbraMtaMaxMessageSize
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
     var jsonArray = new JSONArray("[" + responseContent + "]");
@@ -660,7 +660,7 @@ public class FileUploadServletTest {
 
     account.setFileUploadMaxSizePerFile(10);
 
-    //note that lbfums is true
+    //set lbfums to true to enforce limit using zimbraFileUploadMaxSizePerFile
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, true);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
     var jsonArray = new JSONArray("[" + responseContent + "]");
@@ -680,6 +680,7 @@ public class FileUploadServletTest {
 
     Provisioning.getInstance().getConfig().setMtaMaxMessageSize(10);
 
+    //set lbfums to false to enforce limit using zimbraMtaMaxMessageSize
     var httpResponse = executeUploadRequestWithDummyData(authToken, fileSize, asciiFileName, utf8EncodeFileName, false);
     var responseContent = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
     var jsonArray = new JSONArray("[" + responseContent + "]");


### PR DESCRIPTION
**What has changed:**

- `FileUploadServlet` maxsize 0 now mean unlimited. This aligns the behavior of `zimbraFileUploadMaxSizePerFile` with `zimbraMtaMaxMessageSize`.
- update description of zimbraFileUploadMaxSizePerFile attribute to reflect the updated information.
