### PR TITLE
chore: [CO-3523] define service name and version for otel collection

### DIFF
--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -98,7 +98,8 @@ ENV LDAP_URL="ldap://openldap:1389" \
     CARBONIO_PREVIEW_SERVICE_URL="http://carbonio-preview:10000" \
     CARBONIO_MAILBOX_INTERNAL_API_HOST="0.0.0.0" \
     CARBONIO_MAILBOX_INTERNAL_API_PORT="10000" \
-    MAILBOXD_JAVA_OPTS="-Xss256k -Xms1996m -Xmx1996m"
+    MAILBOXD_JAVA_OPTS="-Xss256k -Xms1996m -Xmx1996m" \
+    OTEL_JAVAAGENT_CONFIGURATION_FILE="/etc/carbonio/mailbox/otel.properties"
 
 COPY docker/mailbox/entrypoint.sh .
 

--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -86,6 +86,7 @@ ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/release
 # Copy additional config files
 COPY docker/mailbox/log4j.properties /opt/zextras/conf/log4j.properties
 COPY docker/mailbox/localconfig/localconfig.xml /localconfig/localconfig.xml
+COPY packages/appserver-service/otel.properties /etc/carbonio/mailbox/otel.properties
 
 ENV LDAP_URL="ldap://openldap:1389" \
     LDAP_ROOT_PASSWORD=qh6hWZvc \

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -36,6 +36,7 @@ JAVA_OPTS="-Dfile.encoding=UTF-8 -server \
                          -Djava.security.egd=file:/dev/./urandom \
                          --add-opens java.base/java.lang=ALL-UNNAMED \
                          ${MAILBOXD_JAVA_OPTS} -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+                         -Dotel.javaagent.configuration-file=/etc/carbonio/mailbox/otel.properties \
                          -Djava.library.path=/opt/zextras/lib \
                          -Dzimbra.config=/localconfig/localconfig.xml \
                          -Dzimbra.native.required=false \

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -36,7 +36,6 @@ JAVA_OPTS="-Dfile.encoding=UTF-8 -server \
                          -Djava.security.egd=file:/dev/./urandom \
                          --add-opens java.base/java.lang=ALL-UNNAMED \
                          ${MAILBOXD_JAVA_OPTS} -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-                         -Dotel.javaagent.configuration-file=/etc/carbonio/mailbox/otel.properties \
                          -Djava.library.path=/opt/zextras/lib \
                          -Dzimbra.config=/localconfig/localconfig.xml \
                          -Dzimbra.native.required=false \

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -45,6 +45,8 @@ _package() {
     "${pkgdir}/etc/carbonio/mailbox/service-discover/policies.json"
   install -Dm644 packages/appserver-service/carbonio-mailbox-service-protocol.json \
     "${pkgdir}/etc/carbonio/mailbox/service-discover/service-protocol.json"
+  install -Dm644 packages/appserver-service/otel.properties \
+    "${pkgdir}/etc/carbonio/mailbox/otel.properties"
 
   # Mailbox Admin
   install -Dm755 packages/appserver-service/carbonio-mailbox-admin \

--- a/packages/appserver-service/carbonio-appserver.service
+++ b/packages/appserver-service/carbonio-appserver.service
@@ -8,6 +8,7 @@ PartOf=carbonio-appserver.target
 User=zextras
 Type=notify
 NotifyAccess=main
+Environment=OTEL_JAVAAGENT_CONFIGURATION_FILE=/etc/carbonio/mailbox/otel.properties
 EnvironmentFile=-/opt/zextras/data/systemd.env
 ExecStartPre=echo REWRITE \
   sasl \
@@ -29,7 +30,6 @@ ExecStart=/opt/zextras/common/bin/java \
   -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
   -Djava.library.path=/opt/zextras/lib \
   -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
-  -Dotel.javaagent.configuration-file=/etc/carbonio/mailbox/otel.properties \
   -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
   com.zextras.mailbox.Mailbox
 LimitNOFILE=524288

--- a/packages/appserver-service/carbonio-appserver.service
+++ b/packages/appserver-service/carbonio-appserver.service
@@ -29,6 +29,7 @@ ExecStart=/opt/zextras/common/bin/java \
   -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
   -Djava.library.path=/opt/zextras/lib \
   -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
+  -Dotel.javaagent.configuration-file=/etc/carbonio/mailbox/otel.properties \
   -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
   com.zextras.mailbox.Mailbox
 LimitNOFILE=524288

--- a/packages/appserver-service/otel.properties
+++ b/packages/appserver-service/otel.properties
@@ -1,0 +1,2 @@
+otel.service.name=carbonio-mailbox
+otel.service.version=4.25.2

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -75,7 +75,7 @@ export default {
     [
       '@semantic-release/git',
       {
-        assets: ['pom.xml', 'package/PKGBUILD', 'packages/**/otel.properties'],
+        assets: ['pom.xml', 'packages/**/PKGBUILD', 'packages/**/otel.properties'],
         message: 'chore(release): ${nextRelease.version} [skip ci]'
       }
     ],

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -69,13 +69,13 @@ export default {
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's|<revision>.*</revision>|<revision>${nextRelease.version}</revision>|' pom.xml && sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' packages/**/PKGBUILD"
+        "prepareCmd": "sed -i 's|<revision>.*</revision>|<revision>${nextRelease.version}</revision>|' pom.xml && sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' packages/**/PKGBUILD && sed -i 's|^otel.service.version=.*|otel.service.version=${nextRelease.version}|' packages/**/otel.properties"
       }
     ],
     [
       '@semantic-release/git',
       {
-        assets: ['pom.xml', 'package/PKGBUILD'],
+        assets: ['pom.xml', 'package/PKGBUILD', 'packages/**/otel.properties'],
         message: 'chore(release): ${nextRelease.version} [skip ci]'
       }
     ],


### PR DESCRIPTION
Endpoint is up to the user, so is agent activation (through env variable).
In container environment we set it using JAVA_TOOL_OPTIONS.
In a VM it is done with https://github.com/open-telemetry/opentelemetry-injector if I'm not wrong

Decide:
- [ ] otel.properties path
- [ ] other conventions?