### PR TITLE
chore: remove closure-compiler

### DIFF
--- a/carbonio-jetty-libs/pom.xml
+++ b/carbonio-jetty-libs/pom.xml
@@ -107,10 +107,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.javascript</groupId>
-      <artifactId>closure-compiler</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
       <artifactId>concurrentlinkedhashmap-lru</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
         <version>1.1</version>
       </dependency>
       <dependency>
-        <groupId>com.google.javascript</groupId>
-        <artifactId>closure-compiler</artifactId>
-        <version>v20180204</version>
-      </dependency>
-      <dependency>
         <groupId>com.kohlschutter.junixsocket</groupId>
         <artifactId>junixsocket-common</artifactId>
         <version>2.4.0</version>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -197,13 +197,6 @@
       <groupId>org.apache.commons</groupId>
     </dependency>
 
-    <!-- Brings in guava, so it is provided -->
-    <dependency>
-      <artifactId>closure-compiler</artifactId>
-      <groupId>com.google.javascript</groupId>
-      <scope>runtime</scope>
-    </dependency>
-
     <dependency>
       <artifactId>junixsocket-common</artifactId>
       <groupId>com.kohlschutter.junixsocket</groupId>


### PR DESCRIPTION
**Reason:** was causing conflict with guava classpath, causing the runtime not able to find certain classes from the intended version of guava (33.3.1)

[closure-compiler](https://developers.google.com/closure/compiler)


see: guava version bump in  #612
 