### PR TITLE
feat: [CO-3422] native sd_notify via Java FFM, sidecar ordering, and systemd hardening

### DIFF
--- a/packages/appserver-conf/PKGBUILD
+++ b/packages/appserver-conf/PKGBUILD
@@ -16,8 +16,8 @@ section="mail"
 priority="optional"
 
 package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
-  gunzip -dc store/conf/common/common-passwords.gz > common-passwords.txt
+  cd "$(dirname "$(find /project -name "yap.json" -print -quit)")/.."
+  gunzip -dc store/conf/common/common-passwords.gz >common-passwords.txt
 
   install -D "store/conf/globs2" \
     "${pkgdir}/opt/zextras/conf/globs2"

--- a/packages/appserver-db/PKGBUILD
+++ b/packages/appserver-db/PKGBUILD
@@ -18,7 +18,7 @@ conflicts=('carbonio-common-appserver-db')
 replaces=('carbonio-common-appserver-db')
 
 _package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
+  cd "$(dirname "$(find /project -name "yap.json" -print -quit)")/.."
 
   install -D "store/db/versions-init.sql" \
     "${pkgdir}/opt/zextras/db/versions-init.sql"

--- a/packages/appserver-db/carbonio-appserver-db.service
+++ b/packages/appserver-db/carbonio-appserver-db.service
@@ -11,8 +11,29 @@ ExecStart=/opt/zextras/common/bin/mysqld_safe \
   --malloc-lib=/opt/zextras/common/lib/libjemalloc.so \
   --ledir=/opt/zextras/common/sbin
 LimitNOFILE=524288
+TimeoutStartSec=300s
+TimeoutStopSec=120s
 Restart=on-failure
 RestartSec=5s
+
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/opt/zextras/data /opt/zextras/log /opt/zextras/conf /opt/zextras/db /run/carbonio
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
 [Install]
 WantedBy=carbonio-appserver.target

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -13,6 +13,7 @@ license=(
 )
 url="https://github.com/zextras"
 depends=(
+  "carbonio-core"
   "service-discover"
   "pending-setups"
 )
@@ -29,7 +30,7 @@ sha256sums=(
 )
 
 _package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
+  cd "$(dirname "$(find /project -name "yap.json" -print -quit)")/.."
 
   # Mailbox
   install -Dm755 packages/appserver-service/carbonio-mailbox \
