### PR TITLE
fix: [CO-1783] remove mailbox permission to access files healthcheck

### DIFF
--- a/packages/appserver-service/carbonio-mailbox-policies.json
+++ b/packages/appserver-service/carbonio-mailbox-policies.json
@@ -23,9 +23,6 @@
       },
       "carbonio-mailbox-sidecar-proxy": {
         "policy": "write"
-      },
-      "carbonio-files": {
-        "policy": "read"
       }
     }
   ]


### PR DESCRIPTION
- this will result in files to appear as "not installed" to mailbox, so no delete event is published during account delete and the user will be immediately deleted