### PR TITLE
refactor: deleteaccount static dependencies

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
@@ -66,7 +66,7 @@ public class AdminService implements DocumentService {
 
     dispatcher.registerHandler(
         AdminConstants.DELETE_ACCOUNT_REQUEST,
-        new DeleteAccount(deleteUserUseCase, getFilesInstalledServiceProvider()));
+        new DeleteAccount(deleteUserUseCase, getFilesInstalledServiceProvider(), () -> Try.of(MessageBrokerFactory::getMessageBrokerClientInstance).get()));
 
     // Start the consumer with retry (not really a handler in a strict sense, but needed
     // to consume the event related to the user deletion, so I put that here to reuse deleteUserUseCase; don't know if

--- a/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/AdminService.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * @zm-service-description The Admin Service includes commands for server, account and mailbox
@@ -66,7 +67,7 @@ public class AdminService implements DocumentService {
 
     dispatcher.registerHandler(
         AdminConstants.DELETE_ACCOUNT_REQUEST,
-        new DeleteAccount(deleteUserUseCase, getFilesInstalledServiceProvider(), () -> Try.of(MessageBrokerFactory::getMessageBrokerClientInstance).get()));
+        new DeleteAccount(deleteUserUseCase, getFilesInstalledServiceProvider(), getMessageBrokerClientProvider()));
 
     // Start the consumer with retry (not really a handler in a strict sense, but needed
     // to consume the event related to the user deletion, so I put that here to reuse deleteUserUseCase; don't know if
@@ -125,10 +126,6 @@ public class AdminService implements DocumentService {
     dispatcher.registerHandler(AdminConstants.PURGE_MESSAGES_REQUEST, new PurgeMessages());
     dispatcher.registerHandler(AdminConstants.DELETE_MAILBOX_REQUEST, new DeleteMailbox());
     dispatcher.registerHandler(AdminConstants.GET_MAILBOX_REQUEST, new GetMailbox());
-
-    // TODO: check if this is required here, we have moved it to package com.zimbra.qa.service.admin
-    // for now to remove dependency of qa package from store module
-    // dispatcher.registerHandler(AdminConstants.RUN_UNIT_TESTS_REQUEST, new RunUnitTests());
 
     dispatcher.registerHandler(AdminConstants.CHECK_AUTH_CONFIG_REQUEST, new CheckAuthConfig());
     dispatcher.registerHandler(AdminConstants.CHECK_GAL_CONFIG_REQUEST, new CheckGalConfig());
@@ -406,6 +403,10 @@ public class AdminService implements DocumentService {
 
   protected ServiceInstalledProvider getFilesInstalledServiceProvider() {
     return new FilesInstalledProvider(Paths.get("/etc/carbonio/mailbox/service-discover/token"));
+  }
+
+  protected Supplier<MessageBrokerClient> getMessageBrokerClientProvider() {
+    return () -> Try.of(MessageBrokerFactory::getMessageBrokerClientInstance).get();
   }
 
   private void scheduleConsumer(MessageBrokerClient client, DeleteUserUseCase deleteUserUseCase) {

--- a/store/src/test/java/com/zextras/mailbox/util/SoapClient.java
+++ b/store/src/test/java/com/zextras/mailbox/util/SoapClient.java
@@ -4,6 +4,7 @@
 
 package com.zextras.mailbox.util;
 
+import com.zextras.mailbox.soap.SoapUtils;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.SoapProtocol;
@@ -60,6 +61,9 @@ public class SoapClient implements Closeable {
     client.close();
   }
 
+  public record SoapResponse(int statusCode, String body) {
+  }
+
   public static class Request {
 
     private final BasicCookieStore cookieStore;
@@ -110,6 +114,11 @@ public class SoapClient implements Closeable {
       httpPost.setURI(URI.create(this.url));
       httpPost.setEntity(createEnvelop());
       return client.execute(httpPost);
+    }
+
+    public SoapResponse call() throws Exception {
+      final HttpResponse httpResponse = this.execute();
+      return new SoapResponse(httpResponse.getStatusLine().getStatusCode(),SoapUtils.getResponse(httpResponse));
     }
 
     private StringEntity createEnvelop() throws XmlParseException, UnsupportedEncodingException {

--- a/store/src/test/java/com/zimbra/cs/service/admin/AdminServiceWithFilesInstalled.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/AdminServiceWithFilesInstalled.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package com.zimbra.cs.service.admin;
+
+import com.zextras.carbonio.message_broker.MessageBrokerClient;
+import com.zextras.carbonio.message_broker.config.enums.Service;
+import com.zextras.mailbox.client.ServiceInstalledProvider;
+import java.util.function.Supplier;
+
+public class AdminServiceWithFilesInstalled extends AdminService {
+
+	public static final int MESSAGE_BROKER_PORT = 20005;
+	public static final String MESSAGE_BROKER_USERNAME = "test";
+	public static final String MESSAGE_BROKER_PASSWORD = "test";
+	public static final String MESSAGE_BROKER_IMAGE = "rabbitmq:3.7.25-management-alpine";
+
+	@Override
+	protected ServiceInstalledProvider getFilesInstalledServiceProvider() {
+		return () -> true;
+	}
+
+	@Override
+	protected Supplier<MessageBrokerClient> getMessageBrokerClientProvider() {
+		return () -> MessageBrokerClient.fromConfig("127.0.0.1", MESSAGE_BROKER_PORT, "guest", MESSAGE_BROKER_PASSWORD).withCurrentService(
+				Service.MAILBOX);
+	}
+}


### PR DESCRIPTION
The main goal of these changes is to add a MessageBrokerClient provider to the DeleteAccount API.
The reason a provider is needed is because in order to instantiate a connection to the message broker we need the consul token, which might not be available depending on the status of the installation. Also the connection is renewed every time.

Along this change, which removes static code, I have added some tests that document the current behavior as I thought we lacked them, so most of the changed files are about testing.