### PR TITLE
fix: [CO-2836] handle calendar groups with no calendarIds

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/mail/CalendarGroupCodec.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/CalendarGroupCodec.java
@@ -3,11 +3,13 @@ package com.zimbra.cs.service.mail;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
+import com.zimbra.cs.mailbox.MailItem.CustomMetadata;
 import com.zimbra.cs.mailbox.Metadata;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CalendarGroupCodec {
@@ -19,8 +21,12 @@ public class CalendarGroupCodec {
     }
 
     protected static List<String> decodeCalendarIds(Folder group) throws ServiceException {
+        final CustomMetadata customData = group.getCustomData(CALENDAR_IDS_SECTION_KEY);
+        if (Objects.isNull(customData)) {
+            return List.of();
+        }
         final var encodedList =
-                group.getCustomData(CALENDAR_IDS_SECTION_KEY).get(CALENDAR_IDS_METADATA_KEY);
+                customData.get(CALENDAR_IDS_METADATA_KEY);
         return !encodedList.isEmpty()
                 ? Arrays.stream(encodedList.split(LIST_SEPARATOR)).toList()
                 : List.of();

--- a/store/src/test/java/com/zimbra/cs/service/mail/CalendarGroupCodecTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/CalendarGroupCodecTest.java
@@ -5,6 +5,7 @@ import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.Folder.FolderOptions;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -12,11 +13,11 @@ class CalendarGroupCodecTest extends MailboxTestSuite {
 
 
 	@Test
-	void shouldDecodeCalendarGroupWithoutCalendarIds() throws Exception {
+	void shouldReturnEmptyCalendarIdsList_IfFolderDoesNotHaveCalendarIds() throws Exception {
 		var account = createAccount().create();
 		final Mailbox mailbox = MailboxManager.getInstance().getMailboxByAccount(account);
-		final FolderOptions fopt = new FolderOptions();
-		final Folder folder = mailbox.createFolder(null, "/myFolder", fopt);
-		Assertions.assertThrows(Exception.class, () ->  CalendarGroupCodec.decodeCalendarIds(folder));
+		final Folder folder = mailbox.createFolder(null, "/myFolder", new FolderOptions());
+		final List<String> strings = CalendarGroupCodec.decodeCalendarIds(folder);
+		Assertions.assertEquals(List.of(), strings);
 	}
 }


### PR DESCRIPTION
If the folder has no calendarIds metadata throws null pointer exception