### PR TITLE
chore: allow overriding certain options of mailbox container on startup

### DIFF
--- a/docker/standalone/mailbox/Dockerfile
+++ b/docker/standalone/mailbox/Dockerfile
@@ -28,8 +28,8 @@ ENV MARIADB_URL=mariadb
 ENV MARIADB_PORT=3306
 ENV CARBONIO_FILES_SERVICE_URL="http://carbonio-files:10000"
 ENV CARBONIO_PREVIEW_SERVICE_URL="http://carbonio-preview:10000"
-
-ENV BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
+ENV MAILBOXD_JAVA_OPTS="-Xss256k -Xms1996m -Xmx1996m"
+ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dhttps.protocols=TLSv1.2,TLSv1.3 \
               -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
               -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \

--- a/docker/standalone/mailbox/description.md
+++ b/docker/standalone/mailbox/description.md
@@ -15,5 +15,8 @@ For example the SERVER_HOSTNAME field is replaced by ${HOSTNAME}.
 
 Mailbox provisioning CLI is available as "zmprov".
 
+Startup options of the mailbox (e.g.: memory) can be overridden by setting 
+the environment variable MAILBOXD_JAVA_OPTS.
+
 Traces can be sent by setting TRACING_OPTIONS, e.g.:  
 `TRACING_OPTIONS=-Dotel.service.name=mailbox -Dotel.metrics.exporter=none -Dotel.traces.exporter=zipkin -Dotel.exporter.zipkin.endpoint=http://zipkin:9411/api/v2/spans`

--- a/docker/standalone/mailbox/entrypoint.sh
+++ b/docker/standalone/mailbox/entrypoint.sh
@@ -24,14 +24,28 @@ if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
                                       zimbraReverseProxyLookupTarget TRUE
   echo "Server ${HOSTNAME} created"
 fi
-
+JAVA_OPTS="-Dfile.encoding=UTF-8 -server \
+                         -Dhttps.protocols=TLSv1.2,TLSv1.3 \
+                         -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
+                         -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
+                         -Dsun.net.inetaddr.ttl=60 -Dorg.apache.jasper.compiler.disablejsr199=true \
+                         -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions \
+                         -XX:G1NewSizePercent=15 -XX:G1MaxNewSizePercent=45 -XX:-OmitStackTraceInFastThrow \
+                         -Djava.security.egd=file:/dev/./urandom \
+                         --add-opens java.base/java.lang=ALL-UNNAMED \
+                         ${MAILBOXD_JAVA_OPTS} -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+                         -Djava.library.path=/opt/zextras/lib \
+                         -Dzimbra.config=/localconfig/localconfig.xml \
+                         -Dzimbra.native.required=false \
+                         -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
+                         -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 if [ -z "${TRACING_OPTIONS}" ]; then
-  java ${BASE_JAVA_ARGS} \
+  java ${JAVA_OPTS} \
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
     com.zextras.mailbox.Mailbox
 else
   java -javaagent:/opt/zextras/opentelemetry-javaagent.jar \
-    ${BASE_JAVA_ARGS} \
+    ${JAVA_OPTS} \
     ${TRACING_OPTIONS} \
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
     com.zextras.mailbox.Mailbox


### PR DESCRIPTION
Proposing a parameter to override some startup options of the mailbox.
There are many things that can be overridden, I decided to start from the memory since we have a use case for it.