### PR TITLE
 feat: [CO-1513] Search users in specified domains by feature (carbonio-advanced)

### DIFF
--- a/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
+++ b/common/src/main/java/com/zimbra/common/account/ZAttrProvisioning.java
@@ -3046,6 +3046,15 @@ public class ZAttrProvisioning {
     public static final String A_carbonioSearchAllDomainsByFeature = "carbonioSearchAllDomainsByFeature";
 
     /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public static final String A_carbonioSearchSpecifiedDomainsByFeature = "carbonioSearchSpecifiedDomainsByFeature";
+
+    /**
      * Whether Carbonio can send analytics reports
      *
      * @since ZCS 9.0.0

--- a/store/src/main/java/com/zimbra/cs/account/SearchDirectoryOptions.java
+++ b/store/src/main/java/com/zimbra/cs/account/SearchDirectoryOptions.java
@@ -12,6 +12,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.ldap.ZLdapFilter;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 public class SearchDirectoryOptions {
@@ -25,6 +26,14 @@ public class SearchDirectoryOptions {
    * honored only for Alias entries
    */
   public static final String SORT_BY_TARGET_NAME = "targetName";
+
+  public List<Domain> getMultipleBases() {
+    return multipleBases;
+  }
+
+  public void setMultipleBases(final List<Domain> multipleBases) {
+    this.multipleBases = multipleBases;
+  }
 
   /*
    * Option to not set account defaults or secondard defaults.
@@ -132,6 +141,8 @@ public class SearchDirectoryOptions {
    * Note: this does NOT affect the search filter not the return attrs
    */
   private Domain domain = null;
+
+  private List<Domain> multipleBases;
 
   /*
    * search filter

--- a/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
+++ b/store/src/main/java/com/zimbra/cs/account/ZAttrDomain.java
@@ -1540,6 +1540,149 @@ public abstract class ZAttrDomain extends NamedEntry {
     }
 
     /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @return carbonioSearchSpecifiedDomainsByFeature, or empty array if unset
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public String[] getCarbonioSearchSpecifiedDomainsByFeature() {
+        return getMultiAttr(ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, true, true);
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature new value
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public void setCarbonioSearchSpecifiedDomainsByFeature(String[] carbonioSearchSpecifiedDomainsByFeature) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature new value
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public Map<String,Object> setCarbonioSearchSpecifiedDomainsByFeature(String[] carbonioSearchSpecifiedDomainsByFeature, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        return attrs;
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature new to add to existing values
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public void addCarbonioSearchSpecifiedDomainsByFeature(String carbonioSearchSpecifiedDomainsByFeature) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        StringUtil.addToMultiMap(attrs, "+"  + ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature new to add to existing values
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public Map<String,Object> addCarbonioSearchSpecifiedDomainsByFeature(String carbonioSearchSpecifiedDomainsByFeature, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        StringUtil.addToMultiMap(attrs, "+"  + ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        return attrs;
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature existing value to remove
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public void removeCarbonioSearchSpecifiedDomainsByFeature(String carbonioSearchSpecifiedDomainsByFeature) throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        StringUtil.addToMultiMap(attrs, "-"  + ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param carbonioSearchSpecifiedDomainsByFeature existing value to remove
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public Map<String,Object> removeCarbonioSearchSpecifiedDomainsByFeature(String carbonioSearchSpecifiedDomainsByFeature, Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        StringUtil.addToMultiMap(attrs, "-"  + ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, carbonioSearchSpecifiedDomainsByFeature);
+        return attrs;
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @throws com.zimbra.common.service.ServiceException if error during update
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public void unsetCarbonioSearchSpecifiedDomainsByFeature() throws com.zimbra.common.service.ServiceException {
+        HashMap<String,Object> attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, "");
+        getProvisioning().modifyAttrs(this, attrs);
+    }
+
+    /**
+     * List of domain names in which the SearchUserByFeature API should
+     * perform users searches
+     *
+     * @param attrs existing map to populate, or null to create a new map
+     * @return populated map to pass into Provisioning.modifyAttrs
+     *
+     * @since ZCS 24.12.0
+     */
+    @ZAttr(id=3148)
+    public Map<String,Object> unsetCarbonioSearchSpecifiedDomainsByFeature(Map<String,Object> attrs) {
+        if (attrs == null) attrs = new HashMap<>();
+        attrs.put(ZAttrProvisioning.A_carbonioSearchSpecifiedDomainsByFeature, "");
+        return attrs;
+    }
+
+    /**
      * Link to the Carbonio User Documentation
      *
      * @return carbonioUserDocumentationUrl, or "https://docs.zextras.com/carbonio/html/usage.html" if unset

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -1829,6 +1829,17 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     return searchDirectoryInternal(options, null);
   }
 
+  public String[] getSearchBases(List<Domain> domains, Set<ObjectType> types) throws ServiceException {
+    List<String> bases = new ArrayList<>();
+    for (Domain domain : domains) {
+      String[] domainBases = getSearchBases(domain, types);
+      if (domainBases != null) {
+        bases.addAll(Arrays.asList(domainBases));
+      }
+    }
+    return bases.toArray(new String[0]);
+  }
+
   public String[] getSearchBases(Domain domain, Set<ObjectType> types) throws ServiceException {
     String[] bases;
 
@@ -1956,6 +1967,8 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     if (options.getTypes().contains(ObjectType.habgroups)) {
       bases = new String[1];
       bases[0] = options.getHabRootGroupDn();
+    } else if (options.getMultipleBases()!= null) {
+      bases = getSearchBases(options.getMultipleBases(), types);
     } else {
       bases = getSearchBases(domain, types);
     }

--- a/store/src/main/resources/conf/attrs/attrs.xml
+++ b/store/src/main/resources/conf/attrs/attrs.xml
@@ -10151,12 +10151,18 @@ TODO: delete them permanently from here
   <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
   <desc>Whether the WS-Collaboration feature enabled for account or COS</desc>
 </attr>
+
 <attr id="3146" name="carbonioSearchAllDomainsByFeature" type="boolean" cardinality="single" optionalIn="globalConfig" since="24.9.0">
   <globalConfigValue>FALSE</globalConfigValue>
   <desc>Whether the SearchUserByFeature API should search on all domains or only the current user domain</desc>
 </attr>
-  <attr id="3147" name="carbonioSMIMESignatureVerificationEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="24.12.0">
-    <globalConfigValue>FALSE</globalConfigValue>
-    <desc>whether S/MIME signature verification is enabled.</desc>
-  </attr>
+
+<attr id="3147" name="carbonioSMIMESignatureVerificationEnabled" type="boolean" cardinality="single" optionalIn="globalConfig,server" flags="serverInherited"  since="24.12.0">
+  <globalConfigValue>FALSE</globalConfigValue>
+  <desc>whether S/MIME signature verification is enabled.</desc>
+</attr>
+
+<attr id="3148" name="carbonioSearchSpecifiedDomainsByFeature" type="string" max="256" cardinality="multi" optionalIn="domain" since="24.12.0">
+  <desc>List of domain names in which the SearchUserByFeature API should perform users searches</desc>
+</attr>
 </attrs>

--- a/store/src/test/java/com/zimbra/cs/account/AttributeManagerTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/AttributeManagerTest.java
@@ -65,6 +65,6 @@ class AttributeManagerTest {
 
   private void assertLoadedAllAttributes(AttributeManager attributeManager) {
     final Map<String, AttributeInfo> allAttrs = attributeManager.getAttrs();
-    assertEquals(1847, allAttrs.size());
+    assertEquals(1848, allAttrs.size());
   }
 }


### PR DESCRIPTION
**Feature Update:**
This update enables searching for users within specified domains, available exclusively in Carbonio (not in CE).

**Changes Made:**
**_New Attribute Added:_** `carbonioSearchSpecifiedDomainsByFeature`
   This attribute was introduced to allow conditional search behavior based on feature availability in Carbonio.
**_Modified Search Directory Options_:**
    Updated SearchDirectoryOptions to support setting multiple search bases in LDAP, enhancing flexibility in user directory searches.
