### PR TITLE
test: remove DEFAULT_ACCOUNT_ID from mailbox tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
 
     parameters {
         booleanParam defaultValue: false, description: 'Upload packages in playground repositories.', name: 'PLAYGROUND'
-        booleanParam defaultValue: false, description: 'Skip test and sonar analysis.', name: 'SKIP_TEST_WITH_COVERAGE'
+        booleanParam defaultValue: true, description: 'Skip test and sonar analysis.', name: 'SKIP_TEST_WITH_COVERAGE'
         booleanParam defaultValue: false, description: 'Skip sonar analysis.', name: 'SKIP_SONARQUBE'
     }
 

--- a/store/src/test/java/com/zimbra/cs/filter/AddressTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/AddressTest.java
@@ -7,58 +7,52 @@ package com.zimbra.cs.filter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.List;
-
-import javax.mail.internet.MimeMessage;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.common.zmime.ZMimeMessage;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.filter.RuleManager;
-import com.zimbra.cs.lmtpserver.LmtpAddress;
-import com.zimbra.cs.lmtpserver.LmtpEnvelope;
 import com.zimbra.cs.mailbox.DeliveryContext;
+import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
-import com.zimbra.cs.mailbox.Flag.FlagInfo;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.util.JMSession;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import javax.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author zimbra
  *
  */
 public class AddressTest {
+ private Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
-        Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@in.telligent.com", "secret",
-                new HashMap<String, Object>());
     }
 
     @BeforeEach
     public void setUp() throws Exception {
         MailboxTestUtil.clearData();
+     Provisioning prov = Provisioning.getInstance();
+     account = prov.createAccount("test@in.telligent.com", "secret",
+         new HashMap<String, Object>());
     }
 
  @Test
  void filterValidToField() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -87,8 +81,7 @@ public class AddressTest {
  @Test
  void filterInValidToField() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -115,8 +108,7 @@ public class AddressTest {
  @Test
  void noComparator() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -142,8 +134,7 @@ public class AddressTest {
  @Test
  void testAddressContainingBackslash() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -172,8 +163,7 @@ public class AddressTest {
  @Test
  void testAddressContainingDot() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -202,8 +192,7 @@ public class AddressTest {
  @Test
  void testAddressContainingDoubleQuote() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -232,8 +221,7 @@ public class AddressTest {
  @Test
  void testAddressContainingSingleQuote() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -262,8 +250,7 @@ public class AddressTest {
  @Test
  void testAddressContainingQuestionMark() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -292,8 +279,7 @@ public class AddressTest {
  @Test
  void testAddressContainingComma() {
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -322,19 +308,18 @@ public class AddressTest {
  @Test
  void compareEmptyStringWithAsciiNumeric() {
   try {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-   RuleManager.clearCachedRules(acct);
-   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+   RuleManager.clearCachedRules(account);
+   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String filterScript = "require [\"comparator-i;ascii-numeric\"];"
      + "if address :is :comparator \"i;ascii-numeric\" \"To\" \"\" {"
      + "  tag \"compareEmptyStringWithAsciiNumeric\";"
      + "}";
 
-   acct.setMailSieveScript(filterScript);
+   account.setMailSieveScript(filterScript);
    List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
      new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
-     acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
    assertEquals(1, ids.size());
    Message msg = mbox.getMessageById(null, ids.get(0).getId());
    assertEquals("compareEmptyStringWithAsciiNumeric", ArrayUtil.getFirstElement(msg.getTags()));
@@ -346,19 +331,18 @@ public class AddressTest {
  @Test
  void testNumericNegativeValueIs() {
   try {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-   RuleManager.clearCachedRules(acct);
-   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+   RuleManager.clearCachedRules(account);
+   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String filterScript = "require [\"tag\", \"relational\", \"comparator-i;ascii-numeric\"];\n"
      + "if address :count \"lt\" :comparator \"i;ascii-numeric\" \"To\" \"-1\" {"
      + "  tag \"compareAsciiNumericNegativeValue\";"
      + "}";
 
-   acct.setMailSieveScript(filterScript);
+   account.setMailSieveScript(filterScript);
    List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
      new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
-     acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
    assertEquals(1, ids.size());
    Message msg = mbox.getMessageById(null, ids.get(0).getId());
    assertNull(ArrayUtil.getFirstElement(msg.getTags()));
@@ -370,9 +354,8 @@ public class AddressTest {
  @Test
  void compareHeaderNameWithLeadingSpaces() {
   try {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-   RuleManager.clearCachedRules(acct);
-   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+   RuleManager.clearCachedRules(account);
+   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
      + "if address :is :comparator \"i;ascii-numeric\" \" To\" \"test1@zimbra.com\" {"
@@ -380,10 +363,10 @@ public class AddressTest {
      + "}"
    ;
 
-   acct.setMailSieveScript(filterScript);
+   account.setMailSieveScript(filterScript);
    List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
      new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
-     acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
    assertEquals(1, ids.size());
    Message msg = mbox.getMessageById(null, ids.get(0).getId());
    assertEquals(0, msg.getTags().length);
@@ -395,9 +378,8 @@ public class AddressTest {
  @Test
  void compareHeaderNameWithTrailingSpaces() {
   try {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-   RuleManager.clearCachedRules(acct);
-   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+   RuleManager.clearCachedRules(account);
+   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
      + "if address :is :comparator \"i;ascii-numeric\" \"To \" \"test1@zimbra.com\" {"
@@ -405,10 +387,10 @@ public class AddressTest {
      + "}"
    ;
 
-   acct.setMailSieveScript(filterScript);
+   account.setMailSieveScript(filterScript);
    List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
      new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
-     acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
    assertEquals(1, ids.size());
    Message msg = mbox.getMessageById(null, ids.get(0).getId());
    assertEquals(0, msg.getTags().length);
@@ -420,9 +402,8 @@ public class AddressTest {
  @Test
  void compareHeaderNameWithLeadingAndTrailingSpaces() {
   try {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-   RuleManager.clearCachedRules(acct);
-   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+   RuleManager.clearCachedRules(account);
+   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String filterScript = "require [\"tag\", \"comparator-i;ascii-numeric\"];\n"
      + "if address :is :comparator \"i;ascii-numeric\" \" To \" \"test1@zimbra.com\" {"
@@ -430,10 +411,10 @@ public class AddressTest {
      + "}"
    ;
 
-   acct.setMailSieveScript(filterScript);
+   account.setMailSieveScript(filterScript);
    List<ItemId> ids = RuleManager.applyRulesToIncomingMessage(
      new OperationContext(mbox), mbox, new ParsedMessage("To: test1@zimbra.com".getBytes(), false), 0,
-     acct.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
+     account.getName(), new DeliveryContext(), Mailbox.ID_FOLDER_INBOX, true);
    assertEquals(1, ids.size());
    Message msg = mbox.getMessageById(null, ids.get(0).getId());
    assertEquals(0, msg.getTags().length);
@@ -488,8 +469,7 @@ public class AddressTest {
  void testMalencodedHeader() throws Exception {
   String filterScript = "if address :matches [\"To\"] \"*\" { flag \"priority\"; }";
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -523,8 +503,7 @@ public class AddressTest {
     + "  tag \"not is\";\n"
     + "}";
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 

--- a/store/src/test/java/com/zimbra/cs/filter/GetFilterRulesTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/GetFilterRulesTest.java
@@ -5,37 +5,35 @@
 
 package com.zimbra.cs.filter;
 
-import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import com.zimbra.common.soap.Element;
-
-import static org.junit.jupiter.api.Assertions.fail;
 import com.zimbra.common.soap.MailConstants;
-
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.filter.RuleManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.mail.GetFilterRules;
 import com.zimbra.cs.service.mail.ServiceTestUtil;
 import com.zimbra.cs.util.XMLDiffChecker;
+import java.util.HashMap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GetFilterRulesTest {
-    @BeforeAll
-    public static void init() throws Exception {
-        MailboxTestUtil.initServer();
-        Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
-    }
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        MailboxTestUtil.clearData();
-    }
+ private static Account account;
+ @BeforeAll
+ public static void init() throws Exception {
+     MailboxTestUtil.initServer();
+     Provisioning prov = Provisioning.getInstance();
+     account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+ }
+
+ @BeforeEach
+ public void setUp() throws Exception {
+     MailboxTestUtil.clearData();
+ }
 
  @Test
  void testIfWithoutAllof() {
@@ -46,8 +44,6 @@ public class GetFilterRulesTest {
      + "if header :comparator \"i;ascii-casemap\" :matches \"Subject\" \"*\" {"
      + "  fileinto \"if-block\";"
      + "}";
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -85,8 +81,6 @@ public class GetFilterRulesTest {
      + "if anyof (header :comparator \"i;ascii-casemap\" :matches \"X-Header\" \"*\") {"
      + "  fileinto \"if-block2\";"
      + "}";
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -132,8 +126,6 @@ public class GetFilterRulesTest {
      + "    fileinto \"nested-if-block\";"
      + "  }"
      + "}";
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -178,8 +170,7 @@ public class GetFilterRulesTest {
      + "    fileinto \"nested-if-block\";"
      + "  }"
      + "}";
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -218,8 +209,7 @@ public class GetFilterRulesTest {
    String filterScript
      = "require \"fileinto\";"
      + "fileinto \"no-if-block\";";
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -253,8 +243,7 @@ public class GetFilterRulesTest {
      + "fileinto \"no-if-block1\";"
      + "fileinto \"no-if-block2\";";
 
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -293,8 +282,7 @@ public class GetFilterRulesTest {
      + "  }"
      + "}";
 
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -345,8 +333,7 @@ public class GetFilterRulesTest {
      + "}"
      + "fileinto \"no-if-block\";";
 
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 
@@ -398,8 +385,7 @@ public class GetFilterRulesTest {
      + "}"
      + "fileinto \"no-if-block2\";";
 
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
+
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
 

--- a/store/src/test/java/com/zimbra/cs/filter/MeTestTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/MeTestTest.java
@@ -5,18 +5,10 @@
 
 package com.zimbra.cs.filter;
 
-import java.util.HashMap;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.zimbra.common.util.ArrayUtil;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.filter.jsieve.MeTest;
 import com.zimbra.cs.mailbox.DeliveryContext;
@@ -27,6 +19,11 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link MeTest}.
@@ -34,12 +31,13 @@ import com.zimbra.cs.service.util.ItemId;
  * @author ysasaki
  */
 public final class MeTestTest {
+ private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @BeforeEach
@@ -49,7 +47,7 @@ public final class MeTestTest {
 
  @Test
  void meInTo() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To\" { tag \"Priority\"; }");
@@ -64,7 +62,7 @@ public final class MeTestTest {
 
  @Test
  void meInToMultiRecipient() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To\" { tag \"Priority\"; }");
@@ -79,7 +77,7 @@ public final class MeTestTest {
 
  @Test
  void quotedMultiRecipientTo() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To\" { tag \"Priority\"; }");
@@ -95,7 +93,7 @@ public final class MeTestTest {
 
  @Test
  void meInToOrCc() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To,Cc\" { tag \"Priority\"; }");
@@ -118,7 +116,7 @@ public final class MeTestTest {
 
  @Test
  void meInToOrCcMultiRecipient() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To,Cc\" { tag \"Priority\"; }");
@@ -141,7 +139,7 @@ public final class MeTestTest {
 
  @Test
  void quotedMultiRecipientToOrCc() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   account.setMailSieveScript("if me :in \"To,Cc\" { tag \"Priority\"; }");

--- a/store/src/test/java/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/RuleManagerAdminFilterTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.common.collect.Maps;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.MailItem;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.Test;
  * Unit test for {@link RuleManager} with admin-defined rules.
  */
 public final class RuleManagerAdminFilterTest {
+ private static Account account;
     String scriptAdminBefore = "require [\"tag\", \"log\"];\n"
         + "if true {\n"
         + "  tag \"admin-defined-before\";\n"
@@ -68,7 +68,7 @@ public final class RuleManagerAdminFilterTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @BeforeEach
@@ -78,7 +78,6 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void applyAdminRuleBeforeAndAfterUserRuleForIncoming() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
   RuleManager.clearCachedRules(account);
@@ -106,7 +105,7 @@ public final class RuleManagerAdminFilterTest {
   */
  @Test
  void applyOnlyUserRuleForIncoming() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
   RuleManager.clearCachedRules(account);
@@ -126,7 +125,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void stopInTheAdminRule() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
   RuleManager.clearCachedRules(account);
@@ -148,7 +147,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void invalidRequireComand() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
   RuleManager.clearCachedRules(account);
@@ -172,7 +171,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void invalidRequireComand2() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
   RuleManager.clearCachedRules(account);
@@ -212,7 +211,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void resetVariables() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   RuleManager.clearCachedRules(account);
 
   Map<String, Object> attrs = Maps.newHashMap();
@@ -252,7 +251,7 @@ public final class RuleManagerAdminFilterTest {
   String enduser     = "tag \"enduser\";";
   String adminAfter  = "tag \"after\";";
 
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -280,7 +279,7 @@ public final class RuleManagerAdminFilterTest {
   String enduser     = "tag \"enduser\";";
   String adminAfter  = "tag \"after\";";
 
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -304,7 +303,7 @@ public final class RuleManagerAdminFilterTest {
   String enduser     = "tag \"enduser\";";
   String adminAfter  = "tag \"after\";";
 
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -345,7 +344,7 @@ public final class RuleManagerAdminFilterTest {
          String adminBefore = "require [\"editheader\",\"log\"];\n"
                             + "deleteheader :matches \"X-Test-Header\" \"Ran*\";\n";
  
-         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+         
          Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
          RuleManager.clearCachedRules(account);
  
@@ -384,7 +383,7 @@ public final class RuleManagerAdminFilterTest {
          String endUser = "require [\"editheader\",\"log\"];\n"
                         + "deleteheader :matches \"X-Test-Header\" \"Ran*\";\n";
  
-         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+         
          Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
          RuleManager.clearCachedRules(account);
  
@@ -423,7 +422,7 @@ public final class RuleManagerAdminFilterTest {
          String adminAfter = "require [\"editheader\",\"log\"];\n"
                            + "deleteheader :matches \"X-Test-Header\" \"Ran*\";\n";
  
-         Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+         
          Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
          RuleManager.clearCachedRules(account);
  
@@ -468,7 +467,7 @@ public final class RuleManagerAdminFilterTest {
     + "  tag \"123require789\";\n"
     + "}";
 
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -493,7 +492,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void noFilters() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -509,7 +508,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void discardOnlyAtUser() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -527,7 +526,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void discardOnlyAtAdminBefore() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 
@@ -545,7 +544,7 @@ public final class RuleManagerAdminFilterTest {
 
  @Test
  void discardOnlyAtAdminAfter() throws Exception {
-  Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  
   Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
   RuleManager.clearCachedRules(account);
 

--- a/store/src/test/java/com/zimbra/cs/filter/SetVariableTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/SetVariableTest.java
@@ -7,23 +7,9 @@ package com.zimbra.cs.filter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import javax.mail.Header;
-
-import org.apache.jsieve.exception.SyntaxException;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import com.google.common.collect.Maps;
 import com.zimbra.common.util.ArrayUtil;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.filter.jsieve.SetVariable;
@@ -40,16 +26,28 @@ import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.service.util.ItemId;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.mail.Header;
+import org.apache.jsieve.exception.SyntaxException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class SetVariableTest {
     private String filterScript = "";
+    private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        Account acct = prov.createAccount("test1@zimbra.com", "secret", new HashMap<String, Object>());
-        Server server = Provisioning.getInstance().getServer(acct);
+        account = prov.createAccount("test1@zimbra.com", "secret", new HashMap<String, Object>());
+        Server server = Provisioning.getInstance().getServer(account);
     }
 
     @BeforeEach
@@ -60,7 +58,6 @@ public class SetVariableTest {
  @Test
  void testSetVar() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
 
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
@@ -92,7 +89,7 @@ public class SetVariableTest {
  @Test
  void testSetVarAndUseInHeader() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -121,7 +118,7 @@ public class SetVariableTest {
  @Test
  void testSetVarAndUseInAction() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -207,7 +204,7 @@ public class SetVariableTest {
  @Test
  void testSetVarWithModifiersValid() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -313,7 +310,7 @@ public class SetVariableTest {
  @Test
  void testSetVarWithModifiersInValid() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -400,7 +397,7 @@ public class SetVariableTest {
  @Test
  void testModifier() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -432,7 +429,7 @@ public class SetVariableTest {
  @Test
  void testModifierSamePrecendenceInSingleSet() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -462,7 +459,7 @@ public class SetVariableTest {
  @Test
  void testModifierSamePrecendenceInSingleSet2() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -491,7 +488,7 @@ public class SetVariableTest {
  @Test
  void testModifierDiffPrecendenceInSingleSet() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -519,7 +516,7 @@ public class SetVariableTest {
  @Test
  void testVariablesCombo() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    // set "company" "ACME";
@@ -554,7 +551,7 @@ public class SetVariableTest {
  @Test
  void testStringInterpretation() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -620,7 +617,7 @@ public class SetVariableTest {
  @Test
  void testStringTest() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
    String raw = "From: sender@zimbra.com\n"
@@ -660,7 +657,7 @@ public class SetVariableTest {
  @Test
  void testSetMatchVarAndUseInHeader() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -690,7 +687,7 @@ public class SetVariableTest {
  @Test
  void testSetMatchVarAndUseInHeaderSingleOccurrence() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -720,7 +717,7 @@ public class SetVariableTest {
     @Disabled
     public void testSetMatchVarAndUseInHeaderSingleOccurrenceReplaceHeader() {
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -766,7 +763,7 @@ public class SetVariableTest {
      + "if address :comparator \"i;ascii-casemap\" :is [\"${from_header_name}\",\"${to_header_name}\"] \"user2@ykomiyam.local\" {"
      + "  tag \"HeaderListTag\";\n" + "}";
 
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    account.setMailSieveScript(filterScript);
@@ -802,8 +799,6 @@ public class SetVariableTest {
   env.setSender(sender);
   env.addLocalRecipient(recipient);
   try {
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(
      account);
@@ -848,8 +843,6 @@ public class SetVariableTest {
    env.setSender(sender);
    env.addLocalRecipient(recipient1);
    env.addLocalRecipient(recipient2);
-   Account account = Provisioning.getInstance().getAccount(
-     MockProvisioning.DEFAULT_ACCOUNT_ID);
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    account.setMailSieveScript(filterScript);
@@ -880,7 +873,7 @@ public class SetVariableTest {
      + "if string :is :comparator \"i;ascii-casemap\" \"{name}\" [\"{name}\", \"Bob\"]{\n"
      + "  tag \"SourceTag\";\n" + "}";
 
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    RuleManager.clearCachedRules(account);
    account.setMailSieveScript(filterScript);
@@ -915,13 +908,12 @@ public class SetVariableTest {
                 + "if header :contains \"Subject\" \"example\" {\n"
                 + " addheader \"${header_name}\" \"${header_value}\" \r\n" + "  ;\n" + "}";
 
-            Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct);
-            RuleManager.clearCachedRules(acct);
-            acct.setMailSieveScript(filterScript);
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(account);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
-                            sampleBaseMsg.getBytes(), false), 0, acct.getName(),
+                            sampleBaseMsg.getBytes(), false), 0, account.getName(),
                             null, new DeliveryContext(),
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
@@ -961,13 +953,12 @@ public class SetVariableTest {
                 + "set \"header_value\" \"test2\";"
                 + "deleteheader :is \"${header_name}\" \"${header_value}\" \r\n" + "  ;\n";
 
-            Account acct1 = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
-            RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(account);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
-                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            sampleBaseMsg.getBytes(), false), 0, account.getName(),
                             null, new DeliveryContext(),
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
@@ -1008,13 +999,12 @@ public class SetVariableTest {
                 + "replaceheader :newvalue \"${new_value}\" :contains \"${header_name}\" \"${header_value}\" \r\n"
                 + "  ;\n";
 
-            Account acct1 = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(acct1);
-            RuleManager.clearCachedRules(acct1);
-            acct1.setMailSieveScript(filterScript);
+            Mailbox mbox1 = MailboxManager.getInstance().getMailboxByAccount(account);
+            RuleManager.clearCachedRules(account);
+            account.setMailSieveScript(filterScript);
             RuleManager.applyRulesToIncomingMessage(
                     new OperationContext(mbox1), mbox1, new ParsedMessage(
-                            sampleBaseMsg.getBytes(), false), 0, acct1.getName(),
+                            sampleBaseMsg.getBytes(), false), 0, account.getName(),
                             null, new DeliveryContext(),
                             Mailbox.ID_FOLDER_INBOX, true);
             Integer itemId = mbox1.getItemIds(null, Mailbox.ID_FOLDER_INBOX).getIds(MailItem.Type.MESSAGE).get(0);
@@ -1036,7 +1026,7 @@ public class SetVariableTest {
  @Test
  void testSetMatchVarAndUseInHeader2() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
 
    Map<String, Object> attrs = Maps.newHashMap();
    attrs = Maps.newHashMap();
@@ -1071,7 +1061,7 @@ public class SetVariableTest {
  @Test
  void testSetMatchVarAndFileInto() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -1164,7 +1154,7 @@ public class SetVariableTest {
         env.setSender(sender);
         env.addLocalRecipient(recipient);
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -1204,7 +1194,7 @@ public class SetVariableTest {
         env.setSender(sender);
         env.addLocalRecipient(recipient);
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -1252,7 +1242,7 @@ public class SetVariableTest {
         env.setSender(sender);
         env.addLocalRecipient(recipient);
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
                
@@ -1302,7 +1292,7 @@ public class SetVariableTest {
  @Test
  void testSetMatchVarAndUseInHeaderForAddress() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -1396,7 +1386,7 @@ public class SetVariableTest {
      "tes"
    };
 
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    Map<String, Object> attrs = Maps.newHashMap();
    attrs = Maps.newHashMap();
    Provisioning.getInstance().getServer(account).modify(attrs);
@@ -1496,7 +1486,7 @@ public class SetVariableTest {
                     + "\n"
                     + "Hello world.";
 
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             Map<String, Object> attrs = Maps.newHashMap();
             attrs = Maps.newHashMap();
             Provisioning.getInstance().getServer(account).modify(attrs);
@@ -1539,7 +1529,7 @@ public class SetVariableTest {
  @Test
  void testDollar() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\"];\n"
@@ -1578,7 +1568,7 @@ public class SetVariableTest {
  @Test
  void testDollar2() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    filterScript = "require [\"variables\", \"envelope\"];\n"
@@ -1846,7 +1836,7 @@ public class SetVariableTest {
                   + "  addheader :last \"X-New-Header-47\" \"string test count numeric lt positive infinity\";\n"
                   + "}"
                   ;
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
             RuleManager.clearCachedRules(account);
             account.setMailSieveScript(filterScript);
@@ -1923,7 +1913,7 @@ public class SetVariableTest {
  @Test
  void testSetVarNameWithDigits() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
 
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
@@ -1967,7 +1957,7 @@ public class SetVariableTest {
  @Test
  void testNumericVarNames() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
 
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
@@ -2005,7 +1995,7 @@ public class SetVariableTest {
  @Test
  void testVarNamesWithDot() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
 
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
@@ -2043,7 +2033,7 @@ public class SetVariableTest {
  @Test
  void testVarIndexWithLeadingZeroes() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2072,7 +2062,7 @@ public class SetVariableTest {
  @Test
  void testNegativeVarIndex() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2105,7 +2095,7 @@ public class SetVariableTest {
  @Test
  void testOutofRangeVarIndex() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2138,7 +2128,7 @@ public class SetVariableTest {
  @Test
  void testOutofRangeVarIndexWithLeadingZeroes() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2171,7 +2161,7 @@ public class SetVariableTest {
  @Test
  void testWildCardGreedyMatch() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2200,7 +2190,7 @@ public class SetVariableTest {
  @Test
  void testMultipleWildCardMatch() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2229,7 +2219,7 @@ public class SetVariableTest {
  @Test
  void testMultipleWildCardMatch2() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2258,7 +2248,7 @@ public class SetVariableTest {
  @Test
  void testMultipleWildCardMatch3() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2287,7 +2277,7 @@ public class SetVariableTest {
  @Test
  void testStringNumericNegativeTest() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2320,7 +2310,7 @@ public class SetVariableTest {
     @Disabled
     public void testNonExistingVarIndexWithLeadingZeroes() {
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2349,7 +2339,7 @@ public class SetVariableTest {
     @Disabled
     public void testNonExistingVarIndexWithLeadingZeroesForQuestionMark() {
         try {
-            Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+            
             RuleManager.clearCachedRules(account);
             Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 
@@ -2378,7 +2368,7 @@ public class SetVariableTest {
  @Test
  void testNoRequireDeclaration() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
    // No "variable" require
@@ -2438,7 +2428,7 @@ public class SetVariableTest {
  @Test
  void testMissingComparatorNumericDeclaration() {
   try {
-   Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   
    RuleManager.clearCachedRules(account);
    Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(account);
 

--- a/store/src/test/java/com/zimbra/cs/index/LuceneQueryOperationTest.java
+++ b/store/src/test/java/com/zimbra/cs/index/LuceneQueryOperationTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.Lists;
 import com.zimbra.common.soap.SoapProtocol;
-import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.MailItem;
@@ -33,12 +33,13 @@ import org.junit.jupiter.api.Test;
  * @author ysasaki
  */
 public final class LuceneQueryOperationTest {
+    private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @AfterEach
@@ -48,7 +49,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void notClause() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   mbox.addMessage(null, new ParsedMessage("From: test1@zimbra.com".getBytes(), false), dopt, null);
   Message msg2 = mbox.addMessage(null, new ParsedMessage("From: test2@zimbra.com".getBytes(), false), dopt, null);
@@ -79,7 +80,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void notClauses() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   mbox.addMessage(null, new ParsedMessage("From: test1@zimbra.com".getBytes(), false), dopt, null);
   Message msg2 = mbox.addMessage(null, new ParsedMessage("From: test2@zimbra.com".getBytes(), false), dopt, null);
@@ -110,7 +111,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void andClauses() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   Message msg1 = mbox.addMessage(null, new ParsedMessage("From: test1@zimbra.com".getBytes(), false), dopt, null);
   mbox.addMessage(null, new ParsedMessage("From: test2@zimbra.com".getBytes(), false), dopt, null);
@@ -131,7 +132,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void subjectQuery() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   Message msg = mbox.addMessage(null, new ParsedMessage("Subject: one two three".getBytes(), false), dopt, null);
   MailboxTestUtil.index(mbox);
@@ -160,7 +161,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void subjectQueryPhrase() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   Message msg1 = mbox.addMessage(null, new ParsedMessage("Subject: one two three".getBytes(), false), dopt, null);
   Message msg2 = mbox.addMessage(null, new ParsedMessage("Subject: one three two".getBytes(), false), dopt, null);
@@ -182,7 +183,7 @@ public final class LuceneQueryOperationTest {
 
  @Test
  void subjectQueryPhraseMultiMatches() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   Message msg1 = mbox.addMessage(null, new ParsedMessage("Subject: one two three".getBytes(), false), dopt, null);
   Message msg2 = mbox.addMessage(null, new ParsedMessage("Subject: one two three".getBytes(), false), dopt, null);

--- a/store/src/test/java/com/zimbra/cs/index/ZimbraQueryTest.java
+++ b/store/src/test/java/com/zimbra/cs/index/ZimbraQueryTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.SoapProtocol;
-import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.db.DbPool;
 import com.zimbra.cs.db.DbPool.DbConnection;
@@ -41,12 +41,14 @@ import org.junit.jupiter.api.Test;
  * @author ysasaki
  */
 public final class ZimbraQueryTest {
+  
+  private static Account account;
 
   @BeforeAll
   public static void init() throws Exception {
     MailboxTestUtil.initServer();
     Provisioning prov = Provisioning.getInstance();
-    prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
   }
 
   @BeforeEach
@@ -57,7 +59,7 @@ public final class ZimbraQueryTest {
   @Test
   void checkSortCompatibility() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     SearchParams params = new SearchParams();
     params.setQueryString("in:inbox content:test");
@@ -95,7 +97,7 @@ public final class ZimbraQueryTest {
   @Test
   void testSanitizedQuery() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     SearchParams params = new SearchParams();
     params.setSortBy(SortBy.NONE);
@@ -118,7 +120,7 @@ public final class ZimbraQueryTest {
   @Test
   void searchResultMode() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     Map<String, Object> fields = new HashMap<String, Object>();
     fields.put(ContactConstants.A_email, "test1@zimbra.com");
@@ -144,7 +146,7 @@ public final class ZimbraQueryTest {
   @Disabled("Fix me. Assertions fails. Standard error: missing .platform")
   void calItemExpandRange() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     SearchParams params = new SearchParams();
     params.setQueryString("test");
@@ -168,7 +170,7 @@ public final class ZimbraQueryTest {
   @Test
   void mdate() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     DbConnection conn = DbPool.getConnection();
     DbUtil.executeUpdate(
@@ -248,7 +250,7 @@ public final class ZimbraQueryTest {
   @Test
   void quick() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     Contact contact =
         mbox.createContact(
@@ -283,7 +285,7 @@ public final class ZimbraQueryTest {
   @Test
   void suggest() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
     DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
     Message msg =
         mbox.addMessage(
@@ -306,7 +308,7 @@ public final class ZimbraQueryTest {
   @Test
   void dumpster() throws Exception {
     Mailbox mbox =
-        MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
     SearchParams params = new SearchParams();
     params.setQueryString("test");

--- a/store/src/test/java/com/zimbra/cs/index/query/QueryParserTest.java
+++ b/store/src/test/java/com/zimbra/cs/index/query/QueryParserTest.java
@@ -5,21 +5,10 @@
 
 package com.zimbra.cs.index.query;
 
-import java.util.Calendar;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.TimeZone;
-
-import org.apache.lucene.document.DateTools;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import com.zimbra.common.service.ServiceException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.index.ZimbraAnalyzer;
 import com.zimbra.cs.index.query.parser.QueryParser;
@@ -28,6 +17,14 @@ import com.zimbra.cs.mailbox.MailServiceException;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
+import java.util.Calendar;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+import org.apache.lucene.document.DateTools;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link QueryParser}.
@@ -36,14 +33,15 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
  */
 public final class QueryParserTest {
     private static QueryParser parser;
+    private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
 
-        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+        Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
         parser = new QueryParser(mbox, ZimbraAnalyzer.getInstance());
     }
 
@@ -267,15 +265,15 @@ public final class QueryParserTest {
  @Test
  void braced() throws Exception {
   String src = "item:{1,2,3}";
-  assertEquals("Q(ITEMID," + MockProvisioning.DEFAULT_ACCOUNT_ID + ":1," +
-    MockProvisioning.DEFAULT_ACCOUNT_ID + ":2," + MockProvisioning.DEFAULT_ACCOUNT_ID + ":3)",
+  assertEquals("Q(ITEMID," + account.getId() + ":1," +
+    account.getId() + ":2," + account.getId() + ":3)",
     Query.toString(parser.parse(src)));
 
   src = "item:({1,2,3} or {4,5,6})";
-  assertEquals("(Q(ITEMID," + MockProvisioning.DEFAULT_ACCOUNT_ID + ":1," +
-    MockProvisioning.DEFAULT_ACCOUNT_ID + ":2," + MockProvisioning.DEFAULT_ACCOUNT_ID + ":3) || Q(ITEMID," +
-    MockProvisioning.DEFAULT_ACCOUNT_ID + ":4," + MockProvisioning.DEFAULT_ACCOUNT_ID + ":5," +
-    MockProvisioning.DEFAULT_ACCOUNT_ID + ":6))", Query.toString(parser.parse(src)));
+  assertEquals("(Q(ITEMID," + account.getId() + ":1," +
+    account.getId() + ":2," + account.getId() + ":3) || Q(ITEMID," +
+    account.getId() + ":4," + account.getId() + ":5," +
+    account.getId() + ":6))", Query.toString(parser.parse(src)));
  }
 
  @Test

--- a/store/src/test/java/com/zimbra/cs/mailbox/SearchFolderTest.java
+++ b/store/src/test/java/com/zimbra/cs/mailbox/SearchFolderTest.java
@@ -5,18 +5,14 @@
 
 package com.zimbra.cs.mailbox;
 
-import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.zimbra.cs.account.Account;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.zimbra.cs.account.MockProvisioning;
-import com.zimbra.cs.account.Provisioning;
 
 /**
  * Unit test for {@link SearchFolder}.
@@ -24,12 +20,13 @@ import com.zimbra.cs.account.Provisioning;
  * @author ysasaki
  */
 public final class SearchFolderTest {
+  private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @BeforeEach
@@ -39,10 +36,8 @@ public final class SearchFolderTest {
 
  @Test
  void defaultFolderFlags() throws Exception {
-  Provisioning prov = Provisioning.getInstance();
-  Account account = prov.getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
   account.setDefaultFolderFlags("*");
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   SearchFolder folder = mbox.createSearchFolder(null, Mailbox.ID_FOLDER_USER_ROOT,
     "test", "test", "message", "none", 0, (byte) 0);
   assertTrue(folder.isFlagSet(Flag.BITMASK_SUBSCRIBED));
@@ -50,7 +45,7 @@ public final class SearchFolderTest {
 
  @Test
  void flagGuard() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   SearchFolder folder = mbox.createSearchFolder(null, Mailbox.ID_FOLDER_USER_ROOT,
     "test", "test", "message", "none", Flag.BITMASK_UNCACHED, (byte) 0);
   assertFalse(folder.isFlagSet(Flag.BITMASK_UNCACHED));

--- a/store/src/test/java/com/zimbra/cs/mime/TestContentTransferEncoding.java
+++ b/store/src/test/java/com/zimbra/cs/mime/TestContentTransferEncoding.java
@@ -5,27 +5,15 @@
 
 package com.zimbra.cs.mime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-
-import javax.mail.internet.MimeMessage;
-import javax.mail.util.SharedByteArrayInputStream;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.zmime.ZMimeMessage;
 import com.zimbra.common.zmime.ZMimeMultipart;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -33,8 +21,8 @@ import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.service.AuthProvider;
-import com.zimbra.cs.service.mail.message.parser.ParseMimeMessage;
 import com.zimbra.cs.service.mail.message.parser.MimeMessageData;
+import com.zimbra.cs.service.mail.message.parser.ParseMimeMessage;
 import com.zimbra.cs.util.JMSession;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
@@ -43,24 +31,34 @@ import com.zimbra.soap.mail.type.AttachmentsInfo;
 import com.zimbra.soap.mail.type.MimePartAttachSpec;
 import com.zimbra.soap.mail.type.MimePartInfo;
 import com.zimbra.soap.mail.type.MsgToSend;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import javax.mail.internet.MimeMessage;
+import javax.mail.util.SharedByteArrayInputStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestContentTransferEncoding {
 
     Mailbox mbox;
+    private static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         Provisioning prov = Provisioning.getInstance();
-        prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     @BeforeEach
     public void setUp() throws Exception {
         MailboxTestUtil.clearData();
         MailboxTestUtil.cleanupIndexStore(
-                MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID));
-        mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+                MailboxManager.getInstance().getMailboxByAccountId(account.getId()));
+        mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
     }
 
     private MimeMessage sendForwardedMessage(SendMsgRequest req, Message origMsg) throws Exception {
@@ -105,7 +103,7 @@ public class TestContentTransferEncoding {
  @Disabled("disabled until bug 98015 is fixed")
  @Test
  void testSimpleMimeMessage() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   MimeMessage mimeMsg = new ZMimeMessage(JMSession.getSession(), new SharedByteArrayInputStream(getSimpleMimeString().getBytes()));
   ParsedMessage pm = new ParsedMessage(mimeMsg, true);
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
@@ -127,7 +125,7 @@ public class TestContentTransferEncoding {
  @Disabled("disabled until bug 98015 is fixed")
  @Test
  void testMultipartMimeMessage() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   MimeMessage mimeMsg = new ZMimeMessage(JMSession.getSession(), new SharedByteArrayInputStream(getMultipartMimeString().getBytes()));
   ParsedMessage pm = new ParsedMessage(mimeMsg, true);
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
@@ -159,7 +157,6 @@ public class TestContentTransferEncoding {
 
  @Test
  void testNestedMultipartMessage() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
   MimeMessage mimeMsg = new ZMimeMessage(JMSession.getSession(), new SharedByteArrayInputStream(getNestedMimeString().getBytes()));
   ParsedMessage pm = new ParsedMessage(mimeMsg, true);
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);

--- a/store/src/test/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessageTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/message/parser/ParseMimeMessageTest.java
@@ -6,8 +6,8 @@ package com.zimbra.cs.service.mail.message.parser;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.zextras.mailbox.util.MailMessageBuilder;
 import com.zextras.mailbox.util.AccountAction;
+import com.zextras.mailbox.util.MailMessageBuilder;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
@@ -15,7 +15,6 @@ import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.common.zmime.ZMimeMultipart;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.MockProvisioning;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.ZimbraAuthToken;
 import com.zimbra.cs.mailbox.DeliveryContext;
@@ -44,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import javax.mail.BodyPart;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
@@ -57,11 +57,15 @@ import org.junit.jupiter.api.Test;
 
 public final class ParseMimeMessageTest {
 
+  private static Account account;
+
   @BeforeAll
   public static void init() throws Exception {
     MailboxTestUtil.initServer();
     Provisioning prov = Provisioning.getInstance();
-    prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+    account = prov.createAccount("test@zimbra.com", "secret", new HashMap<String, Object>(
+        Map.of(Provisioning.A_zimbraId, UUID.randomUUID().toString())
+    ));
   }
 
   @BeforeEach
@@ -82,7 +86,7 @@ public final class ParseMimeMessageTest {
     .addAttribute(MailConstants.A_ADDRESS, "rcpt@zimbra.com");
 
    rootEl.addUniqueElement(el);
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   Account acct = account;
    OperationContext octxt = new OperationContext(acct);
   ZimbraSoapContext zsc = getMockSoapContext();
 
@@ -98,7 +102,7 @@ public final class ParseMimeMessageTest {
 
  @Test
   void parseMimeMsgSoap_withMsgAttachment() throws Exception {
-   Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+   Account acct = account;
    OperationContext octxt = new OperationContext(acct);
    var mbox = MailboxManager.getInstance().createMailbox(octxt, acct);
    final ParsedMessage message = new MailMessageBuilder()
@@ -144,7 +148,6 @@ public final class ParseMimeMessageTest {
 
   @Test
   void parseMimeMsgSoapWithEmptyFile_DoesNotAffectMtaMaxMessageSizeQuotaCheck() throws Exception {
-    Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
     OperationContext octxt = new OperationContext(account);
     ZimbraSoapContext parent =
         new ZimbraSoapContext(
@@ -153,7 +156,7 @@ public final class ParseMimeMessageTest {
             (DocumentHandler) null,
             Collections.<String, Object>emptyMap(),
             SoapProtocol.SoapJS);
-    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), account.getId(), null);
     final Message draftWithFileAttachment = this.createDraftWithFileAttachment(account);
 
     // upload empty file
@@ -188,7 +191,6 @@ public final class ParseMimeMessageTest {
 
   @Test
   void parseMimeMsgSoapWithSmartLink() throws Exception {
-    Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
     OperationContext octxt = new OperationContext(account);
     ZimbraSoapContext parent =
         new ZimbraSoapContext(
@@ -197,7 +199,7 @@ public final class ParseMimeMessageTest {
             (DocumentHandler) null,
             Collections.<String, Object>emptyMap(),
             SoapProtocol.SoapJS);
-    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), account.getId(), null);
 
     // 1 save a draft message with attachments
     final Message draftWithFileAttachment = this.createDraftWithFileAttachment(account);
@@ -230,7 +232,6 @@ public final class ParseMimeMessageTest {
 
   @Test
   void parseMimeMsgSoapWithNewAttachmentShouldNotAddSmartLink() throws Exception {
-    Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
     OperationContext octxt = new OperationContext(account);
     ZimbraSoapContext parent =
         new ZimbraSoapContext(
@@ -239,7 +240,7 @@ public final class ParseMimeMessageTest {
             (DocumentHandler) null,
             Collections.<String, Object>emptyMap(),
             SoapProtocol.SoapJS);
-    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+    ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), account.getId(), null);
 
     // 1 save a draft message with attachments
     final Message draft = this.createDraft(account);
@@ -282,7 +283,6 @@ public final class ParseMimeMessageTest {
           Provisioning.A_zimbraMtaMaxMessageSize, "1"
       )));
 
-      Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
       OperationContext octxt = new OperationContext(account);
       ZimbraSoapContext parent =
           new ZimbraSoapContext(
@@ -291,7 +291,7 @@ public final class ParseMimeMessageTest {
               (DocumentHandler) null,
               Collections.<String, Object>emptyMap(),
               SoapProtocol.SoapJS);
-      ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+      ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), account.getId(), null);
 
       // 1 save a draft message with attachments
       final Message draft = this.createDraft(account);
@@ -325,7 +325,6 @@ public final class ParseMimeMessageTest {
           Provisioning.A_zimbraMtaMaxMessageSize, "1"
       )));
 
-      Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
       OperationContext octxt = new OperationContext(account);
       ZimbraSoapContext parent =
           new ZimbraSoapContext(
@@ -334,7 +333,7 @@ public final class ParseMimeMessageTest {
               (DocumentHandler) null,
               Collections.<String, Object>emptyMap(),
               SoapProtocol.SoapJS);
-      ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+      ZimbraSoapContext zsc = new ZimbraSoapContext(parent, new ZimbraAuthToken(account), account.getId(), null);
 
       // 1 save a draft message with attachments
       final Message draft = this.createDraft(account);
@@ -383,8 +382,7 @@ public final class ParseMimeMessageTest {
         .addAttribute(MailConstants.A_ADDRESS, "rcpt@zimbra.com");
 
     rootEl.addUniqueElement(msgElement);
-    Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-    OperationContext octxt = new OperationContext(acct);
+    OperationContext octxt = new OperationContext(account);
     ZimbraSoapContext zsc = getMockSoapContext();
 
     MimeMessage mm =
@@ -399,8 +397,6 @@ public final class ParseMimeMessageTest {
 
   @Test
   void parseDraftMimeMsgSoap_addNewInlineAttachment() throws Exception {
-    Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
-
     final InputStream uploadInputStream = this.getClass()
         .getResourceAsStream("/test-save-to-files.txt");
     final String filename = "myFiletest.txt";
@@ -448,7 +444,6 @@ public final class ParseMimeMessageTest {
           Provisioning.A_zimbraMtaMaxMessageSize, "1"
       )));
 
-      Account account = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
       OperationContext octxt = new OperationContext(account);
       ZimbraSoapContext zsc = getZimbraSoapContext(account);
 
@@ -504,7 +499,7 @@ public final class ParseMimeMessageTest {
     .setText("\u30ab\u30b9\u30bf\u30e0");
   rootEl.addUniqueElement(el);
 
-  Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Account acct = account;
   OperationContext octxt = new OperationContext(acct);
   ZimbraSoapContext zsc = getMockSoapContext();
 
@@ -554,7 +549,7 @@ public final class ParseMimeMessageTest {
         + "This is the inner message.");
   rootEl.addUniqueElement(el);
 
-  Account acct = Provisioning.getInstance().getAccount(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Account acct = account;
   OperationContext octxt = new OperationContext(acct);
   ZimbraSoapContext zsc = getMockSoapContext();
 
@@ -667,7 +662,7 @@ public final class ParseMimeMessageTest {
             (DocumentHandler) null,
             Collections.<String, Object>emptyMap(),
             SoapProtocol.SoapJS);
-    return new ZimbraSoapContext(parent, MockProvisioning.DEFAULT_ACCOUNT_ID, null);
+    return new ZimbraSoapContext(parent, account.getId(), null);
   }
 
   private ZimbraSoapContext getZimbraSoapContext(Account account) throws ServiceException {

--- a/store/src/test/java/com/zimbra/cs/store/AbstractBlobConsistencyCheckTest.java
+++ b/store/src/test/java/com/zimbra/cs/store/AbstractBlobConsistencyCheckTest.java
@@ -5,20 +5,12 @@
 
 package com.zimbra.cs.store;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import com.zimbra.common.service.ServiceException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.DeliveryOptions;
 import com.zimbra.cs.mailbox.Mailbox;
@@ -29,11 +21,19 @@ import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.store.file.BlobConsistencyChecker;
 import com.zimbra.cs.store.file.BlobConsistencyChecker.BlobInfo;
 import com.zimbra.cs.store.file.BlobConsistencyChecker.Results;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractBlobConsistencyCheckTest {
 
     static StoreManager originalStoreManager;
     protected final Log log = ZimbraLog.store;
+    private static Account account;
 
     protected abstract StoreManager getStoreManager();
     protected abstract BlobConsistencyChecker getChecker();
@@ -46,7 +46,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
     public static void init() throws Exception {
         MailboxTestUtil.initServer();
         MailboxTestUtil.initProvisioning();
-        Provisioning.getInstance().createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = Provisioning.getInstance().createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
         //don't fail test even if native libraries not installed
         //this makes it easier to run unit tests from command line
         System.setProperty("zimbra.native.required", "false");
@@ -64,7 +64,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
 
  @Test
  void singleBlob() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   mbox.addMessage(null, new ParsedMessage("From: test1-1@sub1.zimbra.com".getBytes(), false), dopt, null);
@@ -80,7 +80,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
 
  @Test
  void missingBlobs() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   int msgs = 10;
@@ -103,7 +103,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
 
  @Test
  void unexpectedBlobs() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   String path = createUnexpectedBlob(0);
 
   BlobConsistencyChecker checker = getChecker();
@@ -143,7 +143,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
 
  @Test
  void wrongSize() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   Message msg = mbox.addMessage(null, new ParsedMessage("From: test1-1@sub1.zimbra.com".getBytes(), false), dopt, null);
@@ -168,7 +168,7 @@ public abstract class AbstractBlobConsistencyCheckTest {
 
  @Test
  void allBlobs() throws Exception {
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   DeliveryOptions dopt = new DeliveryOptions().setFolderId(Mailbox.ID_FOLDER_INBOX);
   int msgs = 10;

--- a/store/src/test/java/com/zimbra/cs/store/AbstractStoreManagerTest.java
+++ b/store/src/test/java/com/zimbra/cs/store/AbstractStoreManagerTest.java
@@ -5,21 +5,10 @@
 
 package com.zimbra.cs.store;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Random;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import com.zimbra.common.util.ByteUtil;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.zimbra.cs.account.MockProvisioning;
+import com.zimbra.common.util.ByteUtil;
+import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -27,18 +16,28 @@ import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.ThreaderTest;
 import com.zimbra.cs.mime.ParsedMessage;
 import com.zimbra.cs.store.external.ExternalStoreManager;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Random;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import qa.unittest.TestUtil;
 
 public abstract class AbstractStoreManagerTest {
 
     static StoreManager originalStoreManager;
+    static Account account;
 
     @BeforeAll
     public static void init() throws Exception {
     System.setProperty("zimbra.config", "../store/src/test/resources/localconfig-test.xml");
         MailboxTestUtil.initServer();
         MailboxTestUtil.initProvisioning();
-        Provisioning.getInstance().createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
+        account = Provisioning.getInstance().createAccount("test@zimbra.com", "secret", new HashMap<String, Object>());
     }
 
     /**
@@ -64,7 +63,7 @@ public abstract class AbstractStoreManagerTest {
   ParsedMessage pm = ThreaderTest.getRootMessage();
   byte[] mimeBytes = TestUtil.readInputStream(pm.getRawInputStream());
 
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   StoreManager sm = StoreManager.getInstance();
   Blob blob = sm.storeIncoming(pm.getRawInputStream());
@@ -97,7 +96,7 @@ public abstract class AbstractStoreManagerTest {
  void sameDigest() throws Exception {
   ParsedMessage pm = ThreaderTest.getRootMessage();
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   Blob blob1 = sm.storeIncoming(pm.getRawInputStream());
   StagedBlob staged1 = sm.stage(blob1, mbox);
@@ -120,7 +119,7 @@ public abstract class AbstractStoreManagerTest {
   rand.nextBytes(bytes);
 
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   IncomingBlob incoming = sm.newIncomingBlob("foo", null);
 
@@ -151,7 +150,7 @@ public abstract class AbstractStoreManagerTest {
  void incomingMultipost() throws Exception {
   byte[] bytes = "AAAAStrinGBBB".getBytes();
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   IncomingBlob incoming = sm.newIncomingBlob("foo", null);
 
@@ -201,7 +200,7 @@ public abstract class AbstractStoreManagerTest {
 
   rand.nextBytes(bytes);
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   IncomingBlob incoming = sm.newIncomingBlob("foo", null);
 
@@ -233,7 +232,7 @@ public abstract class AbstractStoreManagerTest {
  @Test
  void emptyBlob() throws Exception {
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
 
   IncomingBlob incoming = sm.newIncomingBlob("foo", null);
   Blob blob = incoming.getBlob();
@@ -269,7 +268,7 @@ public abstract class AbstractStoreManagerTest {
  @Test
  void nonExistingBlob() throws Exception {
   StoreManager sm = StoreManager.getInstance();
-  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(MockProvisioning.DEFAULT_ACCOUNT_ID);
+  Mailbox mbox = MailboxManager.getInstance().getMailboxByAccountId(account.getId());
   MailboxBlob blob = sm.getMailboxBlob(mbox, 999, 1, "1");
   assertNull(blob, "expect null blob");
  }


### PR DESCRIPTION
The idea is to avoid reference to any static variable, in this case the account uuid.
Moreover each one of these tests follows this pattern:

- create an account in the BeforeAll phase (uses default account id)
- initialize and clean the data before/after each single tests

The issue is the tests try to retrieve the account using the static DEFAULT_ACCOUNT_ID, but it is possible to achieve the same result just by declaring the account as static class field since the initialization is done in the beforeall phase.

This will make the tests self-contained and not dependent on outside values. Moreover the DEFAULT_ACCOUNT_ID is a gimmick of the MockProvisioning and the test should avoid tight coupling with the underneath implementation.

Even with that said the results depend on each single test.
Given the test can cleanup the data (in HSQLDB and filesystem but persist the account in the provisioning), the cleanup can lead to issue. This is why in some cases the account is created beforeEach