### PR TITLE
fix: avoid loading callback for attributes that don't have a callback

### DIFF
--- a/store/src/main/java/com/zimbra/cs/account/LdapAttributeInfo.java
+++ b/store/src/main/java/com/zimbra/cs/account/LdapAttributeInfo.java
@@ -15,6 +15,7 @@ import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.DateUtil;
 import com.zimbra.common.util.ZimbraLog;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -39,14 +40,14 @@ public class LdapAttributeInfo {
 		this.attributeInfo = attributeInfo;
 	}
 
-	public synchronized AttributeCallback getCallback() {
+	public AttributeCallback getCallback() {
+		if (Objects.isNull(attributeInfo.getCallbackClassName())) return null;
 		return callbacks.computeIfAbsent(attributeInfo.getName(), key -> {
 			try {
 				return (AttributeCallback) Class.forName(attributeInfo.getCallbackClassName())
 						.getDeclaredConstructor().newInstance();
 			} catch (Exception e) {
-				// Consider logging here
-				System.err.println("Failed to instantiate callback for " + key + ": " + e.getMessage());
+				ZimbraLog.misc.error("Failed to instantiate callback for " + key + ": " + e.getMessage());
 				return null;
 			}
 		});

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
@@ -99,15 +99,16 @@ public class LdapAttributeCallbackHelper {
 				name = name.substring(1);
 			}
 			AttributeInfo info = attributeManager.getmAttrs().get(name.toLowerCase());
-
-			final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
-			final AttributeCallback callback = ldapAttributeInfo.getCallback();
-			if (info != null && (allowCallback && callback != null)) {
-				try {
-					callback.postModify(context, name, entry);
-				} catch (Exception e) {
-					// need to swallow all exceptions as postModify shouldn't throw any...
-					ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);
+			if (info != null) {
+				final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
+				final AttributeCallback callback = ldapAttributeInfo.getCallback();
+				if (info != null && (allowCallback && callback != null)) {
+					try {
+						callback.postModify(context, name, entry);
+					} catch (Exception e) {
+						// need to swallow all exceptions as postModify shouldn't throw any...
+						ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);
+					}
 				}
 			}
 		}

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
@@ -10,6 +10,7 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccountServiceException;
+import com.zimbra.cs.account.AttributeCallback;
 import com.zimbra.cs.account.AttributeClass;
 import com.zimbra.cs.account.AttributeConfig;
 import com.zimbra.cs.account.AttributeInfo;
@@ -100,9 +101,10 @@ public class LdapAttributeCallbackHelper {
 			AttributeInfo info = attributeManager.getmAttrs().get(name.toLowerCase());
 
 			final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
-			if (info != null && (allowCallback && ldapAttributeInfo.getCallback() != null)) {
+			final AttributeCallback callback = ldapAttributeInfo.getCallback();
+			if (info != null && (allowCallback && callback != null)) {
 				try {
-					ldapAttributeInfo.getCallback().postModify(context, name, entry);
+					callback.postModify(context, name, entry);
 				} catch (Exception e) {
 					// need to swallow all exceptions as postModify shouldn't throw any...
 					ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
@@ -98,15 +98,16 @@ public class LdapAttributeCallbackHelper {
 				name = name.substring(1);
 			}
 			AttributeInfo info = attributeManager.getmAttrs().get(name.toLowerCase());
-				final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
-				if (info != null && (allowCallback && ldapAttributeInfo.getCallback() != null)) {
-					try {
-						ldapAttributeInfo.getCallback().postModify(context, name, entry);
-					} catch (Exception e) {
-						// need to swallow all exceptions as postModify shouldn't throw any...
-						ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);
-					}
+
+			final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
+			if (info != null && (allowCallback && ldapAttributeInfo.getCallback() != null)) {
+				try {
+					ldapAttributeInfo.getCallback().postModify(context, name, entry);
+				} catch (Exception e) {
+					// need to swallow all exceptions as postModify shouldn't throw any...
+					ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);
 				}
+			}
 		}
 	}
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapAttributeCallbackHelper.java
@@ -10,7 +10,6 @@ import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccountServiceException;
-import com.zimbra.cs.account.AttributeCallback;
 import com.zimbra.cs.account.AttributeClass;
 import com.zimbra.cs.account.AttributeConfig;
 import com.zimbra.cs.account.AttributeInfo;
@@ -99,18 +98,15 @@ public class LdapAttributeCallbackHelper {
 				name = name.substring(1);
 			}
 			AttributeInfo info = attributeManager.getmAttrs().get(name.toLowerCase());
-			if (info != null) {
 				final LdapAttributeInfo ldapAttributeInfo = LdapAttributeInfo.get(info);
-				final AttributeCallback callback = ldapAttributeInfo.getCallback();
-				if (info != null && (allowCallback && callback != null)) {
+				if (info != null && (allowCallback && ldapAttributeInfo.getCallback() != null)) {
 					try {
-						callback.postModify(context, name, entry);
+						ldapAttributeInfo.getCallback().postModify(context, name, entry);
 					} catch (Exception e) {
 						// need to swallow all exceptions as postModify shouldn't throw any...
 						ZimbraLog.account.warn("postModify caught exception: " + e.getMessage(), e);
 					}
 				}
-			}
 		}
 	}
 

--- a/store/src/test/java/com/zimbra/cs/account/LdapAttributeInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/LdapAttributeInfoTest.java
@@ -24,4 +24,12 @@ class LdapAttributeInfoTest extends MailboxTestSuite {
 		final AttributeCallback callback = LdapAttributeInfo.get(accountStatusAttribute).getCallback();
 		Assertions.assertEquals("com.zimbra.cs.account.callback.AccountStatus", callback.getClass().getName());
 	}
+
+	@Test
+	void shouldNotLoadCallbackIfAttributeDoesNotHaveOne() throws ServiceException {
+		final AttributeManager attributeManager = AttributeManager.getInstance();
+		final AttributeInfo accountStatusAttribute = attributeManager.getAttributeInfo(ZAttrProvisioning.A_zimbraMailTransport);
+		final AttributeCallback callback = LdapAttributeInfo.get(accountStatusAttribute).getCallback();
+		Assertions.assertNull(callback);
+	}
 }


### PR DESCRIPTION
Noticed some logs trying to instantiate a class when no callback exist on the attribute