### PR TITLE
test: run soap, client and common tests in parallel

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,6 +29,7 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -88,10 +89,6 @@
         <configuration>
           <forkMode>always</forkMode>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -65,14 +65,6 @@
       <groupId>org.bouncycastle</groupId>
     </dependency>
 
-    <!--    TODO: fix this, we will locally use the compiled jar to bypass this failure-->
-    <!--    <dependency>-->
-    <!--      &lt;!&ndash;TODO: we are using 0.9.16-patched in our production&ndash;&gt;-->
-    <!--      <artifactId>ical4j</artifactId>-->
-    <!--      <groupId>ical4j</groupId>-->
-    <!--      <version>0.9.16-patched</version>-->
-    <!--    </dependency>-->
-
     <dependency>
       <artifactId>ical4j</artifactId>
       <groupId>ical4j</groupId>
@@ -235,13 +227,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkMode>always</forkMode>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -791,6 +791,12 @@
 
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
+    <test.argLine>
+      -Dserver.dir=${project.basedir}
+      -Djunit.jupiter.execution.parallel.enabled=true
+      -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
+      -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
+    </test.argLine>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.56.v20240826</jetty.version>
@@ -940,14 +946,11 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M7</version>
           <configuration>
+            <forkCount>4</forkCount>
             <threadCount>4</threadCount>
             <reuseForks>false</reuseForks>
-            <parallel>classes</parallel>
-            <argLine>-Dserver.dir=${project.basedir}
-              -Djunit.jupiter.execution.parallel.enabled=true
-              -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
-              -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
-            </argLine>
+            <parallel>both</parallel>
+            <argLine>${test.argLine}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -955,14 +958,12 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.0.0-M7</version>
           <configuration>
-            <parallel>classes</parallel>
-            <reuseForks>false</reuseForks>
             <forkCount>4</forkCount>
+            <threadCount>4</threadCount>
+            <parallel>both</parallel>
+            <reuseForks>false</reuseForks>
             <!-- argline preserves other plugin args, like JaCoCo -->
-            <argLine>-Dserver.dir=${project.basedir}
-              -Djunit.jupiter.execution.parallel.enabled=true
-              -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
-              -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
+            <argLine>${test.argLine}
             </argLine>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.0</version>
+        <version>5.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
@@ -940,10 +940,10 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M7</version>
           <configuration>
-            <threadCount>16</threadCount>
+            <threadCount>4</threadCount>
             <reuseForks>false</reuseForks>
             <parallel>classes</parallel>
-            <argLine>@{argLine} -Dserver.dir=${project.basedir}
+            <argLine>-Dserver.dir=${project.basedir}
               -Djunit.jupiter.execution.parallel.enabled=true
               -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
               -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
@@ -959,7 +959,7 @@
             <reuseForks>false</reuseForks>
             <forkCount>4</forkCount>
             <!-- argline preserves other plugin args, like JaCoCo -->
-            <argLine>@{argLine} -Dserver.dir=${project.basedir}
+            <argLine>-Dserver.dir=${project.basedir}
               -Djunit.jupiter.execution.parallel.enabled=true
               -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
               -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -106,13 +106,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkMode>always</forkMode>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- remove jacoco and custom surefire configuration from client, soap and common modules (enables parallel testing on these modules)
- bump easymock to 5.2.0 to avoid reflection issues (jdk 17+ compatibility)