### PR TITLE
fix: [CO-1848] skip imap UI id range search

### DIFF
--- a/common/src/main/java/com/zimbra/common/localconfig/LC.java
+++ b/common/src/main/java/com/zimbra/common/localconfig/LC.java
@@ -1345,6 +1345,8 @@ public final class LC {
   public static final KnownKey zimbra_imap_folder_pagination_enabled = KnownKey.newKey(false);
   // imap different message size than postfix mta ( useful for import )
   public static final KnownKey imap_max_message_size = KnownKey.newKey(null);
+  // imap uid range search
+  public static final KnownKey ignore_imap_uid_range_search = KnownKey.newKey(true);
   // unsubscribe folder creation enabled
   public static final KnownKey zimbra_feature_safe_unsubscribe_folder_enabled =
       KnownKey.newKey(false);

--- a/store/src/main/java/com/zimbra/cs/imap/ImapSearch.java
+++ b/store/src/main/java/com/zimbra/cs/imap/ImapSearch.java
@@ -26,7 +26,6 @@ abstract class ImapSearch {
     protected boolean requiresMODSEQ()  { return false; }
     // Pattern to match UID range search in the format "1:x,y:*", e.g., "1:100,200:*"
     private static final String UID_SEARCH_PATTERN = "^1:(\\d+),(\\d+):\\*$";
-    private static final boolean isUidRangeSearchIgnored = LC.ignore_imap_uid_range_search.booleanValue();
 
     protected static boolean isAllMessages(ImapFolder i4folder, Set<ImapMessage> i4set) {
         int size = i4set.size() - (i4set.contains(null) ? 1 : 0);
@@ -162,9 +161,10 @@ abstract class ImapSearch {
         protected String toZimbraSearch(ImapFolder i4folder) throws ImapParseException {
             StringBuilder search = new StringBuilder("(");
             Pattern compiledUidPattern = Pattern.compile(UID_SEARCH_PATTERN);
+            boolean ignoreImapUidRangeSearch = LC.ignore_imap_uid_range_search.booleanValue();
             for (ImapSearch i4search : mChildren) {
                 if (i4search instanceof SequenceSearch
-                        && isUidRangeSearchIgnored
+                        && ignoreImapUidRangeSearch
                         && null != ((SequenceSearch) i4search).mSubSequence
                         && compiledUidPattern.matcher(((SequenceSearch) i4search).mSubSequence).find()) {
                     continue;

--- a/store/src/main/java/com/zimbra/cs/imap/ImapSearch.java
+++ b/store/src/main/java/com/zimbra/cs/imap/ImapSearch.java
@@ -163,10 +163,10 @@ abstract class ImapSearch {
             Pattern compiledUidPattern = Pattern.compile(UID_SEARCH_PATTERN);
             boolean ignoreImapUidRangeSearch = LC.ignore_imap_uid_range_search.booleanValue();
             for (ImapSearch i4search : mChildren) {
-                if (i4search instanceof SequenceSearch
+                if (i4search instanceof SequenceSearch sequenceSearch
                         && ignoreImapUidRangeSearch
-                        && null != ((SequenceSearch) i4search).mSubSequence
-                        && compiledUidPattern.matcher(((SequenceSearch) i4search).mSubSequence).find()) {
+                        && null != sequenceSearch.mSubSequence
+                        && compiledUidPattern.matcher(sequenceSearch.mSubSequence).find()) {
                     continue;
                 }
                 search.append(search.length() == 1 ? "" : " ").append(i4search.toZimbraSearch(i4folder));

--- a/store/src/test/java/com/zimbra/cs/imap/ImapSearchTest.java
+++ b/store/src/test/java/com/zimbra/cs/imap/ImapSearchTest.java
@@ -1,0 +1,46 @@
+package com.zimbra.cs.imap;
+
+import com.zimbra.common.localconfig.LC;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+class ImapSearchTest {
+
+    public static final String SEARCH = "1:123,456:*";
+
+    @AfterEach
+    void tearDown() {
+        LC.ignore_imap_uid_range_search.setDefault(true);
+    }
+
+    @Test
+    void test_when_search_range_true_and_other_checks_true_then_not_append() throws Exception {
+        LC.ignore_imap_uid_range_search.setDefault(true);
+        ImapSearch.SequenceSearch sequenceSearch = Mockito.mock(ImapSearch.SequenceSearch.class);
+        Field mSubSequence = ImapSearch.SequenceSearch.class.getDeclaredField("mSubSequence");
+        mSubSequence.setAccessible(true);
+        mSubSequence.set(sequenceSearch, SEARCH);
+        ImapSearch.AndOperation andOperation = new ImapSearch.AndOperation(sequenceSearch);
+        ImapFolder i4folder = Mockito.mock();
+        Mockito.when(i4folder.getSubsequence(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(Mockito.mock());
+        andOperation.toZimbraSearch(i4folder);
+        Mockito.verify(sequenceSearch, Mockito.times(0)).toZimbraSearch(i4folder);
+    }
+
+    @Test
+    void test_when_search_range_false_and_other_checks_true_then_append() throws Exception {
+        LC.ignore_imap_uid_range_search.setDefault(false);
+        ImapSearch.SequenceSearch sequenceSearch = Mockito.mock(ImapSearch.SequenceSearch.class);
+        Field mSubSequence = ImapSearch.SequenceSearch.class.getDeclaredField("mSubSequence");
+        mSubSequence.setAccessible(true);
+        mSubSequence.set(sequenceSearch, SEARCH);
+        ImapSearch.AndOperation andOperation = new ImapSearch.AndOperation(sequenceSearch);
+        ImapFolder i4folder = Mockito.mock();
+        Mockito.when(i4folder.getSubsequence(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(Mockito.mock());
+        andOperation.toZimbraSearch(i4folder);
+        Mockito.verify(sequenceSearch, Mockito.times(1)).toZimbraSearch(i4folder);
+    }
+}


### PR DESCRIPTION
* Back merge of https://github.com/Zimbra/zm-mailbox/commit/893158f277aefd089bbe466eaee8377606681357