### PR TITLE
fix(ci): rename API docs output dir to avoid collision with build artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,19 +157,19 @@ pipeline {
             steps {
                 dockerStage([
                         dockerfile: 'docker/mailbox/Dockerfile',
-                        imageName : 'carbonio-mailbox',
-                        ocLabels  : [
-                            title          : 'Carbonio Mailbox',
-                            descriptionFile: 'docker/mailbox/description.md'
-                        ]
+                    imageName : 'carbonio-mailbox',
+                    ocLabels  : [
+                        title          : 'Carbonio Mailbox',
+                        descriptionFile: 'docker/mailbox/description.md'
+                    ]
                 ])
                 dockerStage([
-                        dockerfile: 'docker/mariadb/Dockerfile',
-                        imageName : 'carbonio-mariadb',
-                        ocLabels  : [
-                                title          : 'Carbonio MariaDB',
-                                descriptionFile: 'docker/mariadb/description.md'
-                        ]
+                    dockerfile: 'docker/mariadb/Dockerfile',
+                    imageName : 'carbonio-mariadb',
+                    ocLabels  : [
+                            title          : 'Carbonio MariaDB',
+                            descriptionFile: 'docker/mariadb/description.md'
+                    ]
                 ])
             }
         }
@@ -178,16 +178,16 @@ pipeline {
             steps {
                 echo 'Building deb/rpm packages'
                 buildStage([
-                        skipStash: true,
-                        buildDirs: ['staging/packages'],
-                        overrides: [
-                                ubuntu: [
-                                        preBuildScript: '''
+                    skipStash: true,
+                    buildDirs: ['staging/packages'],
+                    overrides: [
+                        ubuntu: [
+                            preBuildScript: '''
                                 apt-get update
                                 apt-get install -y --no-install-recommends rsync
                             '''
-                                ]
                         ]
+                    ]
                 ])
             }
         }
@@ -199,7 +199,7 @@ pipeline {
             }
             steps {
                 uploadStage(
-                        packages: yapHelper.getPackageNames('staging/packages/yap.json')
+                    packages: yapHelper.getPackageNames('staging/packages/yap.json')
                 )
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,15 +95,16 @@ pipeline {
             steps {
                 container('jdk-21') {
                     sh """
-                        cd soap
-                        mvn ${MVN_OPTS} antrun:run@generate-soap-docs
-                        cd ..
+                        (
+                            cd soap || echo "Directory soap does not exist"
+                            mvn ${MVN_OPTS} antrun:run@generate-soap-docs
+                        )
                         VERSION=\$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-                        mkdir -p artifacts
-                        tar -czf artifacts/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
+                        mkdir -p docs
+                        tar -czf docs/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
                     """
                 }
-                archiveArtifacts artifacts: 'artifacts/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'docs/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
                 container('jdk-21') {
                     sh """
                         (
-                            cd soap || echo "Directory soap does not exist"
+                            cd soap || { echo "Directory soap does not exist"; exit 1; }
                             mvn ${MVN_OPTS} antrun:run@generate-soap-docs
                         )
                         VERSION=\$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -156,7 +156,7 @@ pipeline {
         stage('Build and Publish Docker images') {
             steps {
                 dockerStage([
-                        dockerfile: 'docker/mailbox/Dockerfile',
+                    dockerfile: 'docker/mailbox/Dockerfile',
                     imageName : 'carbonio-mailbox',
                     ocLabels  : [
                         title          : 'Carbonio Mailbox',
@@ -167,8 +167,8 @@ pipeline {
                     dockerfile: 'docker/mariadb/Dockerfile',
                     imageName : 'carbonio-mariadb',
                     ocLabels  : [
-                            title          : 'Carbonio MariaDB',
-                            descriptionFile: 'docker/mariadb/description.md'
+                        title          : 'Carbonio MariaDB',
+                        descriptionFile: 'docker/mariadb/description.md'
                     ]
                 ])
             }


### PR DESCRIPTION
## Summary

Fixes [IN-1044](https://zextras.atlassian.net/browse/IN-1044) — CI devel builds failing since ~Feb 27 with `AccessDeniedException` during the Upload to Devel stage.

- **Root cause**: The "Build and Package API Docs" stage creates a directory called `artifacts/` (inside the `jdk-21` container, running as root). The `buildStage`/`uploadStage` from `jenkins-lib-common` also uses `artifacts/` for `.deb`/`.rpm` packages. When `unstash` runs on the JNLP agent container (as the `jenkins` user), it cannot write into the root-owned `artifacts/` directory → `AccessDeniedException`.
- **Fix**: Rename the API docs output directory from `artifacts/` to `docs/` to eliminate the collision.
- Also includes minor formatting cleanup of indentation in later stages.

[IN-1044]: https://zextras.atlassian.net/browse/IN-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