### PR TITLE
refactor: [CO-2494] move startup shutdown to jetty lifecycle instead of SoapServlet

### DIFF
--- a/store/src/main/java/com/zimbra/soap/SoapServlet.java
+++ b/store/src/main/java/com/zimbra/soap/SoapServlet.java
@@ -123,30 +123,12 @@ public class SoapServlet extends ZimbraServlet {
 
     if (i == 0)
       throw new ServletException("Must specify at least one handler " + PARAM_ENGINE_HANDLER + i);
-
-    try {
-      Zimbra.startup();
-    } catch (OutOfMemoryError e) {
-      Zimbra.halt("out of memory", e);
-    } catch (Throwable t) {
-      ZimbraLog.soap.fatal("Unable to start servlet", t);
-      throw new UnavailableException(t.getMessage());
-    }
   }
 
   @Override
   public void destroy() {
     String name = getServletName();
     ZimbraLog.soap.info("Servlet " + name + " shutting down");
-    try {
-      Zimbra.shutdown();
-    } catch (ServiceException e) {
-      // Log as error and ignore.
-      ZimbraLog.soap.error("ServiceException while shutting down servlet " + name, e);
-    } catch (RuntimeException e) {
-      ZimbraLog.soap.error("Unchecked Exception while shutting down servlet " + name, e);
-      throw e;
-    }
     // FIXME: we might want to add mEngine.destroy()
     // to allow the mEngine to cleanup?
     mEngine = null;


### PR DESCRIPTION
Allocating/starting dependencies on the main control decouples SoapServlet from the surrounding environment.

This allows, for example, declaring dependencies lifecycle in other manners. 
A particular useful use case is the test environment, where we already declare these dependencies startup/shutdown.
As a matter of fact, when running soap tests we cannot use the same JVM, because these dependencies are permanently shutdown and cannot be reused.

Moreover it will possible, in the future or next PRs, to inject the dependencies startup in the Zimbra class, avoiding using static startup and shutdown access.