### PR TITLE
chore (ci): upgrade to jenkins-packages-build-library@1.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@chore/IN-930',
+    identifier: 'jenkins-packages-build-library@1.0.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',


### PR DESCRIPTION
This PR updates the Jenkins pipeline to use the newly released jenkins-packages-build-library v1.0.0, which introduces major improvements to our build infrastructure:

Key Benefits:

1. reduce duplicated code
2. centralized configuration for supported platforms (ubuntu-jammy, ubuntu-noble etc.)
3. reutilize the playground rt project to test the pipeline release flow

These changes significantly reduce pipeline complexity while making builds more maintainable and reliable across all Zextras repositories.