### PR TITLE
chore(ci): update jenkins-packages-build-library to 1.0.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@1.0.1',
+    identifier: 'jenkins-packages-build-library@1.0.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
@@ -7,25 +7,11 @@ library(
     ])
 )
 
-def mvnCmd(String cmd) {
-    def profile = ''
-    if (isBuildingTag()) {
-        profile = '-Pprod'
-    }
-    else if (env.BRANCH_NAME == 'devel' ) {
-        profile = '-Pdev'
-    }
-    sh 'mvn -B -s settings-jenkins.xml ' + profile + ' ' + cmd
-}
-def isBuildingTag() {
-    if (env.TAG_NAME) {
-        return true
-    }
-    return false
+boolean isBuildingTag() {
+    return env.TAG_NAME ? true : false
 }
 
 pipeline {
-
     agent {
         node {
             label 'zextras-v1'
@@ -33,29 +19,28 @@ pipeline {
     }
 
     environment {
-        BUILD_PROPERTIES_PARAMS='-Ddebug=0 -Dis-production=1'
+        BUILD_PROPERTIES_PARAMS = '-Ddebug=0 -Dis-production=1'
         GITHUB_BOT_PR_CREDS = credentials('jenkins-integration-with-github-account')
-        JAVA_OPTS='-Dfile.encoding=UTF8'
-        LC_ALL='C.UTF-8'
-        MAVEN_OPTS = "-Xmx4g"
+        JAVA_OPTS = '-Dfile.encoding=UTF8'
+        LC_ALL = 'C.UTF-8'
+        MAVEN_OPTS = '-Xmx4g'
     }
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
-        parallelsAlwaysFailFast()
         skipDefaultCheckout()
         timeout(time: 2, unit: 'HOURS')
     }
 
     parameters {
-        booleanParam defaultValue: false, 
-            description: 'Upload packages in playground repositories.', 
+        booleanParam defaultValue: false,
+            description: 'Upload packages in playground repositories.',
             name: 'PLAYGROUND'
         booleanParam defaultValue: false,
-            description: 'Skip test and sonar analysis.', 
+            description: 'Skip test and sonar analysis.',
             name: 'SKIP_TEST_WITH_COVERAGE'
-        booleanParam defaultValue: false, 
-            description: 'Skip sonar analysis.', 
+        booleanParam defaultValue: false,
+            description: 'Skip sonar analysis.',
             name: 'SKIP_SONARQUBE'
     }
 
@@ -67,15 +52,10 @@ pipeline {
         cron(env.BRANCH_NAME == 'devel' ? 'H 5 * * *' : '')
     }
 
-
     stages {
-        
         stage('Checkout') {
             steps {
                 checkout scm
-                withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                    sh 'cp ${SETTINGS_PATH} settings-jenkins.xml'
-                }
                 script {
                     gitMetadata()
                 }
@@ -85,10 +65,16 @@ pipeline {
         stage('Build') {
             steps {
                 container('jdk-17') {
-                    sh 'apt update && apt install -y build-essential'
-                    mvnCmd("$BUILD_PROPERTIES_PARAMS -DskipTests=true clean install")
-                    sh 'mkdir staging'
-                    sh 'cp -r store* milter* attribute-manager right-manager mailbox-ldap-lib native client common packages soap jython-libs staging'
+                    sh """
+                        apt update && apt install -y build-essential
+                        mvn ${BUILD_PROPERTIES_PARAMS} \
+                            -DskipTests=true \
+                            clean install
+                        mkdir staging
+                        cp -a store* milter* attribute-manager right-manager \
+                                mailbox-ldap-lib native client common packages soap jython-libs \
+                                staging/
+                    """
                     stash includes: 'staging/**', name: 'staging'
                 }
             }
@@ -102,9 +88,10 @@ pipeline {
             }
             steps {
                 container('jdk-17') {
-                    mvnCmd("$BUILD_PROPERTIES_PARAMS verify")
-                    junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
+                    sh "mvn ${BUILD_PROPERTIES_PARAMS} verify"
                 }
+                junit allowEmptyResults: true,
+                    testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
         }
 
@@ -118,7 +105,31 @@ pipeline {
             steps {
                 container('jdk-17') {
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        mvnCmd("$BUILD_PROPERTIES_PARAMS sonar:sonar -Dsonar.junit.reportPaths=target/surefire-reports,target/failsafe-reports -Dsonar.exclusions=**/com/zimbra/soap/mail/type/*.java,**/com/zimbra/soap/mail/message/*.java,**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java")
+                        sh """
+                            mvn ${BUILD_PROPERTIES_PARAMS} \
+                                sonar:sonar \
+                                -Dsonar.junit.reportPaths=target/surefire-reports,target/failsafe-reports \
+                                -Dsonar.exclusions=**/com/zimbra/soap/mail/type/*.java,**/com/zimbra/soap/mail/message/*.java,**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Publish to maven') {
+            when {
+                expression {
+                    return isBuildingTag() || env.BRANCH_NAME == 'devel'
+                }
+            }
+            steps {
+                container('jdk-17') {
+                    withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                        script {
+                            String profile = isBuildingTag() ? '-Pprod' :
+                                    (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
+                            sh "mvn ${profile} ${BUILD_PROPERTIES_PARAMS} deploy -DskipTests=true"
+                        }
                     }
                 }
             }
@@ -134,11 +145,11 @@ pipeline {
                 container('dind') {
                     withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
                         script {
-                            def tagVersions = []
+                            Set<String> tagVersions = []
                             if (isBuildingTag()) {
-                                tagVersions = [env.TAG_NAME, "stable"]
+                                tagVersions = [env.TAG_NAME, 'stable']
                             } else {
-                                tagVersions = ["devel", "latest"]
+                                tagVersions = ['devel', 'latest']
                             }
                             dockerHelper.buildImage([
                                 dockerfile: 'docker/standalone/mailbox/Dockerfile',
@@ -147,7 +158,7 @@ pipeline {
                                 ocLabels: [
                                     title: 'Carbonio Mailbox',
                                     descriptionFile: 'docker/standalone/mailbox/description.md',
-                                    version: env.GIT_TAG ? env.GIT_TAG : "stable"
+                                    version: tagVersions[0]
                                 ]
                             ])
                             dockerHelper.buildImage([
@@ -157,7 +168,7 @@ pipeline {
                                 ocLabels: [
                                     title: 'Carbonio MariaDB',
                                     descriptionFile: 'docker/standalone/mariadb/description.md',
-                                    version: env.GIT_TAG ? env.GIT_TAG : "stable"
+                                    version: tagVersions[0]
                                 ]
                             ])
                             dockerHelper.buildImage([
@@ -167,83 +178,25 @@ pipeline {
                                 ocLabels: [
                                     title: 'Carbonio OpenLDAP',
                                     descriptionFile: 'docker/standalone/openldap/description.md',
-                                    version: env.GIT_TAG ? env.GIT_TAG : "stable"
+                                    version: tagVersions[0]
                                 ]
                             ])
                         }
                     }
-                    withDockerRegistry(
-                        credentialsId: 'private-registry', 
-                        url: 'https://registry.dev.zextras.com'
-                    ) {
-                        script {
-                            dockerHelper.buildImage([
-                                dockerfile: 'docker/standalone/mailbox/Dockerfile', 
-                                imageName: 'registry.dev.zextras.com/dev/carbonio-mailbox',
-                                ocLabels: [
-                                    title: 'Carbonio Mailbox', 
-                                    descriptionFile: 'docker/standalone/mailbox/description.md',
-                                    version: 'latest'
-                                ]
-                            ])
-                            dockerHelper.buildImage([
-                                dockerfile: 'docker/standalone/mariadb/Dockerfile', 
-                                imageName: 'registry.dev.zextras.com/dev/carbonio-mariadb',
-                                ocLabels: [
-                                    title: 'Carbonio MariaDB', 
-                                    descriptionFile: 'docker/standalone/mariadb/description.md',
-                                    version: 'latest'
-                                ]
-                            ])
-                            dockerHelper.buildImage([
-                                dockerfile: 'docker/standalone/openldap/Dockerfile', 
-                                imageName: 'registry.dev.zextras.com/dev/carbonio-openldap',
-                                ocLabels: [
-                                    title: 'Carbonio OpenLDAP', 
-                                    descriptionFile: 'docker/standalone/openldap/description.md',
-                                    version: 'latest'
-                                ]
-                            ])
-                        }
-                    }
-                }
-            }
-        }
-
-        stage('Publish SNAPSHOT to maven') {
-            when {
-                branch 'devel';
-            }
-            steps {
-                container('jdk-17') {
-                    mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
-                }
-            }
-        }
-
-        stage('Publish to maven') {
-            when {
-                expression {
-                    return isBuildingTag()
-                }
-            }
-            steps {
-                container('jdk-17') {
-                    mvnCmd('$BUILD_PROPERTIES_PARAMS deploy -DskipTests=true')
                 }
             }
         }
 
         stage('Build deb/rpm') {
             steps {
-                echo "Building deb/rpm packages"
+                echo 'Building deb/rpm packages'
                 buildStage([
                     skipStash: true,
                     buildDirs: ['staging/packages'],
                     overrides: [
-                        'ubuntu': [
+                        ubuntu: [
                             preBuildScript: '''
-                                apt-get update 
+                                apt-get update
                                 apt-get install -y --no-install-recommends rsync
                             '''
                         ]


### PR DESCRIPTION
* Updated the library identifier to version 1.0.4
* Changed method signature from 'def' to 'void' for mvnCmd.
* Simplified isBuildingTag method.
* Improved formatting and consistency in environment variables and parameters.
* Remove unnecessary mvnProfile function.
* Directly use BUILD_PROPERTIES_PARAMS in Maven commands.
* Adjust profile selection logic for publishing to Maven.