### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,6 +191,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mailbox/Dockerfile',
                                 imageName : 'carbonio-mailbox',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title          : 'Carbonio Mailbox',
                                         descriptionFile: 'docker/mailbox/description.md'
@@ -199,6 +200,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mailbox-sidecar/Dockerfile',
                                 imageName : 'carbonio-mailbox-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title : 'Carbonio Mailbox Sidecar',
                                 ]
@@ -206,6 +208,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
                                 imageName : 'carbonio-mailbox-admin-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title : 'Carbonio Mailbox Admin Sidecar',
                                 ]
@@ -213,6 +216,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
                                 imageName : 'carbonio-mailbox-nslookup-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title : 'Carbonio Mailbox NSLookup Sidecar',
                                 ]
@@ -220,6 +224,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
                                 imageName : 'carbonio-mailbox-internal-api-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title : 'Carbonio Mailbox Internal API Sidecar',
                                 ]
@@ -227,6 +232,7 @@ pipeline {
                         dockerStage([
                                 dockerfile: 'docker/mariadb/Dockerfile',
                                 imageName : 'carbonio-mariadb',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ocLabels  : [
                                         title          : 'Carbonio MariaDB',
                                         descriptionFile: 'docker/mariadb/description.md'


### PR DESCRIPTION
## Summary

Add `linux/arm64` platform to all `dockerStage` calls so the CI produces multi-arch Docker images (amd64 + arm64).

This was blocked until [CO-3493] replaced the JNI native library with Java FFM and stdlib (#980), removing the only platform-specific compiled dependency from the mailbox image.

## Changes

- Jenkinsfile: add `platforms: ['linux/amd64', 'linux/arm64']` to all 6 `dockerStage` invocations

## Notes

- Sidecar images depend on `registry.dev.zextras.com/dev/carbonio-sidecar:latest` being published as multi-arch
- `jenkins-lib-common@1.5.0` already supports `platforms` in `dockerStage` and `docker buildx` multi-platform builds
- Verified: `podman manifest inspect registry.dev.zextras.com/dev/carbonio-mailbox:IN-951` shows both amd64 and arm64 manifests

Refs: IN-951

[CO-3493]: https://zextras.atlassian.net/browse/CO-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