### PR TITLE
fix: DeleteAccount fails mailbox startup during bootstrap causing installation to be stuck

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.mailbox.messageBroker;
 
 public class CreateMessageBrokerException extends Exception {

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
@@ -1,0 +1,9 @@
+package com.zextras.mailbox.messageBroker;
+
+public class CreateMessageBrokerException extends Exception {
+
+	public CreateMessageBrokerException(Exception e) {
+		super("Cannot create message broker client", e);
+	}
+
+}

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
 package com.zextras.mailbox.messageBroker;
 
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
@@ -10,7 +13,6 @@ import java.nio.file.Paths;
 
 public class MessageBrokerFactory {
 	private MessageBrokerFactory() {
-		// empty
 	};
 
 	public static MessageBrokerClient getMessageBrokerClientInstance()

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -9,6 +9,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class MessageBrokerFactory {
+	private MessageBrokerFactory() {
+		// empty
+	};
 
 	public static MessageBrokerClient getMessageBrokerClientInstance()
 			throws CreateMessageBrokerException {

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -1,0 +1,35 @@
+package com.zextras.mailbox.messageBroker;
+
+import com.zextras.carbonio.message_broker.MessageBrokerClient;
+import com.zextras.carbonio.message_broker.config.enums.Service;
+import com.zextras.mailbox.client.ServiceDiscoverHttpClient;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class MessageBrokerFactory {
+
+	public static MessageBrokerClient getMessageBrokerClientInstance()
+			throws CreateMessageBrokerException {
+		Path filePath = Paths.get("/etc/carbonio/mailbox/service-discover/token");
+		String token;
+		try {
+			token = Files.readString(filePath);
+			ServiceDiscoverHttpClient serviceDiscoverHttpClient =
+					ServiceDiscoverHttpClient.defaultURL("carbonio-message-broker")
+							.withToken(token);
+
+			return MessageBrokerClient.fromConfig(
+							"127.78.0.7",
+							20005,
+							serviceDiscoverHttpClient.getConfig("default/username")
+									.getOrElse("carbonio-message-broker"),
+							serviceDiscoverHttpClient.getConfig("default/password").getOrElse("")
+					)
+					.withCurrentService(Service.MAILBOX);
+		} catch (IOException e) {
+			throw new CreateMessageBrokerException(e);
+		}
+	}
+}

--- a/store/src/main/java/com/zimbra/cs/account/callback/AccountStatus.java
+++ b/store/src/main/java/com/zimbra/cs/account/callback/AccountStatus.java
@@ -5,11 +5,9 @@
 
 package com.zimbra.cs.account.callback;
 
-import java.util.Map;
-import java.util.Set;
-
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.events.services.mailbox.UserStatusChanged;
+import com.zextras.mailbox.messageBroker.MessageBrokerFactory;
 import com.zimbra.common.account.Key;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
@@ -19,7 +17,8 @@ import com.zimbra.cs.account.AttributeCallback;
 import com.zimbra.cs.account.DistributionList;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.service.admin.AdminService;
+import java.util.Map;
+import java.util.Set;
 
 public class AccountStatus extends AttributeCallback {
 
@@ -80,11 +79,7 @@ public class AccountStatus extends AttributeCallback {
         String userId = account.getId();
 
         try {
-            MessageBrokerClient messageBrokerClient = AdminService.getMessageBrokerClientInstance();
-            if (!messageBrokerClient.healthCheck()) {
-              ZimbraLog.account.warn("Message broker is not reachable, this can happen if message broker is not installed");
-              return;
-            }
+            MessageBrokerClient messageBrokerClient = MessageBrokerFactory.getMessageBrokerClientInstance();
             boolean result = messageBrokerClient.publish(new UserStatusChanged(userId, status.toUpperCase()));
             if (result) {
                 ZimbraLog.account.info("Published status changed event for user: " + userId);

--- a/store/src/test/java/com/zextras/mailbox/callbacks/AccountStatusChangedCallbackTest.java
+++ b/store/src/test/java/com/zextras/mailbox/callbacks/AccountStatusChangedCallbackTest.java
@@ -6,12 +6,12 @@ package com.zextras.mailbox.callbacks;
 
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.events.services.mailbox.UserStatusChanged;
+import com.zextras.mailbox.messageBroker.MessageBrokerFactory;
 import com.zextras.mailbox.util.MailboxTestUtil;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.callback.AccountStatus;
 import com.zimbra.cs.account.callback.CallbackContext;
-import com.zimbra.cs.service.admin.AdminService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -33,7 +33,7 @@ class AccountStatusChangedCallbackTest {
    * This just tests that if calls are successful no other exceptions are thrown.
    */
   @Test
-  void shouldNotFailWhenExecutingUserStatusChangedCallback(){
+  void shouldNotFailWhenExecutingUserStatusChangedCallback() throws Exception {
     CallbackContext context = Mockito.mock(CallbackContext.class);
     String attrName = "fake";
     Account entry = Mockito.mock(Account.class);
@@ -43,7 +43,7 @@ class AccountStatusChangedCallbackTest {
     Mockito.when(entry.getAccountStatus(any(Provisioning.class))).thenReturn("active");
     Mockito.when(entry.getId()).thenReturn("fake-account-id");
 
-    MessageBrokerClient mockedMessageBrokerClient = AdminService.getMessageBrokerClientInstance();
+    MessageBrokerClient mockedMessageBrokerClient = MessageBrokerFactory.getMessageBrokerClientInstance();
     Mockito.when(mockedMessageBrokerClient.publish(any(UserStatusChanged.class))).thenReturn(true);
 
     accountStatus.postModify(context, attrName, entry);

--- a/store/src/test/java/com/zextras/mailbox/messageBroker/MessageBrokerFactoryTest.java
+++ b/store/src/test/java/com/zextras/mailbox/messageBroker/MessageBrokerFactoryTest.java
@@ -1,14 +1,44 @@
 package com.zextras.mailbox.messageBroker;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.vavr.control.Try;
+import java.nio.file.Files;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockserver.integration.ClientAndServer;
 
 class MessageBrokerFactoryTest {
+	private static ClientAndServer consulServer;
+
+	@BeforeAll
+	public static void startUp() throws Exception {
+		consulServer = startClientAndServer(8500);
+	}
 
 	@Test
-	void shouldFailCreatingClient_WhenConsulTokenIsMissing() throws Exception {
+	void shouldFailCreatingClient_WhenConsulTokenIsMissing() {
 		Assertions.assertThrows(CreateMessageBrokerException.class,
 				MessageBrokerFactory::getMessageBrokerClientInstance);
 	}
+
+	@Test
+	void shouldCreateClient_WhenConsulTokenProvided() throws Exception {
+		// Would avoid mock static, but we should refactor the code to avoid static methods
+		MockedStatic<Files> mockFileSystem = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS);
+		mockFileSystem.when(() -> Files.readString(any())).thenReturn("");
+		consulServer
+				.when(any())
+				.respond(response().withStatusCode(200).withBody("[" +
+						"{\"Value\": \"test\"}" +
+						"]"));
+		Assertions.assertDoesNotThrow(MessageBrokerFactory::getMessageBrokerClientInstance);
+	}
+
 
 }

--- a/store/src/test/java/com/zextras/mailbox/messageBroker/MessageBrokerFactoryTest.java
+++ b/store/src/test/java/com/zextras/mailbox/messageBroker/MessageBrokerFactoryTest.java
@@ -1,0 +1,14 @@
+package com.zextras.mailbox.messageBroker;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MessageBrokerFactoryTest {
+
+	@Test
+	void shouldFailCreatingClient_WhenConsulTokenIsMissing() throws Exception {
+		Assertions.assertThrows(CreateMessageBrokerException.class,
+				MessageBrokerFactory::getMessageBrokerClientInstance);
+	}
+
+}

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxTestUtil.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxTestUtil.java
@@ -4,7 +4,7 @@ import static com.zimbra.cs.account.Provisioning.SERVICE_MAILCLIENT;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
-import com.zextras.carbonio.message_broker.config.enums.Service;
+import com.zextras.mailbox.messageBroker.MessageBrokerFactory;
 import com.zextras.mailbox.util.InMemoryLdapServer.Builder;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.localconfig.LC;
@@ -122,8 +122,8 @@ public class MailboxTestUtil {
   private static void mockMessageBrokerClient() {
     if(mockedMessageBrokerClient == null) {
       MessageBrokerClient messageBrokerClient = Mockito.mock(MessageBrokerClient.class);
-      MockedStatic<AdminService> mockedAdminServiceStatic = Mockito.mockStatic(AdminService.class, Mockito.CALLS_REAL_METHODS);
-      mockedAdminServiceStatic.when(AdminService::getMessageBrokerClientInstance).thenReturn(messageBrokerClient);
+      MockedStatic<MessageBrokerFactory> mockedMessageBrokerFactory = Mockito.mockStatic(MessageBrokerFactory.class, Mockito.CALLS_REAL_METHODS);
+      mockedMessageBrokerFactory.when(MessageBrokerFactory::getMessageBrokerClientInstance).thenReturn(messageBrokerClient);
       mockedMessageBrokerClient = messageBrokerClient;
     }
   }

--- a/store/src/test/java/com/zimbra/cs/service/admin/AdminServiceWithFakeBrokerClient.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/AdminServiceWithFakeBrokerClient.java
@@ -1,12 +1,13 @@
 package com.zimbra.cs.service.admin;
 
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
+import io.vavr.control.Try;
 import org.mockito.Mockito;
 
 public class AdminServiceWithFakeBrokerClient extends AdminService {
 
 	@Override
-	protected MessageBrokerClient getMessageBroker() {
-		return Mockito.mock(MessageBrokerClient.class);
+	protected Try<MessageBrokerClient> getMessageBroker() {
+		return Try.of(() -> Mockito.mock(MessageBrokerClient.class));
 	}
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
@@ -8,6 +8,7 @@ import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.events.services.mailbox.UserDeleted;
 import com.zextras.mailbox.account.usecase.DeleteUserUseCase;
 import com.zextras.mailbox.acl.AclService;
+import com.zextras.mailbox.messageBroker.MessageBrokerFactory;
 import com.zextras.mailbox.util.MailboxTestUtil;
 import com.zextras.mailbox.util.MailboxTestUtil.AccountCreator;
 import com.zimbra.common.account.ZAttrProvisioning;
@@ -65,7 +66,7 @@ class DeleteAccountTest {
     final MailboxManager mailboxManager = MailboxManager.getInstance();
     provisioning = Provisioning.getInstance();
     accountCreatorFactory = new AccountCreator.Factory(provisioning);
-    mockMessageBrokerClient = AdminService.getMessageBrokerClientInstance();
+    mockMessageBrokerClient = MessageBrokerFactory.getMessageBrokerClientInstance();
     deleteAccount =
         new DeleteAccount(
             new DeleteUserUseCase(
@@ -73,7 +74,7 @@ class DeleteAccountTest {
                 mailboxManager,
                 new AclService(mailboxManager, provisioning),
                 ZimbraLog.security),
-            mockMessageBrokerClient);
+            Try.of(() -> mockMessageBrokerClient));
     provisioning.createDomain(OTHER_DOMAIN, new HashMap<>());
   }
 
@@ -319,7 +320,7 @@ class DeleteAccountTest {
         DeleteAccount deleteAccountHandler =
                 new DeleteAccount(
                         deleteUserUseCase,
-                        mockMessageBrokerClient);
+                        Try.of(() -> mockMessageBrokerClient));
         Mockito.when(deleteUserUseCase.delete(toDeleteId)).thenReturn(Try.failure(new RuntimeException("message")));
         DeleteAccountRequest deleteAccountRequest = new DeleteAccountRequest(toDeleteId);
         Element request = JaxbUtil.jaxbToElement(deleteAccountRequest);


### PR DESCRIPTION
When installing Carbonio, during bootstrap, instantiation of DeleteAccount fails, causing Mailbox to not start properly (Jetty: UNAVAILABLE) because consul token (and Consul) are not installed/available yet.

Consul and Consul tokens are available only after bootstrap, so we made the SOAP layer (Admin, DeleteAccount API) to "loosely" depend on the message broker client (opted for a Try)