@@ -72,7 +73,6 @@ _package() {
     "${pkgdir}/etc/carbonio/mailbox-nslookup/service-discover/policies.json"
   install -Dm644 packages/appserver-service/carbonio-mailbox-nslookup-service-protocol.json \
     "${pkgdir}/etc/carbonio/mailbox-nslookup/service-discover/service-protocol.json"
-
 
   # Mailbox Internal API
   install -Dm755 packages/appserver-service/carbonio-mailbox-internal-api \

--- a/packages/appserver-service/carbonio-appserver.service
+++ b/packages/appserver-service/carbonio-appserver.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=Carbonio Appserver Daemon
 After=carbonio-appserver-db.service carbonio-configd.service
-Wants=carbonio-appserver-db.service carbonio-configd.service
+Wants=carbonio-appserver-db.service carbonio-configd.service carbonio-mailbox-sidecar.service carbonio-mailbox-internal-api-sidecar.service
 PartOf=carbonio-appserver.target
 
 [Service]
 User=zextras
+Type=notify
+NotifyAccess=main
 EnvironmentFile=-/opt/zextras/data/systemd.env
 ExecStartPre=echo REWRITE \
   sasl \
@@ -18,6 +20,8 @@ ExecStartPre=echo REWRITE \
   | netcat -w 120 localhost 7171
 ExecStartPre=-/opt/zextras/bin/zmtlsctl
 ExecStart=/opt/zextras/common/bin/java \
+  --enable-preview \
+  --enable-native-access=ALL-UNNAMED \
   -Dfile.encoding=UTF-8 \
   $mailboxd_java_options \
   -Xms${java_xms}m \
@@ -28,10 +32,30 @@ ExecStart=/opt/zextras/common/bin/java \
   -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
   com.zextras.mailbox.Mailbox
 LimitNOFILE=524288
+TimeoutStartSec=300s
 RestartSec=3s
 Restart=on-failure
 SuccessExitStatus=143
 StandardError=append:/opt/zextras/log/zmmailboxd.out
+
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/opt/zextras/log /opt/zextras/data /opt/zextras/mailboxd /opt/zextras/conf /run/carbonio
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 
 [Install]
 WantedBy=carbonio-appserver.target

--- a/packages/appserver-service/carbonio-mailbox-admin-sidecar-legacy.service
+++ b/packages/appserver-service/carbonio-mailbox-admin-sidecar-legacy.service
@@ -16,5 +16,24 @@ ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
 WantedBy=multi-user.target

--- a/packages/appserver-service/carbonio-mailbox-admin-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-admin-sidecar.service
@@ -2,20 +2,41 @@
 Description=Carbonio Mailbox Admin Sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
-After=network-online.target
-PartOf=carbonio-appserver.target
+After=network-online.target service-discover.service carbonio-appserver.service
+PartOf=service-discover.target
 
 [Service]
 User=carbonio-mailbox
-ExecStart=/usr/bin/consul connect envoy \
+Type=notify
+NotifyAccess=all
+ExecStart=/usr/bin/service-discover-wrapper.sh \
     -token-file /etc/carbonio/mailbox-admin/service-discover/token \
     -admin-bind localhost:0 \
     -sidecar-for carbonio-mailbox-admin
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=15s
-ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
-WantedBy=carbonio-appserver.target
+WantedBy=service-discover.target

--- a/packages/appserver-service/carbonio-mailbox-internal-api-sidecar-legacy.service
+++ b/packages/appserver-service/carbonio-mailbox-internal-api-sidecar-legacy.service
@@ -16,5 +16,24 @@ ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
 WantedBy=multi-user.target

--- a/packages/appserver-service/carbonio-mailbox-internal-api-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-internal-api-sidecar.service
@@ -2,20 +2,41 @@
 Description=Carbonio Mailbox Internal Api Sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
-After=network-online.target
-PartOf=carbonio-appserver.target
+After=network-online.target service-discover.service carbonio-appserver.service
+PartOf=service-discover.target
 
 [Service]
 User=carbonio-mailbox
-ExecStart=/usr/bin/consul connect envoy \
+Type=notify
+NotifyAccess=all
+ExecStart=/usr/bin/service-discover-wrapper.sh \
     -token-file /etc/carbonio/mailbox-internal-api/service-discover/token \
     -admin-bind localhost:0 \
     -sidecar-for carbonio-mailbox-internal-api
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=15s
-ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
-WantedBy=carbonio-appserver.target
+WantedBy=service-discover.target

--- a/packages/appserver-service/carbonio-mailbox-nslookup-sidecar-legacy.service
+++ b/packages/appserver-service/carbonio-mailbox-nslookup-sidecar-legacy.service
@@ -16,5 +16,24 @@ ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
 WantedBy=multi-user.target

--- a/packages/appserver-service/carbonio-mailbox-nslookup-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-nslookup-sidecar.service
@@ -2,20 +2,41 @@
 Description=Carbonio Mailbox NSLookup Sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
-After=network-online.target
-PartOf=carbonio-appserver.target
+After=network-online.target service-discover.service carbonio-appserver.service
+PartOf=service-discover.target
 
 [Service]
 User=carbonio-mailbox
-ExecStart=/usr/bin/consul connect envoy \
+Type=notify
+NotifyAccess=all
+ExecStart=/usr/bin/service-discover-wrapper.sh \
     -token-file /etc/carbonio/mailbox-nslookup/service-discover/token \
     -admin-bind localhost:0 \
     -sidecar-for carbonio-mailbox-nslookup
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=15s
-ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
-WantedBy=carbonio-appserver.target
+WantedBy=service-discover.target

--- a/packages/appserver-service/carbonio-mailbox-sidecar-legacy.service
+++ b/packages/appserver-service/carbonio-mailbox-sidecar-legacy.service
@@ -16,5 +16,24 @@ ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
 WantedBy=multi-user.target

--- a/packages/appserver-service/carbonio-mailbox-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-sidecar.service
@@ -2,20 +2,41 @@
 Description=Carbonio Mailbox Sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
-After=network-online.target
-PartOf=carbonio-appserver.target
+After=network-online.target service-discover.service carbonio-appserver.service
+PartOf=service-discover.target
 
 [Service]
 User=carbonio-mailbox
-ExecStart=/usr/bin/consul connect envoy \
+Type=notify
+NotifyAccess=all
+ExecStart=/usr/bin/service-discover-wrapper.sh \
     -token-file /etc/carbonio/mailbox/service-discover/token \
     -admin-bind localhost:0 \
     -sidecar-for carbonio-mailbox
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=15s
-ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitNOFILE=65536
 
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
 [Install]
-WantedBy=carbonio-appserver.target
+WantedBy=service-discover.target

--- a/packages/common-appserver-conf/PKGBUILD
+++ b/packages/common-appserver-conf/PKGBUILD
@@ -19,7 +19,7 @@ backup=(
 )
 
 _package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
+  cd "$(dirname "$(find /project -name "yap.json" -print -quit)")/.."
 
   unzip -o store/target/dependencies/mailbox-attribute-manager-*.jar 'conf/*' 'attrs-schema' -d attribute-manager
   install -D "attribute-manager/attrs-schema" \

--- a/packages/common-appserver-conf/carbonio-milter.service
+++ b/packages/common-appserver-conf/carbonio-milter.service
@@ -6,8 +6,12 @@ PartOf=carbonio-mta.target
 
 [Service]
 User=zextras
+Type=notify
+NotifyAccess=main
 EnvironmentFile=-/opt/zextras/data/systemd.env
 ExecStart=/opt/zextras/common/lib/jvm/java/bin/java \
+  --enable-preview \
+  --enable-native-access=ALL-UNNAMED \
   -XX:ErrorFile=/opt/zextras/log \
   -client \
   $java_options \
@@ -19,7 +23,27 @@ ExecStart=/opt/zextras/common/lib/jvm/java/bin/java \
   com.zimbra.cs.milter.MilterServer
 LimitNOFILE=524288
 Restart=on-failure
+RestartSec=3s
 SuccessExitStatus=143
+
+# Hardening
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/opt/zextras/log /opt/zextras/data /run/carbonio
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
 [Install]
 WantedBy=carbonio-mta.target

--- a/packages/mailbox-jar/PKGBUILD
+++ b/packages/mailbox-jar/PKGBUILD
@@ -18,13 +18,13 @@ section="mail"
 priority="optional"
 
 package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
+  cd "$(dirname "$(find /project -name "yap.json" -print -quit)")/.."
 
   install -D store/target/zm-store.jar \
     "${pkgdir}/opt/zextras/mailbox/jars/mailbox.jar"
 
   install -D store/target/dependencies/*.jar \
-     "${pkgdir}/opt/zextras/mailbox/jars/"
+    "${pkgdir}/opt/zextras/mailbox/jars/"
 
   install -Ddm755 "${pkgdir}/opt/zextras/jython/jars/"
 

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -14,6 +14,11 @@
   <!-- To sort out dependencies take a look at:
   https://wiki.eclipse.org/Jetty/Reference/Dependencies -->
   <dependencies>
+    <dependency>
+      <groupId>com.zextras.carbonio</groupId>
+      <artifactId>carbonio-systemd-notify</artifactId>
+      <version>1.0.1</version>
+    </dependency>
     <!-- Must be provided to avoid collision -->
     <dependency>
       <artifactId>httpclient</artifactId>
@@ -622,6 +627,15 @@
     </testResources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>--enable-preview</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <!-- Generate classes -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -896,7 +910,7 @@ EOF
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
-          <argLine>@{argLine} -Xmx2g -Dserver.dir=${project.basedir}
+          <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties
             -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
@@ -912,7 +926,7 @@ EOF
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
-          <argLine>@{argLine} -Xmx2g -Dserver.dir=${project.basedir}
+          <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
             -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI

--- a/store/src/main/java/com/zextras/mailbox/server/MailboxServer.java
+++ b/store/src/main/java/com/zextras/mailbox/server/MailboxServer.java
@@ -57,6 +57,7 @@ public class MailboxServer {
     initDependencies(); // old FirstServlet#init
     Zimbra.startup();
     server.start();
+    com.zextras.carbonio.systemd.SystemdNotify.ready("mailbox ready");
     ZimbraLog.misc.info("Mailbox server started");
   }
 

--- a/store/src/main/java/com/zimbra/cs/milter/MilterServer.java
+++ b/store/src/main/java/com/zimbra/cs/milter/MilterServer.java
@@ -13,6 +13,7 @@ import org.apache.mina.filter.codec.ProtocolEncoder;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
+import com.zextras.carbonio.systemd.SystemdNotify;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.ZimbraLog;
@@ -101,6 +102,7 @@ public final class MilterServer extends NioServer implements Server {
 
             ZimbraLog.milter.info("Starting milter server");
             server.start();
+            SystemdNotify.ready("milter ready");
         } catch (ServiceException e) {
             ZimbraLog.milter.error("Unable to start milter server", e);
         }


### PR DESCRIPTION
## Summary

Reworks systemd service management for the appserver stack to introduce proper readiness signaling, startup ordering, and security hardening.

### Readiness signaling (sd_notify)
- **Appserver**: the JVM now calls `sd_notify(3)` directly via Java FFM (Foreign Function & Memory) binding to `libsystemd.so.0` after Jetty starts, replacing the previous shell polling wrapper. This gives systemd direct PID tracking of the Java process and enables `NotifyAccess=main` (tightest security setting)
- **Sidecars**: switched from raw `consul connect envoy` to `service-discover-wrapper.sh`, which uses `sd_notify` to signal when envoy is LIVE

### Startup ordering
- Sidecars declare `After=carbonio-appserver.service` so they start only after the mailbox is ready
- Appserver declares `Wants=` for the two sidecars that carry upstream dependencies (`carbonio-mailbox-sidecar`, `carbonio-mailbox-internal-api-sidecar`); the remaining sidecars (`admin`, `nslookup`) only perform health checks on the mailbox and are not pulled in
- Sidecars moved from `PartOf=carbonio-appserver.target` to `PartOf=service-discover.target` (infrastructure layer)

### Systemd hardening
- Applied across all units (appserver, appserver-db, milter, all sidecars + legacy variants): `ProtectSystem=strict`, `NoNewPrivileges`, `PrivateDevices`, `PrivateTmp`, `ProtectKernel*`, `RestrictNamespaces`, `RestrictAddressFamilies`, etc.

### Packaging
- Added `carbonio-core` dependency to `appserver-service` PKGBUILD to ensure `sysusers.d` ordering is correct
- Added `--enable-preview` and `--enable-native-access=ALL-UNNAMED` JVM flags for FFM support (Java 21 preview; becomes stable in Java 22+)

## Startup chain

```
carbonio-appserver-db ready
        ↓
carbonio-appserver ready (sd_notify from JVM via FFM)
        ↓
sidecars start → envoy LIVE (sd_notify) → mesh ports available
```

Refs: CO-3422