### PR TITLE
chore: [CO-3381] add images for envoy sidecar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,6 +199,34 @@ pipeline {
                                 ]
                         ])
                         dockerStage([
+                                dockerfile: 'docker/mailbox-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-sidecar',
+                                ocLabels  : [
+                                        title : 'Carbonio Mailbox Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-admin-sidecar',
+                                ocLabels  : [
+                                        title : 'Carbonio Mailbox Admin Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-nslookup-sidecar',
+                                ocLabels  : [
+                                        title : 'Carbonio Mailbox NSLookup Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-internal-api-sidecar',
+                                ocLabels  : [
+                                        title : 'Carbonio Mailbox Internal API Sidecar',
+                                ]
+                        ])
+                        dockerStage([
                                 dockerfile: 'docker/mariadb/Dockerfile',
                                 imageName : 'carbonio-mariadb',
                                 ocLabels  : [

--- a/docker/mailbox-admin-sidecar/Dockerfile
+++ b/docker/mailbox-admin-sidecar/Dockerfile
@@ -14,3 +14,4 @@ RUN chmod +x /usr/local/bin/carbonio-mailbox-admin
 
 ENV SERVICE_NAME=carbonio-mailbox-admin
 ENV SETUP_SCRIPT="carbonio-mailbox-admin setup"
+ENV TOKEN_FILE=/etc/carbonio/mailbox-admin/service-discover/token

--- a/docker/mailbox-admin-sidecar/Dockerfile
+++ b/docker/mailbox-admin-sidecar/Dockerfile
@@ -4,9 +4,9 @@ FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 COPY packages/appserver-service/carbonio-mailbox-admin.hcl /consul/config/
 
 # Setup files
-COPY packages/appserver-service/carbonio-mailbox-admin-service-protocol.json /etc/carbonio/mailbox-admin/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-admin-intentions.json       /etc/carbonio/mailbox-admin/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-admin-policies.json         /etc/carbonio/mailbox-admin/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-admin-service-protocol.json /etc/carbonio/mailbox-admin/service-discover/service-protocol.json
+COPY packages/appserver-service/carbonio-mailbox-admin-intentions.json       /etc/carbonio/mailbox-admin/service-discover/intentions.json
+COPY packages/appserver-service/carbonio-mailbox-admin-policies.json         /etc/carbonio/mailbox-admin/service-discover/policies.json
 
 # Setup script
 COPY packages/appserver-service/carbonio-mailbox-admin /usr/local/bin/carbonio-mailbox-admin

--- a/docker/mailbox-admin-sidecar/Dockerfile
+++ b/docker/mailbox-admin-sidecar/Dockerfile
@@ -1,0 +1,33 @@
+FROM docker.io/envoyproxy/envoy:v1.27-latest
+COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
+# Fake service-discover binary — returns a predefined bootstrap token
+RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
+    && chmod +x /usr/local/bin/service-discover
+
+# Service registration (registered via consul services register)
+COPY packages/appserver-service/carbonio-mailbox-admin.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY packages/appserver-service/carbonio-mailbox-admin-service-protocol.json /etc/carbonio/mailbox-admin/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-admin-intentions.json       /etc/carbonio/mailbox-admin/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-admin-policies.json         /etc/carbonio/mailbox-admin/service-discover/
+
+# Setup script (runs as-is from the package)
+COPY packages/appserver-service/carbonio-mailbox-admin /usr/local/bin/carbonio-mailbox-admin
+RUN chmod +x /usr/local/bin/carbonio-mailbox-admin
+
+ENV SERVICE_NAME=carbonio-mailbox-admin
+
+ENTRYPOINT ["/bin/sh", "-c", "\
+  echo '[sidecar] Waiting for consul agent...' && \
+  until consul members >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Consul agent ready.' && \
+  consul services register /consul/config/*.hcl && \
+  (carbonio-mailbox-admin setup || true) && \
+  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
+  exec consul connect envoy \
+    -sidecar-for=$SERVICE_NAME \
+    -admin-bind=localhost:0 \
+"]

--- a/docker/mailbox-admin-sidecar/Dockerfile
+++ b/docker/mailbox-admin-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost/carbonio-sidecar-base:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 
 # Service registration
 COPY packages/appserver-service/carbonio-mailbox-admin.hcl /consul/config/

--- a/docker/mailbox-admin-sidecar/Dockerfile
+++ b/docker/mailbox-admin-sidecar/Dockerfile
@@ -1,33 +1,16 @@
-FROM docker.io/envoyproxy/envoy:v1.27-latest
-COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
-RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+FROM localhost/carbonio-sidecar-base:latest
 
-# Fake service-discover binary — returns a predefined bootstrap token
-RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
-    && chmod +x /usr/local/bin/service-discover
-
-# Service registration (registered via consul services register)
+# Service registration
 COPY packages/appserver-service/carbonio-mailbox-admin.hcl /consul/config/
 
-# Setup files at the path the setup script expects
+# Setup files
 COPY packages/appserver-service/carbonio-mailbox-admin-service-protocol.json /etc/carbonio/mailbox-admin/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-admin-intentions.json       /etc/carbonio/mailbox-admin/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-admin-policies.json         /etc/carbonio/mailbox-admin/service-discover/
 
-# Setup script (runs as-is from the package)
+# Setup script
 COPY packages/appserver-service/carbonio-mailbox-admin /usr/local/bin/carbonio-mailbox-admin
 RUN chmod +x /usr/local/bin/carbonio-mailbox-admin
 
 ENV SERVICE_NAME=carbonio-mailbox-admin
-
-ENTRYPOINT ["/bin/sh", "-c", "\
-  echo '[sidecar] Waiting for consul agent...' && \
-  until consul members >/dev/null 2>&1; do sleep 1; done && \
-  echo '[sidecar] Consul agent ready.' && \
-  consul services register /consul/config/*.hcl && \
-  (carbonio-mailbox-admin setup || true) && \
-  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
-  exec consul connect envoy \
-    -sidecar-for=$SERVICE_NAME \
-    -admin-bind=localhost:0 \
-"]
+ENV SETUP_SCRIPT="carbonio-mailbox-admin setup"

--- a/docker/mailbox-internal-api-sidecar/Dockerfile
+++ b/docker/mailbox-internal-api-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost/carbonio-sidecar-base:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 
 # Service registration
 COPY packages/appserver-service/carbonio-mailbox-internal-api.hcl /consul/config/

--- a/docker/mailbox-internal-api-sidecar/Dockerfile
+++ b/docker/mailbox-internal-api-sidecar/Dockerfile
@@ -1,33 +1,16 @@
-FROM docker.io/envoyproxy/envoy:v1.27-latest
-COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
-RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+FROM localhost/carbonio-sidecar-base:latest
 
-# Fake service-discover binary — returns a predefined bootstrap token
-RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
-    && chmod +x /usr/local/bin/service-discover
-
-# Service registration (registered via consul services register)
+# Service registration
 COPY packages/appserver-service/carbonio-mailbox-internal-api.hcl /consul/config/
 
-# Setup files at the path the setup script expects
+# Setup files
 COPY packages/appserver-service/carbonio-mailbox-internal-api-service-protocol.json /etc/carbonio/mailbox-internal-api/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-internal-api-intentions.json       /etc/carbonio/mailbox-internal-api/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-internal-api-policies.json         /etc/carbonio/mailbox-internal-api/service-discover/
 
-# Setup script (runs as-is from the package)
+# Setup script
 COPY packages/appserver-service/carbonio-mailbox-internal-api /usr/local/bin/carbonio-mailbox-internal-api
 RUN chmod +x /usr/local/bin/carbonio-mailbox-internal-api
 
 ENV SERVICE_NAME=carbonio-mailbox-internal-api
-
-ENTRYPOINT ["/bin/sh", "-c", "\
-  echo '[sidecar] Waiting for consul agent...' && \
-  until consul members >/dev/null 2>&1; do sleep 1; done && \
-  echo '[sidecar] Consul agent ready.' && \
-  consul services register /consul/config/*.hcl && \
-  (carbonio-mailbox-internal-api setup || true) && \
-  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
-  exec consul connect envoy \
-    -sidecar-for=$SERVICE_NAME \
-    -admin-bind=localhost:0 \
-"]
+ENV SETUP_SCRIPT="carbonio-mailbox-internal-api setup"

--- a/docker/mailbox-internal-api-sidecar/Dockerfile
+++ b/docker/mailbox-internal-api-sidecar/Dockerfile
@@ -1,0 +1,33 @@
+FROM docker.io/envoyproxy/envoy:v1.27-latest
+COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
+# Fake service-discover binary — returns a predefined bootstrap token
+RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
+    && chmod +x /usr/local/bin/service-discover
+
+# Service registration (registered via consul services register)
+COPY packages/appserver-service/carbonio-mailbox-internal-api.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY packages/appserver-service/carbonio-mailbox-internal-api-service-protocol.json /etc/carbonio/mailbox-internal-api/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-internal-api-intentions.json       /etc/carbonio/mailbox-internal-api/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-internal-api-policies.json         /etc/carbonio/mailbox-internal-api/service-discover/
+
+# Setup script (runs as-is from the package)
+COPY packages/appserver-service/carbonio-mailbox-internal-api /usr/local/bin/carbonio-mailbox-internal-api
+RUN chmod +x /usr/local/bin/carbonio-mailbox-internal-api
+
+ENV SERVICE_NAME=carbonio-mailbox-internal-api
+
+ENTRYPOINT ["/bin/sh", "-c", "\
+  echo '[sidecar] Waiting for consul agent...' && \
+  until consul members >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Consul agent ready.' && \
+  consul services register /consul/config/*.hcl && \
+  (carbonio-mailbox-internal-api setup || true) && \
+  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
+  exec consul connect envoy \
+    -sidecar-for=$SERVICE_NAME \
+    -admin-bind=localhost:0 \
+"]

--- a/docker/mailbox-internal-api-sidecar/Dockerfile
+++ b/docker/mailbox-internal-api-sidecar/Dockerfile
@@ -14,3 +14,4 @@ RUN chmod +x /usr/local/bin/carbonio-mailbox-internal-api
 
 ENV SERVICE_NAME=carbonio-mailbox-internal-api
 ENV SETUP_SCRIPT="carbonio-mailbox-internal-api setup"
+ENV TOKEN_FILE=/etc/carbonio/mailbox-internal-api/service-discover/token

--- a/docker/mailbox-internal-api-sidecar/Dockerfile
+++ b/docker/mailbox-internal-api-sidecar/Dockerfile
@@ -4,9 +4,9 @@ FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 COPY packages/appserver-service/carbonio-mailbox-internal-api.hcl /consul/config/
 
 # Setup files
-COPY packages/appserver-service/carbonio-mailbox-internal-api-service-protocol.json /etc/carbonio/mailbox-internal-api/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-internal-api-intentions.json       /etc/carbonio/mailbox-internal-api/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-internal-api-policies.json         /etc/carbonio/mailbox-internal-api/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-internal-api-service-protocol.json /etc/carbonio/mailbox-internal-api/service-discover/service-protocol.json
+COPY packages/appserver-service/carbonio-mailbox-internal-api-intentions.json       /etc/carbonio/mailbox-internal-api/service-discover/intentions.json
+COPY packages/appserver-service/carbonio-mailbox-internal-api-policies.json         /etc/carbonio/mailbox-internal-api/service-discover/policies.json
 
 # Setup script
 COPY packages/appserver-service/carbonio-mailbox-internal-api /usr/local/bin/carbonio-mailbox-internal-api

--- a/docker/mailbox-nslookup-sidecar/Dockerfile
+++ b/docker/mailbox-nslookup-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost/carbonio-sidecar-base:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 
 # Service registration
 COPY packages/appserver-service/carbonio-mailbox-nslookup.hcl /consul/config/

--- a/docker/mailbox-nslookup-sidecar/Dockerfile
+++ b/docker/mailbox-nslookup-sidecar/Dockerfile
@@ -14,3 +14,4 @@ RUN chmod +x /usr/local/bin/carbonio-mailbox-nslookup
 
 ENV SERVICE_NAME=carbonio-mailbox-nslookup
 ENV SETUP_SCRIPT="carbonio-mailbox-nslookup setup"
+ENV TOKEN_FILE=/etc/carbonio/mailbox-nslookup/service-discover/token

--- a/docker/mailbox-nslookup-sidecar/Dockerfile
+++ b/docker/mailbox-nslookup-sidecar/Dockerfile
@@ -1,33 +1,16 @@
-FROM docker.io/envoyproxy/envoy:v1.27-latest
-COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
-RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+FROM localhost/carbonio-sidecar-base:latest
 
-# Fake service-discover binary — returns a predefined bootstrap token
-RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
-    && chmod +x /usr/local/bin/service-discover
-
-# Service registration (registered via consul services register)
+# Service registration
 COPY packages/appserver-service/carbonio-mailbox-nslookup.hcl /consul/config/
 
-# Setup files at the path the setup script expects
+# Setup files
 COPY packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json /etc/carbonio/mailbox-nslookup/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-nslookup-intentions.json       /etc/carbonio/mailbox-nslookup/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-nslookup-policies.json         /etc/carbonio/mailbox-nslookup/service-discover/
 
-# Setup script (runs as-is from the package)
+# Setup script
 COPY packages/appserver-service/carbonio-mailbox-nslookup /usr/local/bin/carbonio-mailbox-nslookup
 RUN chmod +x /usr/local/bin/carbonio-mailbox-nslookup
 
 ENV SERVICE_NAME=carbonio-mailbox-nslookup
-
-ENTRYPOINT ["/bin/sh", "-c", "\
-  echo '[sidecar] Waiting for consul agent...' && \
-  until consul members >/dev/null 2>&1; do sleep 1; done && \
-  echo '[sidecar] Consul agent ready.' && \
-  consul services register /consul/config/*.hcl && \
-  (carbonio-mailbox-nslookup setup || true) && \
-  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
-  exec consul connect envoy \
-    -sidecar-for=$SERVICE_NAME \
-    -admin-bind=localhost:0 \
-"]
+ENV SETUP_SCRIPT="carbonio-mailbox-nslookup setup"

--- a/docker/mailbox-nslookup-sidecar/Dockerfile
+++ b/docker/mailbox-nslookup-sidecar/Dockerfile
@@ -1,0 +1,33 @@
+FROM docker.io/envoyproxy/envoy:v1.27-latest
+COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
+# Fake service-discover binary — returns a predefined bootstrap token
+RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
+    && chmod +x /usr/local/bin/service-discover
+
+# Service registration (registered via consul services register)
+COPY packages/appserver-service/carbonio-mailbox-nslookup.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json /etc/carbonio/mailbox-nslookup/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-nslookup-intentions.json       /etc/carbonio/mailbox-nslookup/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-nslookup-policies.json         /etc/carbonio/mailbox-nslookup/service-discover/
+
+# Setup script (runs as-is from the package)
+COPY packages/appserver-service/carbonio-mailbox-nslookup /usr/local/bin/carbonio-mailbox-nslookup
+RUN chmod +x /usr/local/bin/carbonio-mailbox-nslookup
+
+ENV SERVICE_NAME=carbonio-mailbox-nslookup
+
+ENTRYPOINT ["/bin/sh", "-c", "\
+  echo '[sidecar] Waiting for consul agent...' && \
+  until consul members >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Consul agent ready.' && \
+  consul services register /consul/config/*.hcl && \
+  (carbonio-mailbox-nslookup setup || true) && \
+  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
+  exec consul connect envoy \
+    -sidecar-for=$SERVICE_NAME \
+    -admin-bind=localhost:0 \
+"]

--- a/docker/mailbox-nslookup-sidecar/Dockerfile
+++ b/docker/mailbox-nslookup-sidecar/Dockerfile
@@ -4,9 +4,9 @@ FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 COPY packages/appserver-service/carbonio-mailbox-nslookup.hcl /consul/config/
 
 # Setup files
-COPY packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json /etc/carbonio/mailbox-nslookup/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-nslookup-intentions.json       /etc/carbonio/mailbox-nslookup/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-nslookup-policies.json         /etc/carbonio/mailbox-nslookup/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json /etc/carbonio/mailbox-nslookup/service-discover/service-protocol.json
+COPY packages/appserver-service/carbonio-mailbox-nslookup-intentions.json       /etc/carbonio/mailbox-nslookup/service-discover/intentions.json
+COPY packages/appserver-service/carbonio-mailbox-nslookup-policies.json         /etc/carbonio/mailbox-nslookup/service-discover/policies.json
 
 # Setup script
 COPY packages/appserver-service/carbonio-mailbox-nslookup /usr/local/bin/carbonio-mailbox-nslookup

--- a/docker/mailbox-sidecar/Dockerfile
+++ b/docker/mailbox-sidecar/Dockerfile
@@ -1,0 +1,33 @@
+FROM docker.io/envoyproxy/envoy:v1.27-latest
+COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
+# Fake service-discover binary — returns a predefined bootstrap token
+RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
+    && chmod +x /usr/local/bin/service-discover
+
+# Service registration (registered via consul services register)
+COPY packages/appserver-service/carbonio-mailbox.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY packages/appserver-service/carbonio-mailbox-service-protocol.json /etc/carbonio/mailbox/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-intentions.json       /etc/carbonio/mailbox/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-policies.json         /etc/carbonio/mailbox/service-discover/
+
+# Setup script (runs as-is from the package)
+COPY packages/appserver-service/carbonio-mailbox /usr/local/bin/carbonio-mailbox
+RUN chmod +x /usr/local/bin/carbonio-mailbox
+
+ENV SERVICE_NAME=carbonio-mailbox
+
+ENTRYPOINT ["/bin/sh", "-c", "\
+  echo '[sidecar] Waiting for consul agent...' && \
+  until consul members >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Consul agent ready.' && \
+  consul services register /consul/config/*.hcl && \
+  (carbonio-mailbox setup || true) && \
+  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
+  exec consul connect envoy \
+    -sidecar-for=$SERVICE_NAME \
+    -admin-bind=localhost:0 \
+"]

--- a/docker/mailbox-sidecar/Dockerfile
+++ b/docker/mailbox-sidecar/Dockerfile
@@ -1,33 +1,16 @@
-FROM docker.io/envoyproxy/envoy:v1.27-latest
-COPY --from=docker.io/hashicorp/consul:1.17 /bin/consul /usr/local/bin/consul
-RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+FROM localhost/carbonio-sidecar-base:latest
 
-# Fake service-discover binary — returns a predefined bootstrap token
-RUN printf '#!/bin/sh\necho "00000000-0000-0000-0000-000000000000"\n' > /usr/local/bin/service-discover \
-    && chmod +x /usr/local/bin/service-discover
-
-# Service registration (registered via consul services register)
+# Service registration
 COPY packages/appserver-service/carbonio-mailbox.hcl /consul/config/
 
-# Setup files at the path the setup script expects
+# Setup files
 COPY packages/appserver-service/carbonio-mailbox-service-protocol.json /etc/carbonio/mailbox/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-intentions.json       /etc/carbonio/mailbox/service-discover/
 COPY packages/appserver-service/carbonio-mailbox-policies.json         /etc/carbonio/mailbox/service-discover/
 
-# Setup script (runs as-is from the package)
+# Setup script
 COPY packages/appserver-service/carbonio-mailbox /usr/local/bin/carbonio-mailbox
 RUN chmod +x /usr/local/bin/carbonio-mailbox
 
 ENV SERVICE_NAME=carbonio-mailbox
-
-ENTRYPOINT ["/bin/sh", "-c", "\
-  echo '[sidecar] Waiting for consul agent...' && \
-  until consul members >/dev/null 2>&1; do sleep 1; done && \
-  echo '[sidecar] Consul agent ready.' && \
-  consul services register /consul/config/*.hcl && \
-  (carbonio-mailbox setup || true) && \
-  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
-  exec consul connect envoy \
-    -sidecar-for=$SERVICE_NAME \
-    -admin-bind=localhost:0 \
-"]
+ENV SETUP_SCRIPT="carbonio-mailbox setup"

--- a/docker/mailbox-sidecar/Dockerfile
+++ b/docker/mailbox-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost/carbonio-sidecar-base:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 
 # Service registration
 COPY packages/appserver-service/carbonio-mailbox.hcl /consul/config/

--- a/docker/mailbox-sidecar/Dockerfile
+++ b/docker/mailbox-sidecar/Dockerfile
@@ -4,9 +4,9 @@ FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 COPY packages/appserver-service/carbonio-mailbox.hcl /consul/config/
 
 # Setup files
-COPY packages/appserver-service/carbonio-mailbox-service-protocol.json /etc/carbonio/mailbox/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-intentions.json       /etc/carbonio/mailbox/service-discover/
-COPY packages/appserver-service/carbonio-mailbox-policies.json         /etc/carbonio/mailbox/service-discover/
+COPY packages/appserver-service/carbonio-mailbox-service-protocol.json /etc/carbonio/mailbox/service-discover/service-protocol.json
+COPY packages/appserver-service/carbonio-mailbox-intentions.json       /etc/carbonio/mailbox/service-discover/intentions.json
+COPY packages/appserver-service/carbonio-mailbox-policies.json         /etc/carbonio/mailbox/service-discover/policies.json
 
 # Setup script
 COPY packages/appserver-service/carbonio-mailbox /usr/local/bin/carbonio-mailbox

--- a/docker/mailbox-sidecar/Dockerfile
+++ b/docker/mailbox-sidecar/Dockerfile
@@ -14,3 +14,4 @@ RUN chmod +x /usr/local/bin/carbonio-mailbox
 
 ENV SERVICE_NAME=carbonio-mailbox
 ENV SETUP_SCRIPT="carbonio-mailbox setup"
+ENV TOKEN_FILE=/etc/carbonio/mailbox/service-discover/token


### PR DESCRIPTION
Allows setting up a container infrastructure using Consul mesh.

The idea is:
- one pod per service
- each pod contains an app + sidecar + consul agent

Reduces configuration of container (uses production/default values) + allows testing .hcl, policies, intentions and mesh definitions without the need of a VM infrastructure