### PR TITLE
fix: use tcp as protocol in nslookup Consul definition

### DIFF
--- a/packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json
+++ b/packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json
@@ -1,5 +1,5 @@
 {
   "kind": "service-defaults",
   "name": "carbonio-mailbox-nslookup",
-  "protocol": "http"
+  "protocol": "tcp"
 }


### PR DESCRIPTION
Since nslookup already uses https, using http as protocol definition for Envoy results in a wrong parsing of requests that causes SSL errors on any service that tries to call nslookup via its Consul sidecar.

By using "tcp" the traffic is forwarded as-is to the service, removing the parsing errors.

Refs: GB-830