### PR TITLE
feat: [CO-1528] PreviewServlet allow previewing attachments from Appointments

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/AttachmentService.java
+++ b/store/src/main/java/com/zimbra/cs/service/AttachmentService.java
@@ -1,6 +1,7 @@
 package com.zimbra.cs.service;
 
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.service.util.ItemId;
 import io.vavr.control.Try;
 import javax.mail.internet.MimePart;
 
@@ -16,10 +17,22 @@ public interface AttachmentService {
    * Get attachment for a mail message given account and authorization info.
    *
    * @param accountId id of the account that is requesting the attachment
-   * @param token authorization token for the account
+   * @param token     authorization token for the account
    * @param messageId id of the email/message where attachment lies
-   * @param part part number that identifies attachment in the mail
+   * @param part      part number that identifies attachment in the mail
    * @return try of {@link javax.mail.internet.MimePart} representing the attachment
    */
   Try<MimePart> getAttachment(String accountId, AuthToken token, int messageId, String part);
+
+  /**
+   * Get attachment for a mail message/Appointment given account and authorization info and ItemId information.
+   *
+   * @param accountId id of the account that is requesting the attachment
+   * @param token     authorization token for the account
+   * @param itemId    {@link ItemId} object for attachment
+   * @param part      part number that identifies attachment in the mail
+   * @return try of {@link javax.mail.internet.MimePart} representing the attachment
+   */
+  Try<MimePart> getAttachmentByItemId(String accountId, AuthToken token, ItemId itemId, String part);
+
 }

--- a/store/src/main/java/com/zimbra/cs/service/MailboxAttachmentService.java
+++ b/store/src/main/java/com/zimbra/cs/service/MailboxAttachmentService.java
@@ -1,48 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zimbra.cs.service;
 
 import static io.vavr.API.Case;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.mailbox.CalendarItem;
+import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.Mime;
+import com.zimbra.cs.service.util.ItemId;
 import io.vavr.API.Match.Pattern0;
 import io.vavr.control.Try;
