### PR TITLE
chore: [CO-3283] update test containers version to 2.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 VERSION := $(shell cat version.txt)
 
 build:
-	mvn clean install -DskipTests
+	mvn clean install -DskipTests -Dfile.encoding=UTF-8
 
 tests:
-	mvn verify -DexcludedGroups=api,flaky,e2e
+	mvn verify -DexcludedGroups=api,flaky,e2e -Dfile.encoding=UTF-8
 
 api-tests:
-	cd store && mvn verify -Dgroups=api
+	cd store && mvn verify -Dgroups=api -Dfile.encoding=UTF-8
 
 flaky-tests:
-	cd store && mvn verify -Dgroups=flaky
+	cd store && mvn verify -Dgroups=flaky -Dfile.encoding=UTF-8
 
 e2e-tests:
-	cd store && mvn verify -Dgroups=e2e
+	cd store && mvn verify -Dgroups=e2e -Dfile.encoding=UTF-8
 
 build-packages: build
 	./build_packages.sh	

--- a/pom.xml
+++ b/pom.xml
@@ -791,6 +791,14 @@
          <artifactId>commons-net</artifactId>
          <version>3.10.0</version>
       </dependency>
+      <!-- Source: https://mvnrepository.com/artifact/org.testcontainers/testcontainers-bom -->
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>2.0.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -622,11 +622,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
         <artifactId>commons-rng-core</artifactId>
         <version>1.0</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.1</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>com.kohlschutter.junixsocket</groupId>
@@ -623,7 +623,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.7</version>
+        <version>3.18.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -123,7 +123,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.17.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -133,14 +132,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mariadb</artifactId>
-      <version>1.17.6</version>
+      <artifactId>testcontainers-mariadb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
-      <version>1.19.8</version>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -155,12 +152,6 @@
       <version>5.2.0</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java-api</artifactId>
