### PR TITLE
ci: build and upload of deb/rpm  in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,37 +123,41 @@ pipeline {
             }
         }
 
-        stage('Build deb/rpm') {
-            steps {
-                echo 'Building deb/rpm packages'
-                buildStage([
-                    skipStash: true,
-                    buildDirs: ['staging/packages'],
-                    overrides: [
-                        ubuntu: [
-                            preBuildScript: '''
+        stage('Build and upload artifacts')
+        {
+            parallel {
+                stage('Packages') {
+                    stages {
+                        stage('Build deb/rpm') {
+                            steps {
+                                echo 'Building deb/rpm packages'
+                                buildStage([
+                                        skipStash: true,
+                                        buildDirs: ['staging/packages'],
+                                        overrides: [
+                                                ubuntu: [
+                                                        preBuildScript: '''
                                 apt-get update
                                 apt-get install -y --no-install-recommends rsync
                             '''
-                        ]
-                    ]
-                ])
-            }
-        }
-
-        stage('Upload artifacts')
-        {
-            parallel {
-                stage ('Publish packages') {
-                    tools {
-                        jfrog 'jfrog-cli'
-                    }
-                    steps {
-                        uploadStage(
-                                packages: yapHelper.getPackageNames('staging/packages/yap.json')
-                        )
+                                                ]
+                                        ]
+                                ])
+                            }
+                        }
+                        stage ('Publish packages') {
+                            tools {
+                                jfrog 'jfrog-cli'
+                            }
+                            steps {
+                                uploadStage(
+                                        packages: yapHelper.getPackageNames('staging/packages/yap.json')
+                                )
+                            }
+                        }
                     }
                 }
+
                 stage('Publish SNAPSHOT to maven') {
                     when {
                         not { buildingTag() }


### PR DESCRIPTION
Today the whole CI of mailbox takes ~15 minutes. Despite the improvements we made it is still takes a lot.
Moreover, of 15 minutes, 8 are spent in tests, the rest is split between sonarqube (~4 minutes, varies) and other tasks.

The changes made in this PR focus on running in parallel jobs that don't depend on each other.

```mermaid                                                                                                                                
  graph LR                                                                                                                                  
      A[Checkout] --> B[Build Maven]                                                                                                        
      B --> C[Tests]
      C --> D[Sonarqube]
      D --> E[Build Packages]                                                                                                               
      E --> F[Upload Packages]                                                                                                              
      D --> G[Deploy Maven]                                                                                                                 
      D --> H[Build & Push Container]                                                                                                                                                                                                                                      
```    

This flow focuses on "correctness".

---

Another idea was to parallelize the package build to test:
  
  ```mermaid                                                                                                                                
  graph LR                                                                                                                                  
      A[Checkout] --> B[Build Maven]                                                                                                        
      B --> C[Tests]
      B --> E[Build Packages]                                                                                                               
      C --> D[Sonarqube]
      D --> F[Upload Packages]                                                                                                              
      D --> G[Deploy Maven]                                                                                                                 
      D --> H[Build & Push Container]                                                                                                                                                                                                                                      
  ```
  
**This flow focuses  more on speed optimization**, because tests take ~8 minutes, packages build takes ~2min30s each (in parallel), upload of packages takes ~1min30s, so ~4min total.
**Moving the packages build near tests would save 2min30s.**

I've noticed most time in build of packages is spent when unstashing artifacts (~1min).
Upload of packages takes ~1min30, but most time is spent on build scan, so not negotiable.