+import java.util.Optional;
+import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 
 /**
  * Mailbox attachment provider
- *
- * @author davidefrison
- * @since 4.0.7
  */
 public class MailboxAttachmentService implements AttachmentService {
 
-  //TODO: try to move {AttachmentService and related classes and exceptions outside)
-  public static class MessageNotFound extends Exception {
+  private final OperationContextFactory contextFactory;
 
-    private static final long serialVersionUID = 703424514631475550L;
-
-    public MessageNotFound(Throwable cause) {
-      super("Message not found.", cause);
-    }
+  public MailboxAttachmentService(OperationContextFactory contextFactory) {
+    this.contextFactory = contextFactory;
   }
 
-  public static class AttachmentNotFound extends Exception {
-
-    private static final long serialVersionUID = 1138735883340739827L;
-
-    public AttachmentNotFound(String part) {
-      super(String.format("Missing part %s.", part));
-    }
+  public MailboxAttachmentService() {
+    this.contextFactory = new OperationContextFactory();
   }
 
-  public Try<MimePart> getAttachment(
-      String accountId, AuthToken token, int messageId, String part) {
+  @SuppressWarnings("unchecked")
+  @Override
+  public Try<MimePart> getAttachment(String accountId, AuthToken authToken, int messageId, String part) {
+
     return Try.of(() -> MailboxManager.getInstance().getMailboxByAccountId(accountId))
         .mapTry(mailbox ->
-            mailbox.getMessageById(new OperationContext(token), messageId)
+            mailbox.getMessageById(contextFactory.createOperationContext(authToken), messageId)
         )
         .mapFailure(
             Case(
@@ -64,5 +64,61 @@ public class MailboxAttachmentService implements AttachmentService {
                         : Try.success(mimePart)
                 )
         );
+  }
+
+  public Try<MimePart> getAttachmentByItemId(String accountId, AuthToken authToken, ItemId itemId, String part) {
+    return Try.of(() -> MailboxManager.getInstance().getMailboxByAccountId(accountId))
+        .flatMap(mailbox -> Try.of(() -> {
+          var context = contextFactory.createOperationContext(authToken);
+          MailItem mailItem = itemId.hasSubpart() ?
+              mailbox.getAppointmentById(context, itemId.getId()) :
+              mailbox.getMessageById(context, itemId.getId());
+
+          if (mailItem == null) {
+            throw new MessageNotFound(null);
+          }
+          return mailItem;
+        }))
+        .flatMap(mailItem -> Try.of(() -> {
+          MimePart mimePart;
+          if (mailItem instanceof Message message) {
+            mimePart = Mime.getMimePart(message.getMimeMessage(), part);
+          } else {
+            mimePart = extractMimePartFromCalendarItem((CalendarItem) mailItem, itemId, part).getOrNull();
+          }
+          return Optional.ofNullable(mimePart)
+              .orElseThrow(() -> new AttachmentNotFound(part));
+        }));
+  }
+
+  private Try<MimePart> extractMimePartFromCalendarItem(CalendarItem calItem, ItemId itemId, String part) {
+    return Try.of(() -> {
+      MimeMessage mimeMessage = itemId.hasSubpart()
+          ? calItem.getSubpartMessage(itemId.getSubpartId())
+          : calItem.getMimeMessage();
+
+      return Mime.getMimePart(mimeMessage, part);
+    });
+  }
+
+  public static class MessageNotFound extends Exception {
+
+    public MessageNotFound(Throwable cause) {
+      super("Message not found.", cause);
+    }
+  }
+
+  public static class AttachmentNotFound extends Exception {
+
+    public AttachmentNotFound(String part) {
+      super(String.format("Missing part %s.", part));
+    }
+  }
+
+  public static class OperationContextFactory {
+
+    public OperationContext createOperationContext(AuthToken authToken) throws ServiceException {
+      return new OperationContext(authToken);
+    }
   }
 }

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewHandler.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.http.HttpStatus;
  * validating query parameters, and handling requests for local or remote attachments.
  * </p>
  */
+@SuppressWarnings("ClassCanBeRecord")
 public class PreviewHandler {
 
   private static final Log LOG = LogFactory.getLog(PreviewHandler.class);
@@ -142,7 +143,7 @@ public class PreviewHandler {
    */
   private void handleLocalAttachment(HttpServletRequest request, HttpServletResponse response,
       AuthToken authToken, ItemId itemId, String partId) {
-    var mimePartTry = attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), partId);
+    var mimePartTry = attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, partId);
     if (mimePartTry.isFailure() || mimePartTry.get() == null) {
       var message = mimePartTry.getCause().getMessage();
       if (message == null || message.trim().isEmpty() || message.toLowerCase().contains("account")) {
@@ -171,7 +172,7 @@ public class PreviewHandler {
   }
 
   /**
-   * Proxies preview HTTP request to the mail host associated with the specified account ID.
+   * Proxies preview HTTP requests to the mail host associated with the specified account ID.
    *
    * <p>This method extracts the request ID from the provided {@link HttpServletRequest} object,
    * logs the action of proxying the request along with the target account ID, and then invokes the {@link

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewServlet.java
@@ -7,6 +7,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.service.MailboxAttachmentService;
 import com.zimbra.cs.servlet.ZimbraServlet;
 import java.io.IOException;
+import java.io.Serial;
 import java.time.Duration;
 import java.time.Instant;
 import javax.servlet.ServletException;
@@ -64,7 +65,8 @@ import javax.servlet.http.HttpServletResponse;
 
 public class PreviewServlet extends ZimbraServlet {
 
-  private static final long serialVersionUID = 35984059L;
+  @Serial
+  private static final long serialVersionUID = 359840598568L;
   private static final Log LOG = LogFactory.getLog(PreviewServlet.class);
   private final PreviewClient previewClient;
   private final PreviewHandler previewHandler;

--- a/store/src/test/java/com/zimbra/cs/service/servlet/preview/PreviewHandlerTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/servlet/preview/PreviewHandlerTest.java
@@ -155,12 +155,12 @@ class PreviewHandlerTest {
     when(itemId.getId()).thenReturn(Integer.parseInt(itemIdStr));
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create(itemIdStr, "accountId")).thenReturn(itemId);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
 
     previewHandler.handle(request, response);
 
-    verify(attachmentService).getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2");
+    verify(attachmentService).getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2");
   }
 
   @ParameterizedTest
@@ -177,7 +177,7 @@ class PreviewHandlerTest {
     when(itemId.getId()).thenReturn(Integer.parseInt(itemIdStr));
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create(itemIdStr, "accountId")).thenReturn(itemId);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
 
     var previewHandlerSpy = spy(previewHandler);
@@ -214,7 +214,7 @@ class PreviewHandlerTest {
     when(itemId.getId()).thenReturn(27310);
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create("27310", "accountId")).thenReturn(itemId);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
 
     previewHandler.handle(request, response);
@@ -257,7 +257,7 @@ class PreviewHandlerTest {
     when(itemId.getId()).thenReturn(27310);
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create("27310", "accountId")).thenReturn(itemId);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.failure(new ItemNotFound()));
 
     previewHandler.handle(request, response);
@@ -278,12 +278,11 @@ class PreviewHandlerTest {
     when(itemId.getId()).thenReturn(27310);
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create("27310", "accountId")).thenReturn(itemId);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
     when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), any(String.class)))
         .thenReturn(Try.failure(new InternalServerError()));
 
-//    var previewHandlerSyp = spy(previewHandler);
     previewHandler.handle(request, response);
 
     verify(response).sendError(Constants.STATUS_UNPROCESSABLE_ENTITY,
@@ -306,7 +305,7 @@ class PreviewHandlerTest {
     when(mimePart.getInputStream()).thenReturn(Mockito.mock(InputStream.class));
     when(mimePart.getContentType()).thenReturn("text/plain");
     when(mimePart.getSize()).thenReturn(200);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
     when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), anyString())).thenReturn(
         Try.success(blobResponse));
@@ -334,7 +333,7 @@ class PreviewHandlerTest {
     when(mimePart.getInputStream()).thenReturn(Mockito.mock(InputStream.class));
     when(mimePart.getContentType()).thenReturn("text/plain");
     when(mimePart.getSize()).thenReturn(200);
-    when(attachmentService.getAttachment(itemId.getAccountId(), authToken, itemId.getId(), "2"))
+    when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
     when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), anyString())).thenReturn(
         Try.failure(new InternalServerError()));


### PR DESCRIPTION
**What has changed:**
- `MailboxAttachmentService` has new method called `getAttachmentByItemId` which takes `ItemId` object and allows retrieving attachments from appointments as well as emails `MailItem` types.
- `PreviewHandler` now uses `MailboxAttachmentService::getAttachmentByItemId` to handle previewing attachments from appointments as well.

**Related PRs:**
- https://github.com/zextras/carbonio-calendars-ui/pull/505