-      <version>3.2.13</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
@@ -588,8 +579,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>1.19.0</version>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/store/src/test/java/com/zimbra/cs/imap/MemcachedImapCacheTest.java
+++ b/store/src/test/java/com/zimbra/cs/imap/MemcachedImapCacheTest.java
@@ -39,9 +39,7 @@ public class MemcachedImapCacheTest extends MailboxTestSuite {
 
 	@Test
 	void testInvalidObject() {
-		try {
-
-			mockStatic(MemcachedConnector.class);
+		try (var mockedStatic = mockStatic(MemcachedConnector.class)) {
 			ZimbraMemcachedClient memcachedClient = new MockZimbraMemcachedClient();
 			when(MemcachedConnector.getClient()).thenReturn(memcachedClient);
 			ImapFolder folder = mock(ImapFolder.class);

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -118,16 +118,14 @@ class UserServletTest extends MailboxTestSuite {
 	 * javax.servlet.http.HttpServletResponse)}.
 	 */
 	@Test
-	void testDoGet() {
+	void testDoGet() throws Exception {
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		UserServlet userServlet = new UserServlet();
-		try {
+		spy(ZimbraServlet.class);
+		spy(UserServlet.class);
 
-			spy(ZimbraServlet.class);
-			spy(UserServlet.class);
-
-			mockStatic(L10nUtil.class);
+		try(var mockedStatic = mockStatic(L10nUtil.class)) {
 
 			when(request.getPathInfo()).thenReturn("/testbug3948@zimbra.com");
 			when(request.getRequestURI()).thenReturn("service/home/");
@@ -138,12 +136,8 @@ class UserServletTest extends MailboxTestSuite {
 
 			userServlet.doGet(request, response);
 			assertEquals(401, response.getStatus());
-			//            Commenting until we can figure out why this fails in CI env.
-			//            Assert.assertEquals("must authenticate", response.getMsg());
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail("No exception should be thrown.");
 		}
+
 	}
 
 	/**

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -2,8 +2,7 @@
 package com.zimbra.cs.service;
 
 import static com.zimbra.common.util.ZimbraCookie.COOKIE_ZM_AUTH_TOKEN;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -119,20 +118,20 @@ class UserServletTest extends MailboxTestSuite {
 	 */
 	@Test
 	void testDoGet() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		UserServlet userServlet = new UserServlet();
-		spy(ZimbraServlet.class);
-		spy(UserServlet.class);
-
+		// TODO: refactor to API tests, avoid mocking http layer and requests
 		try(var mockedStatic = mockStatic(L10nUtil.class)) {
-
+			HttpServletRequest request = mock(HttpServletRequest.class);
+			MockHttpServletResponse response = new MockHttpServletResponse();
+			UserServlet userServlet = new UserServlet();
+			spy(ZimbraServlet.class);
+			spy(UserServlet.class);
 			when(request.getPathInfo()).thenReturn("/testbug3948@zimbra.com");
 			when(request.getRequestURI()).thenReturn("service/home/");
 			when(request.getParameter("auth")).thenReturn("basic");
 			when(request.getParameter("loc")).thenReturn("en_US");
 			when(request.getHeader("Authorization")).thenReturn("Basic dGVzdDM0ODg6dGVzdDEyMw==");
 			when(request.getQueryString()).thenReturn("auth=basic&view=text&id=261");
+			when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/service/home/"));
 
 			userServlet.doGet(request, response);
 			assertEquals(401, response.getStatus());

--- a/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/account/GetAccountInfoTest.java
@@ -3,6 +3,7 @@ package com.zimbra.cs.service.account;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.zextras.mailbox.MailboxTestSuite;
+import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
@@ -26,7 +27,7 @@ class GetAccountInfoTest extends MailboxTestSuite {
     request.setAccount(AccountSelector.fromId(account.getId()));
     Element requestElement = JaxbUtil.jaxbToElement(request);
 
-    Element handle = new GetAccountInfo()
+    Element handle = newRequest()
         .handle(requestElement, ServiceTestUtil.getRequestContext(account));
     GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
 
@@ -44,7 +45,7 @@ class GetAccountInfoTest extends MailboxTestSuite {
     request.setAccount(AccountSelector.fromId(account.getId()));
     Element requestElement = JaxbUtil.jaxbToElement(request);
 
-    Element handle = new GetAccountInfo()
+    Element handle = newRequest()
         .handle(requestElement, ServiceTestUtil.getRequestContext(account));
     GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
 
@@ -55,4 +56,12 @@ class GetAccountInfoTest extends MailboxTestSuite {
     assertEquals(1, attributes.size());
     assertEquals("FALSE", attributes.get(0).getValue());
   }
+
+  private GetAccountInfo newRequest() {
+    final GetAccountInfo getAccountInfo = new GetAccountInfo();
+    getAccountInfo.setResponseQName(AccountConstants.GET_ACCOUNT_INFO_RESPONSE);
+    return getAccountInfo;
+
+  }
+
 }

--- a/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/DeleteAccountTest.java
@@ -17,6 +17,9 @@ import com.zextras.mailbox.acl.AclService;
 import com.zextras.mailbox.util.PortUtil;
 import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
@@ -28,6 +31,7 @@ import com.zimbra.cs.account.accesscontrol.ZimbraACE;
 import com.zimbra.cs.account.accesscontrol.generated.AdminRights;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.service.mail.ServiceTestUtil;
+import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.admin.message.DeleteAccountRequest;
 import io.vavr.control.Try;
@@ -229,6 +233,8 @@ class DeleteAccountTest extends MailboxTestSuite {
 
 	private void doDeleteAccount(DeleteAccount deleteAccount, Account caller,
 			String accountToDeleteId) throws Exception {
+		// TODO: prefer creating api tests and interact through http call rather then using DocumentHandler handle
+		deleteAccount.setResponseQName(AdminConstants.DELETE_ACCOUNT_RESPONSE);
 		deleteAccount.handle(
 				JaxbUtil.jaxbToElement(new DeleteAccountRequest(accountToDeleteId)),
 				ServiceTestUtil.getRequestContext(caller));

--- a/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/admin/GetAccountInfoTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Maps;
 import com.zextras.mailbox.MailboxTestSuite;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.SoapProtocol;
 import com.zimbra.cs.account.Account;
@@ -41,7 +43,7 @@ class GetAccountInfoTest extends MailboxTestSuite {
     request.setAccount(AccountSelector.fromId(adminAccount.getId()));
     Element requestElement = JaxbUtil.jaxbToElement(request);
 
-    Element handle = new GetAccountInfo().handle(requestElement, getAdminContext(adminAccount));
+    Element handle = newRequest().handle(requestElement, getAdminContext(adminAccount));
     GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
 
     List<Attr> attrs =
@@ -65,7 +67,7 @@ class GetAccountInfoTest extends MailboxTestSuite {
     request.setAccount(AccountSelector.fromId(adminAccount.getId()));
     Element requestElement = JaxbUtil.jaxbToElement(request);
 
-    Element handle = new GetAccountInfo().handle(requestElement, getAdminContext(adminAccount));
+    Element handle = newRequest().handle(requestElement, getAdminContext(adminAccount));
     GetAccountInfoResponse response = JaxbUtil.elementToJaxb(handle);
 
     List<Attr> attrs =
@@ -86,5 +88,11 @@ class GetAccountInfoTest extends MailboxTestSuite {
             SoapProtocol.Soap12);
     context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
     return context;
+  }
+
+  private GetAccountInfo newRequest() {
+    final GetAccountInfo getAccountInfo = new GetAccountInfo();
+    getAccountInfo.setResponseQName(AdminConstants.GET_ACCOUNT_INFO_RESPONSE);
+    return getAccountInfo;
   }
 }

--- a/store/src/test/java/com/zimbra/cs/service/mail/CalendarRequestTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/CalendarRequestTest.java
@@ -4,7 +4,7 @@
 
 package com.zimbra.cs.service.mail;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -22,7 +22,6 @@ import com.zimbra.cs.mailbox.calendar.CalendarMailSender;
 import com.zimbra.cs.mailbox.calendar.Invite;
 import com.zimbra.cs.mailbox.calendar.ZAttendee;
 import com.zimbra.cs.service.mail.CalendarRequest.MailSendQueue;
-import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -105,22 +104,23 @@ public class CalendarRequestTest {
   when(calItem.getSubpartMessage(2)).thenReturn(mm2);
 
   when(mbox.getCalendarItemById(octxt, calItem.getId())).thenReturn(calItem);
-  MockedStatic<CalendarMailSender> calendarMailSenderMockedStatic =
+  try (MockedStatic<CalendarMailSender> calendarMailSenderMockedStatic =
     mockStatic(CalendarMailSender.class);
-  calendarMailSenderMockedStatic
-    .when(() -> CalendarMailSender.toListFromAttendees(attendeeList))
-    .thenReturn(addressList);
-  MockedStatic<CalendarRequest> calendarRequestMockedStatic = mockStatic(CalendarRequest.class);
-  calendarRequestMockedStatic
-    .when(() -> CalendarRequest.isOnBehalfOfRequest(any(ZimbraSoapContext.class)))
-    .thenReturn(false);
-  calendarRequestMockedStatic
-    .when(() -> CalendarRequest.getAuthenticatedAccount(any(ZimbraSoapContext.class)))
-    .thenReturn(account);
+    MockedStatic<CalendarRequest> calendarRequestMockedStatic = mockStatic(CalendarRequest.class)) {
+    calendarMailSenderMockedStatic
+        .when(() -> CalendarMailSender.toListFromAttendees(attendeeList))
+        .thenReturn(addressList);
+    calendarRequestMockedStatic
+        .when(() -> CalendarRequest.isOnBehalfOfRequest(any(ZimbraSoapContext.class)))
+        .thenReturn(false);
+    calendarRequestMockedStatic
+        .when(() -> CalendarRequest.getAuthenticatedAccount(any(ZimbraSoapContext.class)))
+        .thenReturn(account);
 
-  CalendarRequest.notifyCalendarItem(
-    zsc, octxt, account, mbox, calItem, true, attendeeList, true, sendQueue);
-  assertEquals(1, sendQueue.queue.size());
+    CalendarRequest.notifyCalendarItem(
+        zsc, octxt, account, mbox, calItem, true, attendeeList, true, sendQueue);
+    assertEquals(1, sendQueue.queue.size());
+  }
  }
 
 }

--- a/store/src/test/java/com/zimbra/cs/service/mail/SearchActionTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SearchActionTest.java
@@ -119,17 +119,18 @@ public class SearchActionTest extends MailboxTestSuite {
     ConvActionRequest req = SearchAction.getConvActionRequest(searchHits, "read");
     ConvAction convAction = new ConvAction();
     SoapHttpTransport mockSoapHttpTransport = mock(SoapHttpTransport.class);
-    MockedStatic<SearchAction> searchActionMockedStatic = mockStatic(SearchAction.class);
-    searchActionMockedStatic
-        .when(() -> SearchAction.getSoapHttpTransportInstance(anyString()))
-        .thenReturn(mockSoapHttpTransport);
+    try (MockedStatic<SearchAction> searchActionMockedStatic = mockStatic(SearchAction.class)) {
+      searchActionMockedStatic
+          .when(() -> SearchAction.getSoapHttpTransportInstance(anyString()))
+          .thenReturn(mockSoapHttpTransport);
 
-    when(mockSoapHttpTransport.invokeWithoutSession(any()))
-        .thenReturn(
-            convAction.handle(zsc.jaxbToElement(req), ServiceTestUtil.getRequestContext(acct)));
-    SearchAction.performAction(bAction, sRequest, searchHits, mbox, null);
-    // check search result message is marked read
-    assertEquals(false, message1.isUnread());
-    assertEquals(true, message2.isUnread());
+      when(mockSoapHttpTransport.invokeWithoutSession(any()))
+          .thenReturn(
+              convAction.handle(zsc.jaxbToElement(req), ServiceTestUtil.getRequestContext(acct)));
+      SearchAction.performAction(bAction, sRequest, searchHits, mbox, null);
+      // check search result message is marked read
+      assertEquals(false, message1.isUnread());
+      assertEquals(true, message2.isUnread());
+    }
   }
 }

--- a/store/src/test/java/com/zimbra/cs/servlet/util/CsrfUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/servlet/util/CsrfUtilTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import javax.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -204,10 +205,7 @@ public class CsrfUtilTest extends MailboxTestSuite {
 	@Test
 	final void testIsCsrfRequestForRefererInMatchHost() {
 
-		String[] allowedRefHost = new String[3];
-		allowedRefHost[0] = "www.newexample.com";
-		allowedRefHost[1] = "www.zextras.com:8080";
-		allowedRefHost[2] = "www.abc.com";
+		final String[] allowedRefHost = getAllowedRefHosts();
 		HttpServletRequest request = Mockito
 				.mock(HttpServletRequest.class);
 		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn(
@@ -227,6 +225,14 @@ public class CsrfUtilTest extends MailboxTestSuite {
 			e.printStackTrace();
 			fail("Should not throw exception. ");
 		}
+	}
+
+	private static String[] getAllowedRefHosts() {
+		String[] allowedRefHost = new String[3];
+		allowedRefHost[0] = "www.newexample.com";
+		allowedRefHost[1] = "www.zextras.com:8080";
+		allowedRefHost[2] = "www.abc.com";
+		return allowedRefHost;
 	}
 
 	@Test
@@ -257,8 +263,7 @@ public class CsrfUtilTest extends MailboxTestSuite {
 
 	@Test
 	final void testIsCsrfRequestForRefererNotInMatchHost() {
-
-		String[] allowedRefHost = new String[3];
+		String[] allowedRefHost = getAllowedRefHost();
 		HttpServletRequest request = Mockito
 				.mock(HttpServletRequest.class);
 		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(null);

--- a/store/src/test/java/com/zimbra/cs/servlet/util/CsrfUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/servlet/util/CsrfUtilTest.java
@@ -15,12 +15,9 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.account.ZimbraAuthToken;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.net.MalformedURLException;
 import java.util.Random;
 import javax.servlet.http.HttpServletRequest;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -55,50 +52,30 @@ public class CsrfUtilTest extends MailboxTestSuite {
 	}
 
 	@Test
-	final void testIsCsrfRequest() {
-
-		List<String> urlsWithDisabledCsrfCheck = new ArrayList<String>();
-		urlsWithDisabledCsrfCheck.add("/AuthRequest");
+	final void testIsCsrfRequest() throws MalformedURLException {
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		Mockito.when(request.getMethod()).thenReturn("POST");
 		Mockito.when(request.getRequestURI()).thenReturn(
 				"service/soap/AuthRequest");
-		try {
-			boolean csrfReq = CsrfUtil.doCsrfCheck(request,
-					null);
-			assertEquals(false, csrfReq);
 
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.doCsrfCheck(request, null);
+		assertFalse(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForGet() {
-
-		List<String> urlsWithDisabledCsrfCheck = new ArrayList<String>();
-		urlsWithDisabledCsrfCheck.add("/AuthRequest");
+	final void testIsCsrfRequestForGet() throws MalformedURLException {
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 		Mockito.when(request.getMethod()).thenReturn("GET");
 		Mockito.when(request.getRequestURI()).thenReturn(
 				"service/soap/AuthRequest");
-		try {
-			
-			boolean csrfReq = CsrfUtil.doCsrfCheck(request,
-					null);
-			assertEquals(false, csrfReq);
 
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.doCsrfCheck(request, null);
+		assertFalse(csrfReq);
 	}
 
 
 	@Test
-	final void testDecodeValidCsrfToken() {
-		try {
+	final void testDecodeValidCsrfToken() throws ServiceException, AuthTokenException {
 			AuthToken authToken = new ZimbraAuthToken(acct);
 
 			String csrfToken = CsrfUtil.generateCsrfToken(acct.getId(),
@@ -107,47 +84,31 @@ public class CsrfUtilTest extends MailboxTestSuite {
 			assertNotNull(tokenParts.getFirst());
 			assertNotNull(tokenParts.getSecond());
 			assertEquals("0", tokenParts.getSecond());
-
-		} catch (ServiceException | AuthTokenException e) {
-			fail("Should not throw exception.");
-		}
 	}
 
 	@Test
-	final void testIsValidCsrfTokenForAccountWithMultipleTokens() {
-		try {
+	final void testIsValidCsrfTokenForAccountWithMultipleTokens() throws ServiceException {
 			AuthToken authToken = new ZimbraAuthToken(acct);
 
 			String csrfToken1 = CsrfUtil.generateCsrfToken(acct.getId(),
 					AUTH_TOKEN_EXPR, CSRFTOKEN_SALT, authToken);
 			boolean validToken = CsrfUtil.isValidCsrfToken(csrfToken1, authToken);
 			assertTrue(validToken);
-
-
-		} catch (ServiceException e) {
-			fail("Should not throw exception.");
-		}
 	}
 
 	@Test
-	final void testIsValidCsrfTokenForAccountWithNullAuthToken() {
-		try {
-			AuthToken authToken = new ZimbraAuthToken(acct);
+	final void testIsValidCsrfTokenForAccountWithNullAuthToken() throws Exception {
+		AuthToken authToken = new ZimbraAuthToken(acct);
 
-			String csrfToken1 = CsrfUtil.generateCsrfToken(acct.getId(),
-					AUTH_TOKEN_EXPR, CSRFTOKEN_SALT, authToken);
-			boolean validToken = CsrfUtil.isValidCsrfToken(csrfToken1, null);
-			assertEquals(false, validToken);
-
-
-		} catch (Exception e) {
-			fail("Should not throw exception.");
-		}
+		String csrfToken1 = CsrfUtil.generateCsrfToken(acct.getId(),
+				AUTH_TOKEN_EXPR, CSRFTOKEN_SALT, authToken);
+		boolean validToken = CsrfUtil.isValidCsrfToken(csrfToken1, null);
+		assertFalse(validToken);
 	}
 
 
 	@Test
-	final void testIsCsrfRequestWhenCsrfCheckIsTurnedOn() {
+	final void testIsCsrfRequestWhenCsrfCheckIsTurnedOn() throws MalformedURLException {
 
 		String[] allowedRefHost = getAllowedRefHost();
 		HttpServletRequest request = Mockito
@@ -160,16 +121,8 @@ public class CsrfUtilTest extends MailboxTestSuite {
 		Mockito.when(request.getMethod()).thenReturn("POST");
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(null);
 
-		try {
-
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
 	private static String[] getAllowedRefHost() {
@@ -177,57 +130,36 @@ public class CsrfUtilTest extends MailboxTestSuite {
 	}
 
 	@Test
-	final void testIsCsrfRequestForSameReferer() {
-
+	final void testIsCsrfRequestForSameReferer() throws MalformedURLException {
 		String[] allowedRefHost = getAllowedRefHost();
-		HttpServletRequest request = Mockito
-				.mock(HttpServletRequest.class);
-		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn(
-				"www.example.com");
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn("www.example.com");
 		Mockito.when(request.getServerName()).thenReturn("www.example.com");
 		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"http://www.example.com/zimbra/#15");
 		Mockito.when(request.getMethod()).thenReturn("POST");
 
-		try {
-
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForRefererInMatchHost() {
-
-		final String[] allowedRefHost = getAllowedRefHosts();
-		HttpServletRequest request = Mockito
-				.mock(HttpServletRequest.class);
-		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn(
-				"example.com");
+	final void testIsCsrfRequestForRefererInMatchHost() throws MalformedURLException {
+		final String[] allowedRefHost = generateThreeRefHosts();
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn("example.com");
 		Mockito.when(request.getServerName()).thenReturn("example.com");
 		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"http://www.newexample.com");
 		Mockito.when(request.getMethod()).thenReturn("POST");
 
-		try {
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
-	private static String[] getAllowedRefHosts() {
+	private static String[] generateThreeRefHosts() {
 		String[] allowedRefHost = new String[3];
 		allowedRefHost[0] = "www.newexample.com";
 		allowedRefHost[1] = "www.zextras.com:8080";
@@ -236,33 +168,22 @@ public class CsrfUtilTest extends MailboxTestSuite {
 	}
 
 	@Test
-	final void testIsCsrfRequestForAllowedRefHostListEmptyAndNonMatchingHost() {
-
+	final void testIsCsrfRequestForAllowedRefHostListEmptyAndNonMatchingHost() throws MalformedURLException {
 		String[] allowedRefHost = getAllowedRefHost();
-		HttpServletRequest request = Mockito
-				.mock(HttpServletRequest.class);
-		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn(
-				"example.com");
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn("example.com");
 		Mockito.when(request.getServerName()).thenReturn("example.com");
 		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"http://www.newexample.com");
 		Mockito.when(request.getMethod()).thenReturn("POST");
 
-		try {
-
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(true, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertTrue(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForRefererNotInMatchHost() {
+	final void testIsCsrfRequestForRefererNotInMatchHost() throws MalformedURLException {
 		String[] allowedRefHost = getAllowedRefHost();
 		HttpServletRequest request = Mockito
 				.mock(HttpServletRequest.class);
@@ -274,18 +195,12 @@ public class CsrfUtilTest extends MailboxTestSuite {
 				"http://www.newexample.com");
 		Mockito.when(request.getMethod()).thenReturn("POST");
 
-		try {
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(true, csrfReq);
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertTrue(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForSameRefererWithUrlHavingPort() {
+	final void testIsCsrfRequestForSameRefererWithUrlHavingPort() throws MalformedURLException {
 
 		String[] allowedRefHost = getAllowedRefHost();
 		HttpServletRequest request = Mockito
@@ -298,64 +213,36 @@ public class CsrfUtilTest extends MailboxTestSuite {
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"http://www.example.com:7070");
 		Mockito.when(request.getMethod()).thenReturn("POST");
-		try {
-
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForSameRefererWithHttpsUrl() {
-
+	final void testIsCsrfRequestForSameRefererWithHttpsUrl() throws MalformedURLException {
 		String[] allowedRefHost = getAllowedRefHost();
-		HttpServletRequest request = Mockito
-				.mock(HttpServletRequest.class);
-		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn(
-				"mail.zimbra.com");
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getHeader(HttpHeaders.HOST)).thenReturn("mail.zimbra.com");
 		Mockito.when(request.getServerName()).thenReturn("mail.zimbra.com");
 		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"https://mail.zimbra.com/zimbra/");
 		Mockito.when(request.getMethod()).thenReturn("POST");
-		try {
 
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
 	@Test
-	final void testIsCsrfRequestForSameRefererWithXFowardedHostHdr() {
-
+	final void testIsCsrfRequestForSameRefererWithXFowardedHostHdr() throws MalformedURLException {
 		String[] allowedRefHost = getAllowedRefHost();
-		HttpServletRequest request = Mockito
-				.mock(HttpServletRequest.class);
-		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn(
-				"mail.zimbra.com");
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("mail.zimbra.com");
 		Mockito.when(request.getHeader(HttpHeaders.REFERER)).thenReturn(
 				"https://mail.zimbra.com/zimbra/");
 		Mockito.when(request.getMethod()).thenReturn("POST");
-		try {
 
-			
-			boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
-			assertEquals(false, csrfReq);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Should not throw exception. ");
-		}
+		boolean csrfReq = CsrfUtil.isCsrfRequestBasedOnReferrer(request, allowedRefHost);
+		assertFalse(csrfReq);
 	}
 
 }


### PR DESCRIPTION
## Goal
Update test containers to 2.0+.
Test containers 1.X is not compatible and cannot start latest docker environments due to a change in client api

## Details
Since the codebase was defining commons-lang3 3.5 and the project also defines commons-text 3.1, which depends on common-lang3 3.5, I removed commons-lang3 from dependency management + bumped commons-text to 3.12.0 (from 3.1).

This is because HealthServlet fails because it needs a newer version of commons-lang3 (runtime exception, method not found).

These changes should be ok, because minor.

## Failing tests and issues with mockStatic
I've also updated some tests that fail locally, because polluted by other tests, specifically:

- tests that use mockStatic (not using try-with-resources)
- tests calling Handlers without QName setup (I think we should avoid writing these kind of tests and prefer a soap api test with the full http stack, so tests become cleaner) 

## Result

**Now you should be able to run tests locally without any failures.**

**See Makefile for commands on how to run tests.**