### PR TITLE
feat(CO-1264): set attachment filename on attached emails

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
@@ -4,6 +4,7 @@
 
 package com.zimbra.cs.service.mail.message.parser;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.localconfig.LC;
@@ -48,6 +49,8 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.JMSession;
 import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.ZimbraSoapContext;
+import org.apache.commons.codec.net.URLCodec;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,6 +58,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -693,10 +697,15 @@ public final class ParseMimeMessage {
     } else {
       mbp.setDataHandler(new DataHandler(new MailboxBlobDataSource(msg.getBlob())));
       mbp.setHeader("Content-Type", MimeConstants.CT_MESSAGE_RFC822);
-      mbp.setHeader("Content-Disposition", Part.ATTACHMENT);
+      mbp.setHeader("Content-Disposition", Part.ATTACHMENT + ";filename*=UTF-8''" + sanitizeFileName(msg.getSubject() + ".eml\""));
     }
     mbp.setContentID(contentID);
     mmp.addBodyPart(mbp);
+  }
+
+  private static String sanitizeFileName(String filename) {
+    return new String(URLCodec.encodeUrl(new BitSet(256), filename.getBytes(Charsets.UTF_8)),
+            Charsets.ISO_8859_1);
   }
 
   private static void attachContact(MimeMultipart mmp, ItemId iid, String contentID,

--- a/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
@@ -704,8 +704,8 @@ public final class ParseMimeMessage {
   }
 
   private static String sanitizeFileName(String filename) {
-    return new String(URLCodec.encodeUrl(new BitSet(256), filename.getBytes(Charsets.UTF_8)),
-            Charsets.ISO_8859_1);
+    return new String(URLCodec.encodeUrl(new BitSet(256), filename.getBytes(StandardCharsets.UTF_8)),
+        StandardCharsets.ISO_8859_1);
   }
 
   private static void attachContact(MimeMultipart mmp, ItemId iid, String contentID,

--- a/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessage.java
@@ -4,7 +4,6 @@
 
 package com.zimbra.cs.service.mail.message.parser;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.localconfig.LC;
@@ -697,7 +696,7 @@ public final class ParseMimeMessage {
     } else {
       mbp.setDataHandler(new DataHandler(new MailboxBlobDataSource(msg.getBlob())));
       mbp.setHeader("Content-Type", MimeConstants.CT_MESSAGE_RFC822);
-      mbp.setHeader("Content-Disposition", Part.ATTACHMENT + ";filename*=UTF-8''" + sanitizeFileName(msg.getSubject() + ".eml\""));
+      mbp.setHeader("Content-Disposition", Part.ATTACHMENT + ";filename*=UTF-8''" + sanitizeFileName(msg.getSubject() + ".eml"));
     }
     mbp.setContentID(contentID);
     mmp.addBodyPart(mbp);

--- a/store/src/test/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessageTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessageTest.java
@@ -118,11 +118,11 @@ public final class ParseMimeMessageTest {
    el.addUniqueElement(MailConstants.E_MIMEPART)
        .addAttribute(MailConstants.A_CONTENT_TYPE, "text/plain")
        .addAttribute(MailConstants.E_CONTENT, "foo bar");
-   el.addElement(MailConstants.E_EMAIL)
+   el.addUniqueElement(MailConstants.E_EMAIL)
        .addAttribute(MailConstants.A_ADDRESS_TYPE, EmailType.TO.toString())
        .addAttribute(MailConstants.A_ADDRESS, "rcpt@zimbra.com");
    el.addUniqueElement(MailConstants.E_ATTACH)
-       .addElement(MailConstants.E_MSG)
+       .addUniqueElement(MailConstants.E_MSG)
        .addAttribute(MailConstants.A_ID, acct.getId() + ":" + msg.getId());
 
    rootEl.addUniqueElement(el);


### PR DESCRIPTION
Attachments to messages have a suggested filename for browsers, except for attached emails.
This PR adds a filename using the original email subject.