### PR TITLE
chore: do not publish MTA container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,8 +175,6 @@ pipeline {
                                 'docker/standalone/mariadb/Dockerfile', 'registry.dev.zextras.com/dev/carbonio-mariadb:latest')
                         buildContainer('Carbonio OpenLDAP', '$(cat docker/standalone/openldap/description.md)',
                                 'docker/standalone/openldap/Dockerfile', 'registry.dev.zextras.com/dev/carbonio-openldap:latest')
-                        buildContainer('Carbonio MTA', '$(cat docker/standalone/postfix/description.md)',
-                                'docker/standalone/postfix/Dockerfile', 'registry.dev.zextras.com/dev/carbonio-mta:latest')
                     }
                 }
             }


### PR DESCRIPTION
Kept container definition for testing purposes in this repo, but the real container used for development is defined here: https://github.com/zextras/carbonio-mta/pull/27