### PR TITLE
ci: other branches should not publish snapshots -> breaks devel channel of advanced and other repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,11 @@ pipeline {
 
                 stage('Publish SNAPSHOT to maven') {
                     when {
-                        not { buildingTag() }
+                        allOf {
+                            not { buildingTag() }
+                            branch 'devel'
+                        }
+
                     }
                     steps {
                         container('jdk-21') {


### PR DESCRIPTION
We cannot publish snapshot when in other branches yet, beacuse devel channels of advanced and zal refer to -SNAPSHOT of mailbox.

Same for: https://github.com/zextras/carbonio-directory-server/blob/c1b0d0275480227ae98d737d015ebd7a861ecaed/Jenkinsfile#L84

This could lead to inconsistencies. Either we don't use snapshots anymore or we have to publish snapshots only in stable channels, else build will start to randomly fail