### PR TITLE
fix: [CO-3526] pin down mailbox internal api local service address

### DIFF
--- a/packages/appserver-service/carbonio-mailbox-internal-api.hcl
+++ b/packages/appserver-service/carbonio-mailbox-internal-api.hcl
@@ -7,6 +7,7 @@ services {
   connect {
     sidecar_service {
       proxy {
+        local_service_address = "127.78.0.7"
         upstreams = [
           {
             destination_name   = "carbonio-memcached"


### PR DESCRIPTION
- without it envoy defaults to the agent address, but the api is exposed only at 127.78.0.7.

Without it we get:

upstream connect error or disconnect/reset before headers. reset reason: remote connection failure, transport failure reason: delayed connect error: Connection refused

This causes storages and other services in user-management to not be able to reach mailbox internal apis