### PR TITLE
fix: retry consumer init if failed and handle message broker factory exceptions

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/CreateMessageBrokerException.java
@@ -10,4 +10,8 @@ public class CreateMessageBrokerException extends Exception {
 		super("Cannot create message broker client", e);
 	}
 
+	public CreateMessageBrokerException(String msg) {
+		super("Cannot create message broker client: " + msg);
+	}
+
 }

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -27,7 +27,8 @@ public class MessageBrokerFactory {
 					ServiceDiscoverHttpClient.defaultUrl()
 							.withToken(token);
 
-			return MessageBrokerClient.fromConfig(
+			MessageBrokerClient client =
+					MessageBrokerClient.fromConfig(
 							"127.78.0.7",
 							20005,
 							serviceDiscoverHttpClient.getConfig(SERVICE_NAME,"default/username")
@@ -36,7 +37,11 @@ public class MessageBrokerFactory {
 									.getOrElse("")
 					)
 					.withCurrentService(Service.MAILBOX);
-		} catch (IOException e) {
+
+			if (!client.healthCheck()) throw new RuntimeException("Message broker healthcheck failed");
+
+			return client;
+		} catch (Exception e) {
 			throw new CreateMessageBrokerException(e);
 		}
 	}

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -6,7 +6,7 @@ package com.zextras.mailbox.messageBroker;
 import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.config.enums.Service;
 import com.zextras.mailbox.client.ServiceDiscoverHttpClient;
-import java.io.IOException;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,6 +17,7 @@ public class MessageBrokerFactory {
 	private MessageBrokerFactory() {
 	};
 
+	// Returns a working and healthy MessageBrokerClient instance or throws an exception
 	public static MessageBrokerClient getMessageBrokerClientInstance()
 			throws CreateMessageBrokerException {
 		Path filePath = Paths.get("/etc/carbonio/mailbox/service-discover/token");

--- a/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
+++ b/store/src/main/java/com/zextras/mailbox/messageBroker/MessageBrokerFactory.java
@@ -20,6 +20,9 @@ public class MessageBrokerFactory {
 	// Returns a working and healthy MessageBrokerClient instance or throws an exception
 	public static MessageBrokerClient getMessageBrokerClientInstance()
 			throws CreateMessageBrokerException {
+
+		MessageBrokerClient client;
+
 		Path filePath = Paths.get("/etc/carbonio/mailbox/service-discover/token");
 		String token;
 		try {
@@ -28,7 +31,7 @@ public class MessageBrokerFactory {
 					ServiceDiscoverHttpClient.defaultUrl()
 							.withToken(token);
 
-			MessageBrokerClient client =
+			client =
 					MessageBrokerClient.fromConfig(
 							"127.78.0.7",
 							20005,
@@ -39,11 +42,11 @@ public class MessageBrokerFactory {
 					)
 					.withCurrentService(Service.MAILBOX);
 
-			if (!client.healthCheck()) throw new RuntimeException("Message broker healthcheck failed");
-
-			return client;
 		} catch (Exception e) {
 			throw new CreateMessageBrokerException(e);
 		}
+
+		if (!client.healthCheck()) throw new CreateMessageBrokerException("Message broker healthcheck failed");
+		return client;
 	}
 }

--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
@@ -68,7 +68,11 @@ public class AdminService implements DocumentService {
     // If message broker client is available, register the consumer here (not really a handler in a strict sense, but needed
     // to consume the event related to the user deletion, so I put that here to reuse deleteUserUseCase; don't know if
     // it is the best place)
-    messageBrokerClientTry.onSuccess(client -> client.consume(new DeletedUserFilesConsumer(deleteUserUseCase)));
+    messageBrokerClientTry.onSuccess(client -> {
+      if (!client.consume(new DeletedUserFilesConsumer(deleteUserUseCase))) {
+        ZimbraLog.security.warn("Failed to start consumer for DeletedUserFilesConsumer");
+      }
+    });
 
     dispatcher.registerHandler(AdminConstants.SET_PASSWORD_REQUEST, new SetPassword());
     dispatcher.registerHandler(

--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
@@ -63,8 +63,7 @@ public class AdminService implements DocumentService {
     dispatcher.registerHandler(
         AdminConstants.DELETE_ACCOUNT_REQUEST,
         new DeleteAccount(
-            deleteUserUseCase,
-            messageBrokerClientTry));
+            deleteUserUseCase));
 
     // If message broker client is available, register the consumer here (not really a handler in a strict sense, but needed
     // to consume the event related to the user deletion, so I put that here to reuse deleteUserUseCase; don't know if

--- a/store/src/main/java/com/zimbra/cs/service/admin/DeleteAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/DeleteAccount.java
@@ -12,6 +12,7 @@ import com.zextras.carbonio.message_broker.MessageBrokerClient;
 import com.zextras.carbonio.message_broker.events.services.mailbox.DeleteUserRequested;
 import com.zextras.mailbox.account.usecase.DeleteUserUseCase;
 import com.zextras.mailbox.client.ServiceDiscoverHttpClient;
+import com.zextras.mailbox.messageBroker.MessageBrokerFactory;
 import com.zimbra.common.account.Key.AccountBy;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.AdminConstants;
@@ -41,11 +42,9 @@ public class DeleteAccount extends AdminDocumentHandler {
   private static final String[] TARGET_ACCOUNT_PATH = new String[] {AdminConstants.E_ID};
 
   private final DeleteUserUseCase deleteUserUseCase;
-  private final Try<MessageBrokerClient> messageBrokerClientTry;
 
-  public DeleteAccount(DeleteUserUseCase deleteUserUseCase, Try<MessageBrokerClient> messageBrokerClientTry) {
+  public DeleteAccount(DeleteUserUseCase deleteUserUseCase) {
     this.deleteUserUseCase = deleteUserUseCase;
-    this.messageBrokerClientTry = messageBrokerClientTry;
   }
 
   @Override
@@ -146,7 +145,7 @@ public class DeleteAccount extends AdminDocumentHandler {
   private boolean publishDeleteUserRequestedEvent(Account account) {
     String userId = account.getId();
     try {
-			final MessageBrokerClient messageBrokerClient = messageBrokerClientTry.get();
+      MessageBrokerClient messageBrokerClient = MessageBrokerFactory.getMessageBrokerClientInstance();
 			boolean result = messageBrokerClient.publish(new DeleteUserRequested(userId));
       if (result) {
         ZimbraLog.account.info("Published deleted account event for user: " + userId);

--- a/store/src/main/java/com/zimbra/cs/service/admin/DeleteAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/DeleteAccount.java
@@ -26,8 +26,6 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.DeleteAccountRequest;
 import com.zimbra.soap.admin.message.DeleteAccountResponse;
 
-import io.vavr.control.Try;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
@@ -81,8 +81,7 @@ class DeleteAccountTest {
                 provisioning,
                 mailboxManager,
                 new AclService(mailboxManager, provisioning),
-                ZimbraLog.security),
-            Try.of(() -> mockMessageBrokerClient));
+                ZimbraLog.security));
     provisioning.createDomain(OTHER_DOMAIN, new HashMap<>());
 
     consulServer = startClientAndServer(8500);
@@ -348,8 +347,7 @@ class DeleteAccountTest {
         context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
         DeleteAccount deleteAccountHandler =
             new DeleteAccount(
-                deleteUserUseCase,
-                Try.of(() -> mockMessageBrokerClient));
+                deleteUserUseCase);
         Mockito.when(deleteUserUseCase.delete(toDeleteId)).thenReturn(Try.failure(new RuntimeException("message")));
         DeleteAccountRequest deleteAccountRequest = new DeleteAccountRequest(toDeleteId);
         Element request = JaxbUtil.jaxbToElement(deleteAccountRequest);


### PR DESCRIPTION
- MessageBrokerClientFactory now returns a MessageBrokerClient that is working and healthy (added generic exception handler to catch runtimes and add healthcheck call)
- DeletedUserFilesConsumer init will now be retried if it fails to handle message broker downtime on boot
- MessageBrokerClient is now created for each publish event request to handle a permanently broker client if initialized and passed on boot while message broker was down

Refs: CO-1757