### PR TITLE
chore: remove tracing options

### DIFF
--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -95,8 +95,7 @@ ENV LDAP_URL="ldap://openldap:1389" \
     MARIADB_PORT=3306 \
     CARBONIO_FILES_SERVICE_URL="http://carbonio-files:10000" \
     CARBONIO_PREVIEW_SERVICE_URL="http://carbonio-preview:10000" \
-    MAILBOXD_JAVA_OPTS="-Xss256k -Xms1996m -Xmx1996m" \
-    TRACING_OPTIONS=""
+    MAILBOXD_JAVA_OPTS="-Xss256k -Xms1996m -Xmx1996m"
 
 COPY docker/mailbox/entrypoint.sh .
 

--- a/docker/mailbox/description.md
+++ b/docker/mailbox/description.md
@@ -17,6 +17,3 @@ Mailbox provisioning CLI is available as "zmprov".
 
 Startup options of the mailbox (e.g.: memory) can be overridden by setting 
 the environment variable MAILBOXD_JAVA_OPTS.
-
-Traces can be sent by setting TRACING_OPTIONS, e.g.:  
-`TRACING_OPTIONS=-Dotel.service.name=mailbox -Dotel.metrics.exporter=none -Dotel.traces.exporter=zipkin -Dotel.exporter.zipkin.endpoint=http://zipkin:9411/api/v2/spans`

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -39,14 +39,7 @@ JAVA_OPTS="-Dfile.encoding=UTF-8 -server \
                          -Dzimbra.native.required=false \
                          -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
                          -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
-if [ -z "${TRACING_OPTIONS}" ]; then
-  exec java ${JAVA_OPTS} \
-    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
-    com.zextras.mailbox.Mailbox
-else
-  exec java -javaagent:/opt/zextras/opentelemetry-javaagent.jar \
-    ${JAVA_OPTS} \
-    ${TRACING_OPTIONS} \
-    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
-    com.zextras.mailbox.Mailbox
-fi
+
+exec java ${JAVA_OPTS} \
+  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+  com.zextras.mailbox.Mailbox


### PR DESCRIPTION
tracing can be added by setting JAVA_TOOL_OPTIONS and OTEL env variables