### PR TITLE
chore: check jacoco coverage

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -84,6 +84,10 @@
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -225,6 +225,10 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -950,7 +950,7 @@
             <threadCount>4</threadCount>
             <reuseForks>false</reuseForks>
             <parallel>both</parallel>
-            <argLine>${test.argLine}</argLine>
+            <argLine>@{argLine} ${test.argLine}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -963,8 +963,7 @@
             <parallel>both</parallel>
             <reuseForks>false</reuseForks>
             <!-- argline preserves other plugin args, like JaCoCo -->
-            <argLine>${test.argLine}
-            </argLine>
+            <argLine>@{argLine}${test.argLine}</argLine>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -963,7 +963,7 @@
             <parallel>both</parallel>
             <reuseForks>false</reuseForks>
             <!-- argline preserves other plugin args, like JaCoCo -->
-            <argLine>@{argLine}${test.argLine}</argLine>
+            <argLine>@{argLine} ${test.argLine}</argLine>
           </configuration>
           <executions>
             <execution>

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -104,6 +104,10 @@
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
Just checking if Sonar is using the default jacoco path to collect coverage or is using junit.xml reports.

Note from the CI:

'sonar.coverage.jacoco.xmlReportPaths' is not defined. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml

So by default it uses target/site/jacoco/jacoico.xml, hence Jacoco is mandatory to collect coverage