### PR TITLE
chore(ci): bump jenkins-lib-common to 1.5.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@1.4.0',
+        identifier: 'jenkins-lib-common@1.5.0',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
@@ -132,16 +132,10 @@ pipeline {
                             steps {
                                 echo 'Building deb/rpm packages'
                                 buildStage([
+                                        addCarbonioRepos: true,
+                                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
                                         skipStash: true,
                                         buildDirs: ['staging/packages'],
-                                        overrides: [
-                                                ubuntu: [
-                                                        preBuildScript: '''
-                                apt-get update
-                                apt-get install -y --no-install-recommends rsync
-                            '''
-                                                ]
-                                        ]
                                 ])
                             }
                         }

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -12,5 +12,5 @@ docker run -it --rm \
     --entrypoint=yap \
     -v "$(pwd)/artifacts/${OS}":/artifacts \
     -v "$(pwd)":/tmp/build \
-    "docker.io/m0rf30/yap-${OS}:1.49" \
+    "docker.io/m0rf30/yap-${OS}:1.53" \
     build "${OS}" /tmp/build/packages

--- a/packages/appserver-db/PKGBUILD
+++ b/packages/appserver-db/PKGBUILD
@@ -17,10 +17,6 @@ priority="optional"
 conflicts=('carbonio-common-appserver-db')
 replaces=('carbonio-common-appserver-db')
 
-makedepends=(
-  "rsync"
-)
-
 _package() {
   cd "$(dirname "$(find / -name "yap.json" -print -quit)")/.."
 
@@ -32,7 +28,7 @@ _package() {
     "${pkgdir}/opt/zextras/db/create_database.sql"
 
   mkdir -p "${pkgdir}/opt/zextras/libexec/scripts/migrations"
-  rsync -a "store/db/migration/" \
+  cp -a store/db/migration/* \
     "${pkgdir}/opt/zextras/libexec/scripts/migrations"
 }
 


### PR DESCRIPTION
## Summary

- Bumps `jenkins-lib-common` library version from `1.4.0` to `1.5.0`
- Adds `buildFlags: ' -sd '` to the `buildStage()` call in the _Build deb/rpm_ stage

## Why `-d` is needed now

`yap` recently started resolving `makedepends` from the `PKGBUILD` spec during the build stage. However, `makedepends` are build-time dependencies of the **package being built**, not of the build environment itself — they are only needed at runtime by the installed package. Checking them during CI builds is unnecessary and can cause failures if those packages aren't present in the build agent.

The `-d` / `--nomakedeps` flag restores the previous behaviour by skipping all `makedepends` checks.

## Flags added

| Flag | Long form | Effect |
|------|-----------|--------|
| `-s` | `--skip-sync` | Skip sync with remotes for package managers |
| `-d` | `--nomakedeps` | Skip all `makedepends` checks |