### PR TITLE
fix: mailbox-internal-api allow carbonio-storages 

### DIFF
--- a/packages/appserver-service/carbonio-mailbox-internal-api-intentions.json
+++ b/packages/appserver-service/carbonio-mailbox-internal-api-intentions.json
@@ -3,7 +3,7 @@
   "name": "carbonio-mailbox-internal-api",
   "sources": [
     {
-      "name": "carbonio-storages-service",
+      "name": "carbonio-storages",
       "action": "allow"
     }
   ]


### PR DESCRIPTION
Was:  carbonio-storages-service.

Found with podman local infrastructure with policy deny. We noticed storages -> mailbox-internal-api was red and storages was returning 500