### PR TITLE
chore(Dockerfile): use temurin jammy

### DIFF
--- a/docker/standalone/mailbox/Dockerfile
+++ b/docker/standalone/mailbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jdk
+FROM eclipse-temurin:17-jre-jammy
 
 COPY store/src/test/resources/timezones-test.ics /opt/zextras/conf/timezones.ics
 COPY store-conf/conf/msgs/* /opt/zextras/conf/msgs/


### PR DESCRIPTION
- temurin is the default JRE used in Carbonio (zmjava)
- based on ubuntu jammy (allows installing carbonio packages on top if needed, such as carbonio-nginx in case of carbonio-proxy)