### PR TITLE
feat: [CO-3499] add dsId and dsType attributes in GetFolder response 

### DIFF
--- a/common/src/main/java/com/zimbra/common/soap/MailConstants.java
+++ b/common/src/main/java/com/zimbra/common/soap/MailConstants.java
@@ -998,6 +998,7 @@ public final class MailConstants {
   public static final String A_REPLY_TYPE = "rt";
   public static final String A_IDENTITY_ID = "idnt";
   public static final String A_DATASOURCE_ID = "dsId";
+  public static final String A_DATASOURCE_TYPE = "dsType";
   public static final String A_NO_SAVE_TO_SENT = "noSave";
   public static final String A_FETCH_SAVED_MSG = "fetchSavedMsg";
   public static final String A_SEND_UID = "suid";

--- a/soap/src/main/java/com/zimbra/soap/mail/type/Folder.java
+++ b/soap/src/main/java/com/zimbra/soap/mail/type/Folder.java
@@ -249,6 +249,23 @@ public class Folder {
   @XmlAttribute(name = MailConstants.A_LAST_SYNC_DATE /* lsd */, required = false)
   private Long lastSyncDate;
 
+  /**
+   * @zm-api-field-tag datasource-id
+   * @zm-api-field-description If this folder is the root folder of a DataSource (e.g. a CalDAV or
+   *     IMAP sync account), this attribute contains the ID of that DataSource. Only present on
+   *     datasource root folders; absent on regular folders and datasource sub-folders.
+   */
+  @XmlAttribute(name = MailConstants.A_DATASOURCE_ID /* dsId */, required = false)
+  private String datasourceId;
+
+  /**
+   * @zm-api-field-tag datasource-type
+   * @zm-api-field-description Type of the DataSource this folder is the root of (e.g.
+   *     <b>caldav</b>, <b>imap</b>, <b>pop3</b>). Only present when {@code dsId} is present.
+   */
+  @XmlAttribute(name = MailConstants.A_DATASOURCE_TYPE /* dsType */, required = false)
+  private String datasourceType;
+
   @XmlAttribute(
       name = MailConstants.A_ACTIVESYNC_DISABLED /* activesyncdisabled */,
       required = false)
@@ -396,6 +413,14 @@ public class Folder {
     return lastSyncDate;
   }
 
+  public String getDatasourceId() {
+    return datasourceId;
+  }
+
+  public String getDatasourceType() {
+    return datasourceType;
+  }
+
   public Boolean isActiveSyncDisabled() {
     return ZmBoolean.toBool(activeSyncDisabled);
   }
@@ -514,6 +539,14 @@ public class Folder {
 
   public void setLastSyncDate(Long lastSyncDate) {
     this.lastSyncDate = lastSyncDate;
+  }
+
+  public void setDatasourceId(String datasourceId) {
+    this.datasourceId = datasourceId;
+  }
+
+  public void setDatasourceType(String datasourceType) {
+    this.datasourceType = datasourceType;
   }
 
   public void setDisableActiveSync(Boolean disableActiveSync) {

--- a/store/src/main/java/com/zimbra/cs/mailbox/OperationContextData.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/OperationContextData.java
@@ -5,13 +5,16 @@
 
 package com.zimbra.cs.mailbox;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.SetUtil;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.Mailbox.FolderNode;
 
@@ -289,6 +292,93 @@ public abstract class OperationContextData {
                 return null;
         }
 
+    }
+
+    /**
+     * Per-request cache of the folderId-to-DataSource mapping for an account.
+     *
+     * <p>Avoids calling {@link Provisioning#getAllDataSources} once per folder when
+     * {@code ToXML.encodeFolder()} annotates each folder with its datasource metadata
+     * (e.g. during GetFolder or Sync, which can encode many folders in one request).
+     *
+     * <p>The outer map is keyed by {@code accountId} so that the cache is correct even
+     * when the same {@link OperationContext} is reused across accounts (e.g. admin proxy).
+     * The inner map is keyed by the datasource root {@code folderId}.
+     */
+    public static class DataSourceIndex extends OperationContextData {
+
+        private static final String KEY = "DataSourceIndex";
+
+        /** accountId → (folderId → DataSource) */
+        private final Map<String, Map<Integer, DataSource>> mIndex = new HashMap<>();
+
+        DataSourceIndex(OperationContext octxt) {
+            super(octxt);
+        }
+
+        /**
+         * Returns the non-internal {@link DataSource} whose root folder is {@code folderId}
+         * for the given account, or {@code null} if none exists.
+         *
+         * <p>The datasource list for the account is fetched from {@link Provisioning} exactly
+         * once and cached for the lifetime of this object (i.e. the current request).
+         */
+        public DataSource getByFolderId(com.zimbra.cs.account.Account account, int folderId)
+                throws ServiceException {
+            String accountId = account.getId();
+            Map<Integer, DataSource> folderMap = mIndex.get(accountId);
+            if (folderMap == null) {
+                folderMap = new HashMap<>();
+                List<DataSource> sources = Provisioning.getInstance().getAllDataSources(account);
+                for (DataSource ds : sources) {
+                    if (!ds.isInternal()) {
+                        // folderId is the datasource root; one datasource → one folder
+                        folderMap.put(ds.getFolderId(), ds);
+                    }
+                }
+                mIndex.put(accountId, folderMap);
+            }
+            return folderMap.get(folderId);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Static helpers — mirrors the GranteeNames static API style          //
+        // ------------------------------------------------------------------ //
+
+        private static DataSourceIndex getOrInit(OperationContext octxt) {
+            DataSourceIndex idx = (DataSourceIndex) octxt.getCtxtData(KEY);
+            if (idx == null) {
+                idx = new DataSourceIndex(octxt);
+                octxt.setCtxtData(KEY, idx);
+            }
+            return idx;
+        }
+
+        /**
+         * Looks up the datasource for {@code folderId} in {@code account}.
+         *
+         * <p>If {@code octxt} is non-null the per-account datasource list is loaded once and
+         * cached for the remainder of the request. If {@code octxt} is {@code null} (e.g.
+         * internal / redo-log calls) a direct uncached scan is performed so callers never
+         * need to special-case a null context.
+         *
+         * @return the matching {@link DataSource}, or {@code null} if none
+         */
+        public static DataSource lookup(
+                OperationContext octxt,
+                com.zimbra.cs.account.Account account,
+                int folderId) throws ServiceException {
+            if (octxt == null) {
+                // No request context available — fall back to a direct (uncached) scan.
+                for (DataSource ds : Provisioning.getInstance().getAllDataSources(account)) {
+                    if (!ds.isInternal() && ds.getFolderId() == folderId) {
+                        return ds;
+                    }
+                }
+                return null;
+            }
+            return getOrInit(octxt).getByFolderId(account, folderId);
+        }
     }
 
 }

--- a/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
@@ -366,17 +366,19 @@ public final class ToXML {
     // Annotate the folder with the ID and type of the DataSource it is the root of, if any.
     // This allows clients to identify CalDAV / IMAP / etc. sync root folders without
     // separately correlating against a GetDataSources response.
+    // Only exposed to the account owner / full-access delegates (mirrors the GetDataSources
+    // canAccessAccount gate) to avoid leaking datasource UUIDs via shared-folder access.
+    // The datasource list is fetched once per account per request via DataSourceIndex and
+    // reused across all folder encodes (avoids N×getAllDataSources during GetFolder / Sync).
     if (folder.getId() > Mailbox.HIGHEST_SYSTEM_ID) {
       try {
         if (hasFullAccess(mbox, octxt)) {
-          List<DataSource> allDataSources =
-              Provisioning.getInstance().getAllDataSources(folder.getMailbox().getAccount());
-          for (DataSource ds : allDataSources) {
-            if (!ds.isInternal() && ds.getFolderId() == folder.getId()) {
-              elem.addAttribute(MailConstants.A_DATASOURCE_ID, ds.getId());
-              elem.addAttribute(MailConstants.A_DATASOURCE_TYPE, ds.getType().toString());
-              break;
-            }
+          DataSource ds =
+              OperationContextData.DataSourceIndex.lookup(
+                  octxt, folder.getMailbox().getAccount(), folder.getId());
+          if (ds != null) {
+            elem.addAttribute(MailConstants.A_DATASOURCE_ID, ds.getId());
+            elem.addAttribute(MailConstants.A_DATASOURCE_TYPE, ds.getType().toString());
           }
         }
       } catch (ServiceException e) {

--- a/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
@@ -368,13 +368,15 @@ public final class ToXML {
     // separately correlating against a GetDataSources response.
     if (folder.getId() > Mailbox.HIGHEST_SYSTEM_ID) {
       try {
-        List<DataSource> allDataSources =
-            Provisioning.getInstance().getAllDataSources(folder.getMailbox().getAccount());
-        for (DataSource ds : allDataSources) {
-          if (!ds.isInternal() && ds.getFolderId() == folder.getId()) {
-            elem.addAttribute(MailConstants.A_DATASOURCE_ID, ds.getId());
-            elem.addAttribute(MailConstants.A_DATASOURCE_TYPE, ds.getType().toString());
-            break;
+        if (hasFullAccess(mbox, octxt)) {
+          List<DataSource> allDataSources =
+              Provisioning.getInstance().getAllDataSources(folder.getMailbox().getAccount());
+          for (DataSource ds : allDataSources) {
+            if (!ds.isInternal() && ds.getFolderId() == folder.getId()) {
+              elem.addAttribute(MailConstants.A_DATASOURCE_ID, ds.getId());
+              elem.addAttribute(MailConstants.A_DATASOURCE_TYPE, ds.getType().toString());
+              break;
+            }
           }
         }
       } catch (ServiceException e) {

--- a/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
@@ -362,6 +362,26 @@ public final class ToXML {
         }
       }
     }
+
+    // Annotate the folder with the ID and type of the DataSource it is the root of, if any.
+    // This allows clients to identify CalDAV / IMAP / etc. sync root folders without
+    // separately correlating against a GetDataSources response.
+    if (folder.getId() > Mailbox.HIGHEST_SYSTEM_ID) {
+      try {
+        List<DataSource> allDataSources =
+            Provisioning.getInstance().getAllDataSources(folder.getMailbox().getAccount());
+        for (DataSource ds : allDataSources) {
+          if (!ds.isInternal() && ds.getFolderId() == folder.getId()) {
+            elem.addAttribute(MailConstants.A_DATASOURCE_ID, ds.getId());
+            elem.addAttribute(MailConstants.A_DATASOURCE_TYPE, ds.getType().toString());
+            break;
+          }
+        }
+      } catch (ServiceException e) {
+        ZimbraLog.soap.warn("Unable to encode datasource info for folder %d", folder.getId(), e);
+      }
+    }
+
     return elem;
   }
 

--- a/store/src/test/java/com/zimbra/cs/service/mail/GetFolderTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/GetFolderTest.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableSet;
 import com.zextras.mailbox.MailboxTestSuite;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.account.DataSource;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.MailItem;
@@ -18,7 +20,10 @@ import com.zimbra.cs.mailbox.MailItem.Type;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.Mountpoint;
+import com.zimbra.soap.admin.type.DataSourceType;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -99,6 +104,134 @@ public class GetFolderTest extends MailboxTestSuite {
 				expectedSyncEpochSeconds,
 				folderElem.getAttributeLong(MailConstants.A_LAST_SYNC_DATE, 0),
 				"external iCal URL folder should return last successful sync date in epoch seconds");
+	}
+
+	/**
+	 * Verifies that GetFolder response includes dsId and dsType attributes on the folder
+	 * when it is the root folder of a CalDAV DataSource, allowing clients to identify
+	 * datasource-synced folders without needing to cross-reference GetDataSources.
+	 */
+	@Test
+	void caldavDataSourceRootFolderIncludesDsIdAndDsType() throws Exception {
+		var acct = createAccount().create();
+		Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+		// Create a calendar folder that will be the root of the CalDAV datasource
+		Folder.FolderOptions folderOptions = new Folder.FolderOptions()
+				.setDefaultView(Type.APPOINTMENT);
+		Folder calFolder = mbox.createFolder(null, "CalDAV Root", Mailbox.ID_FOLDER_USER_ROOT, folderOptions);
+
+		// Create a CalDAV datasource pointing to this folder
+		Map<String, Object> dsAttrs = new HashMap<>();
+		dsAttrs.put(Provisioning.A_zimbraDataSourceFolderId, String.valueOf(calFolder.getId()));
+		dsAttrs.put(Provisioning.A_zimbraDataSourceHost, "caldav.example.com");
+		dsAttrs.put(Provisioning.A_zimbraDataSourcePort, "443");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceUsername, "user@example.com");
+		dsAttrs.put(Provisioning.A_zimbraDataSourcePassword, "password");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceConnectionType, "ssl");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceEnabled, "TRUE");
+
+		DataSource caldavDs = Provisioning.getInstance().createDataSource(
+				acct, DataSourceType.caldav, "My CalDAV", dsAttrs);
+
+		// Fetch the folder via GetFolder
+		Element request = new Element.XMLElement(MailConstants.GET_FOLDER_REQUEST);
+		request.addUniqueElement(MailConstants.E_FOLDER)
+				.addAttribute(MailConstants.A_FOLDER, String.valueOf(calFolder.getId()));
+
+		Element response = new GetFolder().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+		Element folderElem = response.getOptionalElement(MailConstants.E_FOLDER);
+		assertNotNull(folderElem, "folder element should be present in response");
+
+		// Verify dsId is present and matches the datasource ID
+		String dsId = folderElem.getAttribute(MailConstants.A_DATASOURCE_ID, null);
+		assertNotNull(dsId, "datasource root folder should have dsId attribute");
+		assertEquals(caldavDs.getId(), dsId, "dsId should match the datasource ID");
+
+		// Verify dsType is present and set to 'caldav'
+		String dsType = folderElem.getAttribute(MailConstants.A_DATASOURCE_TYPE, null);
+		assertNotNull(dsType, "datasource root folder should have dsType attribute");
+		assertEquals(DataSourceType.caldav.toString(), dsType, "dsType should be 'caldav'");
+	}
+
+	/**
+	 * Verifies that non-datasource folders do NOT include dsId and dsType attributes.
+	 */
+	@Test
+	void regularFolderDoesNotIncludeDsIdAndDsType() throws Exception {
+		var acct = createAccount().create();
+		Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+		// Create a regular calendar folder (not a datasource root)
+		Folder.FolderOptions folderOptions = new Folder.FolderOptions()
+				.setDefaultView(Type.APPOINTMENT);
+		Folder calFolder = mbox.createFolder(null, "Regular Calendar", Mailbox.ID_FOLDER_USER_ROOT, folderOptions);
+
+		// Fetch the folder via GetFolder
+		Element request = new Element.XMLElement(MailConstants.GET_FOLDER_REQUEST);
+		request.addUniqueElement(MailConstants.E_FOLDER)
+				.addAttribute(MailConstants.A_FOLDER, String.valueOf(calFolder.getId()));
+
+		Element response = new GetFolder().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+		Element folderElem = response.getOptionalElement(MailConstants.E_FOLDER);
+		assertNotNull(folderElem, "folder element should be present in response");
+
+		// Verify dsId and dsType are NOT present
+		String dsId = folderElem.getAttribute(MailConstants.A_DATASOURCE_ID, null);
+		assertNull(dsId, "regular folder should not have dsId attribute");
+
+		String dsType = folderElem.getAttribute(MailConstants.A_DATASOURCE_TYPE, null);
+		assertNull(dsType, "regular folder should not have dsType attribute");
+	}
+
+	/**
+	 * Verifies that sub-folders created by CalDAV sync under a datasource root folder
+	 * do NOT include dsId/dsType attributes (only the root folder should have them).
+	 */
+	@Test
+	void caldavSubFolderDoesNotIncludeDsIdAndDsType() throws Exception {
+		var acct = createAccount().create();
+		Mailbox mbox = MailboxManager.getInstance().getMailboxByAccount(acct);
+
+		// Create a CalDAV datasource root folder
+		Folder.FolderOptions folderOptions = new Folder.FolderOptions()
+				.setDefaultView(Type.APPOINTMENT);
+		Folder rootFolder = mbox.createFolder(null, "CalDAV Root", Mailbox.ID_FOLDER_USER_ROOT, folderOptions);
+
+		// Create a CalDAV datasource
+		Map<String, Object> dsAttrs = new HashMap<>();
+		dsAttrs.put(Provisioning.A_zimbraDataSourceFolderId, String.valueOf(rootFolder.getId()));
+		dsAttrs.put(Provisioning.A_zimbraDataSourceHost, "caldav.example.com");
+		dsAttrs.put(Provisioning.A_zimbraDataSourcePort, "443");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceUsername, "user@example.com");
+		dsAttrs.put(Provisioning.A_zimbraDataSourcePassword, "password");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceConnectionType, "ssl");
+		dsAttrs.put(Provisioning.A_zimbraDataSourceEnabled, "TRUE");
+
+		Provisioning.getInstance().createDataSource(
+				acct, DataSourceType.caldav, "My CalDAV", dsAttrs);
+
+		// Create a sub-folder (simulating what CalDAV import would create)
+		Folder subFolder = mbox.createFolder(null, "Work Calendar", rootFolder.getId(), folderOptions);
+
+		// Fetch the sub-folder via GetFolder
+		Element request = new Element.XMLElement(MailConstants.GET_FOLDER_REQUEST);
+		request.addUniqueElement(MailConstants.E_FOLDER)
+				.addAttribute(MailConstants.A_FOLDER, String.valueOf(subFolder.getId()));
+
+		Element response = new GetFolder().handle(request, ServiceTestUtil.getRequestContext(acct));
+
+		Element folderElem = response.getOptionalElement(MailConstants.E_FOLDER);
+		assertNotNull(folderElem, "subfolder element should be present in response");
+
+		// Verify dsId and dsType are NOT on the sub-folder
+		String dsId = folderElem.getAttribute(MailConstants.A_DATASOURCE_ID, null);
+		assertNull(dsId, "datasource sub-folder should not have dsId attribute (only root should)");
+
+		String dsType = folderElem.getAttribute(MailConstants.A_DATASOURCE_TYPE, null);
+		assertNull(dsType, "datasource sub-folder should not have dsType attribute (only root should)");
 	}
 
 	@Disabled


### PR DESCRIPTION
Adds DataSource identification metadata (`dsId`, `dsType`) to folder SOAP responses so clients can recognize datasource-backed sync root folders directly from `GetFolder`, without needing a separate `GetDataSources` correlation.

**Changes:**
- Add `dsType` SOAP attribute constant and expose `dsId/dsType` on the SOAP `Folder` type.
- Update folder XML encoding to attach `dsId/dsType` when the folder is the configured root of a non-internal DataSource.
- Add unit tests covering datasource root, regular folders, and datasource sub-folders.