### PR TITLE
hotfix: [CO-1529] add charset dependency

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -205,7 +205,7 @@
     <dependency>
       <artifactId>zm-charset</artifactId>
       <groupId>zimbra</groupId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Charset dependency is needed at runtime in order to handle special characters, such as cyrillic alphabet.
See: https://github.com/zextras/carbonio-charset