### PR TITLE
OpenLDAP service startup failure in the Docker container

### DIFF
--- a/docker/standalone/docker-compose.yaml
+++ b/docker/standalone/docker-compose.yaml
@@ -41,6 +41,13 @@ services:
       - mailbox
     ports:
       - "1389:1389"
+    ulimits:
+     nofile:
+       soft: 65536
+       hard: 65536
+     nproc:
+       soft: 65535
+       hard: 65535
   mariadb:
     build:
       context: ./../../


### PR DESCRIPTION
During the initialization of the OpenLDAP Docker container, the service failed with the following error:

```
ch_calloc of 1073741816 elems of 664 bytes failed  
slapd: ch_malloc.c:107: ch_calloc: Assertion '0' failed
```

The issue was due to memory allocation limits. After adjusting the container's ulimit settings, the slapd service started successfully.

I'm using Ubuntu 24.10
Regards
M