### PR TITLE
chore: [CO-2521] add opentelemetry java agent and tracing options to container

### DIFF
--- a/docker/standalone/mailbox/Dockerfile
+++ b/docker/standalone/mailbox/Dockerfile
@@ -1,14 +1,16 @@
 FROM eclipse-temurin:17-jre-jammy
 
-COPY store/src/test/resources/timezones-test.ics /opt/zextras/conf/timezones.ics
-COPY store-conf/conf/msgs/* /opt/zextras/conf/msgs/
-COPY store-conf/conf/owasp_policy.xml /opt/zextras/conf/owasp_policy.xml
-
 RUN mkdir -p /opt/zextras/mailbox/jars/ && \
     mkdir -p /opt/zextras/lib/ext/nginx-lookup/ && \
     mkdir -p /opt/zextras/store && \
     mkdir -p /opt/zextras/mailboxd/work && \
     mkdir -p /opt/zextras/log
+
+COPY store/src/test/resources/timezones-test.ics /opt/zextras/conf/timezones.ics
+COPY store-conf/conf/msgs/* /opt/zextras/conf/msgs/
+COPY store-conf/conf/owasp_policy.xml /opt/zextras/conf/owasp_policy.xml
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar \
+    /opt/zextras/opentelemetry-javaagent.jar
 
 COPY store/target/zm-store.jar /opt/zextras/mailbox/jars/
 COPY store/target/dependencies/* /opt/zextras/mailbox/jars/
@@ -44,20 +46,25 @@ ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
               -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 
-ENV JAVA_ARGS="${BASE_JAVA_ARGS} \
-              -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
-              com.zextras.mailbox.Mailbox"
 ARG JAVA_CLI_ARGS="${BASE_JAVA_ARGS} \
               com.zimbra.cs.account.ProvUtil \"\$@\""
+RUN echo "java ${JAVA_CLI_ARGS}" > /usr/bin/zmprov && chmod +x /usr/bin/zmprov && mkdir -p /opt/zextras/db
 
 ARG JAVA_ZMGSA_ARGS="${BASE_JAVA_ARGS} \
               com.zimbra.cs.util.GalSyncAccountUtil \"\$@\""
 RUN echo "java ${JAVA_ZMGSA_ARGS}" > /usr/bin/zmgsautil && chmod +x /usr/bin/zmgsautil
 
-RUN echo "java ${JAVA_CLI_ARGS}" > /usr/bin/zmprov && chmod +x /usr/bin/zmprov && mkdir -p /opt/zextras/db
 ARG JAVA_ZMMAILBOX_ARG="${BASE_JAVA_ARGS} \
               com.zimbra.cs.zclient.ZMailboxUtil \"\$@\""
 RUN echo "java ${JAVA_ZMMAILBOX_ARG}" > /usr/bin/zmmailbox && chmod +x /usr/bin/zmmailbox
+
+# example: -Dotel.service.name=your-service-name -Dotel.traces.exporter=zipkin
+ENV TRACING_OPTIONS=""
+ENV JAVA_ARGS="-javaagent:/opt/zextras/opentelemetry-javaagent.jar ${BASE_JAVA_ARGS} ${TRACING_OPTIONS} \
+              -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+              com.zextras.mailbox.Mailbox"
+ENV MAILBOX_ENTRYPOINT="${JAVA} ${JAVA_ARGS}"
+
 COPY store/db/create_database.sql /opt/zextras/db/
 
 COPY docker/standalone/mailbox/localconfig/localconfig.xml /localconfig/localconfig.xml

--- a/docker/standalone/mailbox/Dockerfile
+++ b/docker/standalone/mailbox/Dockerfile
@@ -29,7 +29,7 @@ ENV MARIADB_PORT=3306
 ENV CARBONIO_FILES_SERVICE_URL="http://carbonio-files:10000"
 ENV CARBONIO_PREVIEW_SERVICE_URL="http://carbonio-preview:10000"
 
-ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
+ENV BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dhttps.protocols=TLSv1.2,TLSv1.3 \
               -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
               -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
@@ -60,10 +60,6 @@ RUN echo "java ${JAVA_ZMMAILBOX_ARG}" > /usr/bin/zmmailbox && chmod +x /usr/bin/
 
 # example: -Dotel.service.name=your-service-name -Dotel.traces.exporter=zipkin
 ENV TRACING_OPTIONS=""
-ENV JAVA_ARGS="-javaagent:/opt/zextras/opentelemetry-javaagent.jar ${BASE_JAVA_ARGS} ${TRACING_OPTIONS} \
-              -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
-              com.zextras.mailbox.Mailbox"
-ENV MAILBOX_ENTRYPOINT="${JAVA} ${JAVA_ARGS}"
 
 COPY store/db/create_database.sql /opt/zextras/db/
 

--- a/docker/standalone/mailbox/description.md
+++ b/docker/standalone/mailbox/description.md
@@ -5,13 +5,15 @@ names.
 For example, in order to have a working docker-compose setup, you need to 
 define containers with these names:
 - carbonio-ldap -> openldap 
-- carbonio-mariadb -> mariadb
+- carbonio-mta -> postfix
 - carbonio-mariadb -> mariadb
 
 You can customize the local configuration of the mailbox by replacing /localconfig/localconfig.xml
-By default the localconfig of the container will be replaced with some 
+At startup the localconfig will be replaced with some 
 ENVIRONMENT variables that you can find in the container build file.
-Specifically the SERVER_HOSTNAME field is replaced by ${HOSTNAME} 
-automatically.
+For example the SERVER_HOSTNAME field is replaced by ${HOSTNAME}.
 
 Mailbox provisioning CLI is available as "zmprov".
+
+Traces can be sent by setting TRACING_OPTIONS, e.g.:  
+`TRACING_OPTIONS=-Dotel.service.name=mailbox -Dotel.metrics.exporter=none -Dotel.traces.exporter=zipkin -Dotel.exporter.zipkin.endpoint=http://zipkin:9411/api/v2/spans`

--- a/docker/standalone/mailbox/entrypoint.sh
+++ b/docker/standalone/mailbox/entrypoint.sh
@@ -25,4 +25,6 @@ if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
   echo "Server ${HOSTNAME} created"
 fi
 
-java ${JAVA_ARGS}
+java -javaagent:/opt/zextras/opentelemetry-javaagent.jar ${BASE_JAVA_ARGS} ${TRACING_OPTIONS} \
+              -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+              com.zextras.mailbox.Mailbox

--- a/docker/standalone/mailbox/entrypoint.sh
+++ b/docker/standalone/mailbox/entrypoint.sh
@@ -25,6 +25,14 @@ if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
   echo "Server ${HOSTNAME} created"
 fi
 
-java -javaagent:/opt/zextras/opentelemetry-javaagent.jar ${BASE_JAVA_ARGS} ${TRACING_OPTIONS} \
-              -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
-              com.zextras.mailbox.Mailbox
+if [ -z "${TRACING_OPTIONS}" ]; then
+  java ${BASE_JAVA_ARGS} \
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+    com.zextras.mailbox.Mailbox
+else
+  java -javaagent:/opt/zextras/opentelemetry-javaagent.jar \
+    ${BASE_JAVA_ARGS} \
+    ${TRACING_OPTIONS} \
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+    com.zextras.mailbox.Mailbox
+fi


### PR DESCRIPTION
Allows collecting traces from the mailbox.
Doesn't start with the agent if no tracing options provided (else causes nasty but non-harmful stack traces in logs)