### PR TITLE
[🐸 Frogbot] Update version of org.apache.mina:mina-core to 2.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.10</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.concurrentlinkedhashmap</groupId>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | CVE-2024-52046 | org.apache.mina:mina-core:2.1.6 | org.apache.mina:mina-core 2.1.6 | [2.0.27]<br>[2.1.10]<br>[2.2.4] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Direct Dependencies:** | org.apache.mina:mina-core:2.1.6 |
| **Impacted Dependency:** | org.apache.mina:mina-core:2.1.6 |
| **Fixed Versions:** | [2.0.27], [2.1.10], [2.2.4] |
| **CVSS V3:** | 9.8 |

The ObjectSerializationDecoder in Apache MINA uses Java’s native deserialization protocol to process
incoming serialized data but lacks the necessary security checks and defenses. This vulnerability allows
attackers to exploit the deserialization process by sending specially crafted malicious serialized data,
potentially leading to remote code execution (RCE) attacks.



					


				


			


		


	
This issue affects MINA core versions 2.0.X, 2.1.X and 2.2.X, and will be fixed by the releases 2.0.27, 2.1.10 and 2.2.4.





It's also important to note that an application using MINA core library will only be affected if the IoBuffer#getObject() method is called, and this specific method is potentially called when adding a ProtocolCodecFilter instance using the ObjectSerializationCodecFactory class in the filter chain. If your application is specifically using those classes, you have to upgrade to the latest version of MINA core library.




Upgrading will  not be enough: you also need to explicitly allow the classes the decoder will accept in the ObjectSerializationDecoder instance, using one of the three new methods:




    /**

     * Accept class names where the supplied ClassNameMatcher matches for

     * deserialization, unless they are otherwise rejected.

     *

     * @param classNameMatcher the matcher to use

     */

    public void accept(ClassNameMatcher classNameMatcher)




    /**

     * Accept class names that match the supplied pattern for

     * deserialization, unless they are otherwise rejected.

     *

     * @param pattern standard Java regexp

     */

    public void accept(Pattern pattern) 





    /**

     * Accept the wildcard specified classes for deserialization,

     * unless they are otherwise rejected.

     *

     * @param patterns Wildcard file name patterns as defined by

     *                  {@link org.apache.commons.io.FilenameUtils#wildcardMatch(String, String) FilenameUtils.wildcardMatch}

     */

    public void accept(String... patterns)







By defa...
<details><summary><b>Note</b></summary>

---
<div align='center'>

**Frogbot** also supports **Contextual Analysis, Secret Detection, IaC and SAST Vulnerabilities Scanning**. This features are included as part of the [JFrog Advanced Security](https://jfrog.com/advanced-security) package, which isn't enabled on your system.

</div>
<br></details>

---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
