### PR TITLE
chore: register carbonio mailbox container as available for proxy

### DIFF
--- a/docker/standalone/docker-compose.yaml
+++ b/docker/standalone/docker-compose.yaml
@@ -55,24 +55,44 @@ services:
     ports:
       - "1389:1389"
     ulimits:
-     nofile:
-       soft: 65536
-       hard: 65536
-     nproc:
-       soft: 65535
-       hard: 65535
+      nofile:
+        soft: 65536
+        hard: 65536
+      nproc:
+        soft: 65535
+        hard: 65535
   mariadb:
     build:
       context: ./../../
       dockerfile: docker/standalone/mariadb/Dockerfile
     ports:
       - "3306:3306"
+  memcached:
+    profiles:
+      - carbonio-proxy
+    image: memcached:1.6.38-alpine
   webui:
+    profiles:
+      - webui
     depends_on:
       - mailbox1
       - mailbox2
     build:
       dockerfile: webui/Dockerfile
+    ports:
+      - "443:443"
+      - "6071:6071"
+      - "993:993"
+      - "143:143"
+  carbonio-proxy:
+    profiles:
+      - carbonio-proxy
+    depends_on:
+      - mailbox1
+      - mailbox2
+      - memcached
+    hostname: proxy.demo.zextras.io
+    image: carbonio-proxy-local
     ports:
       - "443:443"
       - "6071:6071"

--- a/docker/standalone/docker-compose.yaml
+++ b/docker/standalone/docker-compose.yaml
@@ -55,44 +55,24 @@ services:
     ports:
       - "1389:1389"
     ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-      nproc:
-        soft: 65535
-        hard: 65535
+     nofile:
+       soft: 65536
+       hard: 65536
+     nproc:
+       soft: 65535
+       hard: 65535
   mariadb:
     build:
       context: ./../../
       dockerfile: docker/standalone/mariadb/Dockerfile
     ports:
       - "3306:3306"
-  memcached:
-    profiles:
-      - carbonio-proxy
-    image: memcached:1.6.38-alpine
   webui:
-    profiles:
-      - webui
     depends_on:
       - mailbox1
       - mailbox2
     build:
       dockerfile: webui/Dockerfile
-    ports:
-      - "443:443"
-      - "6071:6071"
-      - "993:993"
-      - "143:143"
-  carbonio-proxy:
-    profiles:
-      - carbonio-proxy
-    depends_on:
-      - mailbox1
-      - mailbox2
-      - memcached
-    hostname: proxy.demo.zextras.io
-    image: carbonio-proxy-local
     ports:
       - "443:443"
       - "6071:6071"

--- a/docker/standalone/mailbox/entrypoint.sh
+++ b/docker/standalone/mailbox/entrypoint.sh
@@ -16,7 +16,10 @@ sed -i -e "s/SERVER_HOSTNAME/${HOSTNAME}/g" /localconfig/localconfig.xml
 SERVER_EXISTS=$(/usr/bin/zmprov -l gs "${HOSTNAME}" 2>&1)
 if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
   echo "Creating server ${HOSTNAME}"
-  /usr/bin/zmprov -l cs "${HOSTNAME}" zimbraServiceInstalled mailbox zimbraServiceEnabled mailbox zimbraServiceEnabled service
+  /usr/bin/zmprov -l cs "${HOSTNAME}" zimbraServiceInstalled mailbox \
+                                      zimbraServiceEnabled mailbox \
+                                      zimbraServiceEnabled service \
+                                      zimbraReverseProxyLookupTarget TRUE
   echo "Server ${HOSTNAME} created"
 fi
 


### PR DESCRIPTION
Makes mailbox container available/autodiscovered for reverse proxy when used with https://github.com/zextras/carbonio-proxy/ container