### PR TITLE
refactor: [CO-1826] classify and give mailbox ports a proper name

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
+++ b/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
@@ -159,7 +159,7 @@ public class MailboxAPIs {
 
 
 		soapServlet.setInitParameter(
-				allowedPortsParameter, mailPort + ", " + mailSSLPort + ", " + defaultUserHttpPor
+				allowedPortsParameter, mailPort + ", " + mailSSLPort + ", " + defaultUserHttpPort
 						+ ", " + defaultUserHttpsPort);
 		soapServlet.setInitParameter("engine.handler.0", AccountService.class.getName());
 		soapServlet.setInitParameter("engine.handler.1", MailService.class.getName());

--- a/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
+++ b/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
@@ -125,13 +125,10 @@ public class MailboxAPIs {
 	}
 
 	private void addServlets(ServletContextHandler servletContextHandler) {
-		// See for example: https://github.com/zextras/carbonio-mailbox/blob/1b5290416ccb6298f3504c2736b8f0587910150d/store/conf/web.xml.production#L244
-		// user ports: 7070, 7443 (default) + customMailPort, customMailSSLPort
-		// admin ports: 7071 (admin), 7073 (mtaAuth) + customAdminPort, customMtaAuthPort
 		final String adminPortOnly = String.valueOf(server.getAdminPort());
 		final String adminAndMTAPort = adminPortOnly + ", " + server.getMtaAuthPort();
-		final String userAndAdminPorts = server.getMailPort() + ", " + server.getMailSSLPort() + ", " + adminPortOnly;
 		final String userOnlyPorts = server.getMailPort() + ", " + server.getMailSSLPort();
+		final String userAndAdminPorts = server.getMailPort() + ", " + server.getMailSSLPort() + ", " + adminPortOnly;
 
 		final var firstServlet = new ServletHolder(FirstServlet.class);
 		firstServlet.setInitOrder(1);
@@ -152,8 +149,6 @@ public class MailboxAPIs {
 		final var soapServlet = new ServletHolder(SoapServlet.class);
 		soapServlet.setAsyncSupported(true);
 		soapServlet.setInitOrder(2);
-
-
 		soapServlet.setInitParameter(
 				allowedPortsParameter, userOnlyPorts);
 		soapServlet.setInitParameter("engine.handler.0", AccountService.class.getName());


### PR DESCRIPTION
While converting web.xml to servlets I found some static ports were configured statically in the original web.xml, in addition to dinamically configured ports coming from LDAP attributes. 
These values are used to determine which API calls are accepted based on port.
For example, while the standard soap servlet technically binds also at adminPort, it cannot receive any request on it, because allowed ports is only mailPort + mailSSLPort and not adminPort. This logic is managed by the parameter "allowed.ports", defined in the parent class ZimbraServlet. 

The static allowed ports are:
- 7071, 7073, 7070, 7443

Since Mailbox binds only on ports defined in LDAP config, these static values are not needed. 
While extracting the ports into variables I was able to classify mailbox APIs in these group:

- APIs that allow requests on user ports only (mailPort + mailSSLPort -> user SoapServlet, DavServlet, DavWellKnown, Extensionservlet, Proxyservlet)
- APIs that allow request on admin port only (adminPort -> statsImageServlet, collectLdapConfig and collectConfigFiles)
- APIs that run on admin and mta ports only (adminPort + mtaAuth -> admin SOAP APIs)
- APIs that run on admin + user ports (adminPort+ mailPort + mailSSLPort -> all the other)