### PR TITLE
fix: use full locale resolution chain in internal API

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponse.java
+++ b/store/src/main/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponse.java
@@ -43,6 +43,6 @@ public record AccountInfoResponse(String id, String name, String displayName, St
 		return new AccountInfoResponse(account.getId(), account.getName(), account.getDisplayName(),
 				account.getCOSId(), account.getDomainId(), account.getPublicServiceUrl(),
 				account.getAccountStatus(), account.isIsAdminAccount(), isExternal,
-				account.getLocaleAsString(), features, capabilities, sessionLifetimeMs);
+				account.getLocale().toString(), features, capabilities, sessionLifetimeMs);
 	}
 }

--- a/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
+++ b/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
@@ -110,6 +110,36 @@ class AccountResourceIT {
 				.containsEntry("locale", frFr);
 	}
 
+	@Test
+	void localeIsResolvedFromZimbraPrefLocale() throws Exception {
+		final String itIt = "it_IT";
+		final Account account = server.getAccountFactory()
+				.withAttribute(ZAttrProvisioning.A_zimbraPrefLocale, itIt)
+				.create();
+
+		final Response response = server.getHttpClient().get(
+				server.getInternalApiEndpoint() + "/accounts/" + account.getId() + "/info");
+
+		assertThatJson(response.body()).isObject()
+				.containsEntry("locale", itIt);
+	}
+
+	@Test
+	void zimbraPrefLocaleWinsOverZimbraLocale() throws Exception {
+		final String prefLocale = "de_DE";
+		final String adminLocale = "en_US";
+		final Account account = server.getAccountFactory()
+				.withAttribute(ZAttrProvisioning.A_zimbraPrefLocale, prefLocale)
+				.withAttribute(ZAttrProvisioning.A_zimbraLocale, adminLocale)
+				.create();
+
+		final Response response = server.getHttpClient().get(
+				server.getInternalApiEndpoint() + "/accounts/" + account.getId() + "/info");
+
+		assertThatJson(response.body()).isObject()
+				.containsEntry("locale", prefLocale);
+	}
+
 	private static void assertInfo(Response response, Account account) throws ServiceException {
 		assertThatJson(response.body()).isObject()
 				.containsEntry("id", account.getId())
@@ -120,7 +150,7 @@ class AccountResourceIT {
 				.containsEntry("status", account.getAccountStatus().toString())
 				.containsEntry("isGlobalAdmin", account.isIsAdminAccount())
 				.containsEntry("isExternal", account.isAccountExternal())
-				.containsEntry("locale", account.getLocaleAsString())
+				.containsEntry("locale", account.getLocale().toString())
 		;
 
 	}


### PR DESCRIPTION
Replace account.getLocaleAsString() (reads only zimbraLocale) with account.getLocale().toString() (resolves zimbraPrefLocale → zimbraLocale → COS → domain → server → JVM default) in AccountInfoResponse.

This fixes the /internal/accounts/myself endpoint returning null for locale when the user has zimbraPrefLocale set but not zimbraLocale, which is the common case for all end-users who set their language preference in the webmail UI.