### PR TITLE
ci: bump only in main or devel + upload all artifacts in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,9 +123,37 @@ pipeline {
             }
         }
 
+        stage('Build deb/rpm') {
+            steps {
+                echo 'Building deb/rpm packages'
+                buildStage([
+                    skipStash: true,
+                    buildDirs: ['staging/packages'],
+                    overrides: [
+                        ubuntu: [
+                            preBuildScript: '''
+                                apt-get update
+                                apt-get install -y --no-install-recommends rsync
+                            '''
+                        ]
+                    ]
+                ])
+            }
+        }
 
-        stage('Publish artifacts and container') {
+        stage('Upload artifacts')
+        {
             parallel {
+                stage ('Publish packages') {
+                    tools {
+                        jfrog 'jfrog-cli'
+                    }
+                    steps {
+                        uploadStage(
+                                packages: yapHelper.getPackageNames('staging/packages/yap.json')
+                        )
+                    }
+                }
                 stage('Publish SNAPSHOT to maven') {
                     when {
                         not { buildingTag() }
@@ -177,36 +205,7 @@ pipeline {
                     }
                 }
             }
-        }
 
-        stage('Build deb/rpm') {
-            steps {
-                echo 'Building deb/rpm packages'
-                buildStage([
-                    skipStash: true,
-                    buildDirs: ['staging/packages'],
-                    overrides: [
-                        ubuntu: [
-                            preBuildScript: '''
-                                apt-get update
-                                apt-get install -y --no-install-recommends rsync
-                            '''
-                        ]
-                    ]
-                ])
-            }
-        }
-
-        stage('Upload artifacts')
-        {
-            tools {
-                jfrog 'jfrog-cli'
-            }
-            steps {
-                uploadStage(
-                    packages: yapHelper.getPackageNames('staging/packages/yap.json')
-                )
-            }
         }
         stage('Bump version and tag') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,6 +204,12 @@ pipeline {
             }
         }
         stage('Bump version and tag') {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch 'devel'
+                }
+            }
             steps {
                 script {
                     dt2_semanticRelease()


### PR DESCRIPTION
Changes:
- bump version only in main/devel (avoids ~1 min in CI)
- parallel upload of all artifacts