### PR TITLE
chore: remove stale mailbox-native exclusion

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -463,12 +463,6 @@
     <dependency>
       <artifactId>zm-common</artifactId>
       <groupId>com.zextras</groupId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.zextras</groupId>
-          <artifactId>mailbox-native</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <artifactId>zm-client</artifactId>


### PR DESCRIPTION
## Summary

- Remove vestigial `<exclusion>` for `mailbox-native` from `zm-common` dependency in `store/pom.xml`
- The `carbonio-mailbox-native` module has been removed; this exclusion is no longer needed

Refs: CO-3493