### PR TITLE
feat: [CO-3098] add version filtering options to prov describe command

### DIFF
--- a/store/src/main/java/com/zimbra/cs/account/Command.java
+++ b/store/src/main/java/com/zimbra/cs/account/Command.java
@@ -148,7 +148,7 @@ public enum Command {
   DESCRIBE(
       "describe",
       "desc",
-      "[[-v] [-ni] [{entry-type}]] | [-a {attribute-name}]",
+      "[[-v] [-ni] [-since {version} | -since-after {version}] [{entry-type}]] | [-a {attribute-name}] | [-list-since-versions]",
       Category.MISC,
       0,
       Integer.MAX_VALUE,

--- a/store/src/main/java/com/zimbra/cs/account/commands/DescribeArgs.java
+++ b/store/src/main/java/com/zimbra/cs/account/commands/DescribeArgs.java
@@ -34,6 +34,34 @@ class DescribeArgs {
           throw ServiceException.INVALID_REQUEST("cannot specify -only when -a is specified", null);
         }
         descArgs.mOnThisObjectTypeOnly = true;
+      } else if ("-list-since-versions".equals(args[i])) {
+        descArgs.mListSinceVersions = true;
+      } else if ("-since".equals(args[i])) {
+        if (descArgs.mAttr != null) {
+          throw ServiceException.INVALID_REQUEST("cannot specify -since when -a is specified", null);
+        }
+        if (descArgs.mSinceAfter != null) {
+          throw ServiceException.INVALID_REQUEST("cannot specify both -since and -since-after", null);
+        }
+        if (args.length <= i + 1) {
+          throw ServiceException.INVALID_REQUEST("-since requires a version argument", null);
+        }
+        i++;
+        descArgs.mSinceParts = parseVersionGranularity(args[i]);
+        descArgs.mSince = parseVersion(args[i]);
+      } else if ("-since-after".equals(args[i])) {
+        if (descArgs.mAttr != null) {
+          throw ServiceException.INVALID_REQUEST("cannot specify -since-after when -a is specified", null);
+        }
+        if (descArgs.mSince != null) {
+          throw ServiceException.INVALID_REQUEST("cannot specify both -since and -since-after", null);
+        }
+        if (args.length <= i + 1) {
+          throw ServiceException.INVALID_REQUEST("-since-after requires a version argument", null);
+        }
+        i++;
+        descArgs.mSinceAfterParts = parseVersionGranularity(args[i]);
+        descArgs.mSinceAfter = parseVersion(args[i]);
       } else if (args[i].startsWith("-a")) {
         if (descArgs.mAttrClass != null) {
           throw ServiceException.INVALID_REQUEST(
@@ -78,7 +106,79 @@ class DescribeArgs {
           "-ni -only must be specified with an entry type", null);
     }
 
+    if (descArgs.mListSinceVersions
+        && (descArgs.mAttr != null
+            || descArgs.mAttrClass != null
+            || descArgs.hasSinceFilter()
+            || descArgs.mVerbose
+            || descArgs.mNonInheritedOnly
+            || descArgs.mOnThisObjectTypeOnly)) {
+      throw ServiceException.INVALID_REQUEST(
+          "-list-since-versions cannot be combined with other options", null);
+    }
+
     return descArgs;
+  }
+
+  private static AttributeVersion parseVersion(String version) throws ServiceException {
+    try {
+      return new AttributeVersion(version);
+    } catch (AttributeManagerException e) {
+      throw ServiceException.INVALID_REQUEST(
+          "invalid version \"" + version + "\" — expected MAJOR.MINOR[.MICRO], e.g. 26.6 or 26.6.0",
+          null);
+    }
+  }
+
+  /**
+   * Returns the number of dot-separated numeric segments in the user-supplied version
+   * (ignoring any release suffix like "_BETA1"). Used to determine match granularity:
+   * 2 segments (e.g. "26.6") matches the whole major.minor line; 3 segments (e.g. "26.6.1")
+   * requires an exact match. Single-segment input is rejected.
+   */
+  private static int parseVersionGranularity(String version) throws ServiceException {
+    if (AttributeVersion.FUTURE.equalsIgnoreCase(version)) {
+      return 3;
+    }
+    int underscoreAt = version.indexOf('_');
+    String numericPart = underscoreAt == -1 ? version : version.substring(0, underscoreAt);
+    int parts = numericPart.split("\\.").length;
+    if (parts < 2) {
+      throw ServiceException.INVALID_REQUEST(
+          "version \"" + version + "\" must include at least major and minor (e.g., 26.6 or 26.6.0)",
+          null);
+    }
+    return parts;
+  }
+
+  boolean hasSinceFilter() {
+    return mSince != null || mSinceAfter != null;
+  }
+
+  boolean matchesSinceFilter(AttributeInfo ai) {
+    if (!hasSinceFilter()) {
+      return true;
+    }
+    List<AttributeVersion> attrSince = ai.getSince();
+    if (attrSince == null || attrSince.isEmpty()) {
+      return false;
+    }
+    if (mSince != null) {
+      boolean exact = mSinceParts >= 3;
+      for (AttributeVersion v : attrSince) {
+        if (exact ? v.compareTo(mSince) == 0 : v.isSameMinorRelease(mSince)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    boolean exact = mSinceAfterParts >= 3;
+    for (AttributeVersion v : attrSince) {
+      if (exact ? v.compareTo(mSinceAfter) > 0 : v.isLaterMajorMinorRelease(mSinceAfter)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   enum Field {
@@ -247,6 +347,15 @@ class DescribeArgs {
   boolean mOnThisObjectTypeOnly;
   AttributeClass mAttrClass;
   boolean mVerbose;
+
+  /*
+   * version filters
+   */
+  AttributeVersion mSince;
+  AttributeVersion mSinceAfter;
+  int mSinceParts;
+  int mSinceAfterParts;
+  boolean mListSinceVersions;
 
   /*
    * args when a specific attribute is specified

--- a/store/src/main/java/com/zimbra/cs/account/commands/DescribeCommandHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/commands/DescribeCommandHandler.java
@@ -11,10 +11,17 @@ import com.zimbra.cs.account.CommandHandler;
 import com.zimbra.cs.account.FileGenUtil;
 import com.zimbra.cs.account.ProvUtil;
 
+import com.zimbra.cs.account.AttributeVersion;
 import com.zimbra.cs.account.StoreAttributeManager;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 class DescribeCommandHandler implements CommandHandler {
@@ -38,10 +45,15 @@ class DescribeCommandHandler implements CommandHandler {
       return;
     }
 
+    AttributeManager am = StoreAttributeManager.getInstance();
+
+    if (descArgs.mListSinceVersions) {
+      printAvailableSinceVersions(am);
+      return;
+    }
+
     SortedSet<String> attrs = null;
     String specificAttr = null;
-
-    AttributeManager am = StoreAttributeManager.getInstance();
 
     if (descArgs.mAttr != null) {
       // specific attr
@@ -125,6 +137,8 @@ class DescribeCommandHandler implements CommandHandler {
       }
       console.println();
 
+    } else if (descArgs.hasSinceFilter()) {
+      printSinceFiltered(am, attrs, descArgs);
     } else {
       for (String attr : attrs) {
         AttributeInfo ai = am.getAttributeInfo(attr);
@@ -140,6 +154,169 @@ class DescribeCommandHandler implements CommandHandler {
         }
       }
     }
+  }
+
+  private void printSinceFiltered(AttributeManager am, SortedSet<String> attrs, DescribeArgs descArgs) {
+    var console = provUtil.getConsole();
+
+    List<AttributeInfo> matched = new ArrayList<>();
+    for (String attr : attrs) {
+      AttributeInfo ai = am.getAttributeInfo(attr);
+      if (ai == null) {
+        continue;
+      }
+      if (descArgs.matchesSinceFilter(ai)) {
+        matched.add(ai);
+      }
+    }
+
+    String header = descArgs.mSince != null
+            ? "Attributes introduced in " + descArgs.mSince + ":"
+            : "Attributes introduced after " + descArgs.mSinceAfter + ":";
+    console.println(header);
+    console.println();
+
+    if (matched.isEmpty()) {
+      console.println("  (none)");
+      console.println();
+      console.println("Tip: run \"zmprov desc -list-since-versions\" to see all available since values.");
+      return;
+    }
+
+    if (descArgs.mVerbose) {
+      for (AttributeInfo ai : matched) {
+        console.println(ai.getName());
+        String desc = ai.getDescription();
+        console.println(FileGenUtil.wrapComments((desc == null ? "" : desc), 70, "    "));
+        console.println();
+        for (DescribeArgs.Field f : DescribeArgs.Field.values()) {
+          console.print(String.format("    %15s : %s%n", f.name(), DescribeArgs.Field.print(f, ai)));
+        }
+        console.println();
+      }
+      console.println(matched.size() + " attribute(s).");
+      return;
+    }
+
+    int sinceWidth = "SINCE".length();
+    int appliesWidth = "APPLIES TO".length();
+    int nameWidth = "ATTRIBUTE".length();
+    int defaultWidth = "DEFAULT".length();
+    String[][] rows = new String[matched.size()][4];
+    for (int i = 0; i < matched.size(); i++) {
+      AttributeInfo ai = matched.get(i);
+      rows[i][0] = formatSince(ai);
+      rows[i][1] = formatAppliesTo(ai);
+      rows[i][2] = ai.getName();
+      rows[i][3] = formatDefaultOrDash(ai);
+      sinceWidth = Math.max(sinceWidth, rows[i][0].length());
+      appliesWidth = Math.max(appliesWidth, rows[i][1].length());
+      nameWidth = Math.max(nameWidth, rows[i][2].length());
+      defaultWidth = Math.max(defaultWidth, rows[i][3].length());
+    }
+
+    String fmt = "  %-" + sinceWidth + "s  %-" + appliesWidth + "s  %-" + nameWidth + "s  %-" + defaultWidth + "s%n";
+    console.print(String.format(fmt, "SINCE", "APPLIES TO", "ATTRIBUTE", "DEFAULT"));
+    console.print(String.format(fmt,
+            "-".repeat(sinceWidth),
+            "-".repeat(appliesWidth),
+            "-".repeat(nameWidth),
+            "-".repeat(defaultWidth)));
+    for (String[] row : rows) {
+      console.print(String.format(fmt, row[0], row[1], row[2], row[3]));
+    }
+    console.println();
+    console.println(matched.size() + " attribute(s). Use -v for descriptions, or -a <name> for full details.");
+  }
+
+  private void printAvailableSinceVersions(AttributeManager am) {
+    var console = provUtil.getConsole();
+
+    Set<String> seenNames = new HashSet<>();
+    List<AttributeInfo> all = new ArrayList<>();
+    for (AttributeClass ac : AttributeClass.values()) {
+      for (String name : am.getAllAttrsInClass(ac)) {
+        if (seenNames.add(name)) {
+          AttributeInfo ai = am.getAttributeInfo(name);
+          if (ai != null) {
+            all.add(ai);
+          }
+        }
+      }
+    }
+
+    SortedMap<AttributeVersion, Integer> counts = countSinceVersions(all);
+    int totalAttrsWithSince = counts.values().stream().mapToInt(Integer::intValue).sum();
+
+    console.println("Available \"since\" versions in attribute definitions:");
+    console.println();
+
+    if (counts.isEmpty()) {
+      console.println("  (none)");
+      console.println();
+      return;
+    }
+
+    int versionWidth = "VERSION".length();
+    for (AttributeVersion v : counts.keySet()) {
+      versionWidth = Math.max(versionWidth, v.toString().length());
+    }
+    String fmt = "  %-" + versionWidth + "s  %s%n";
+    console.print(String.format(fmt, "VERSION", "ATTRIBUTES"));
+    console.print(String.format(fmt, "-".repeat(versionWidth), "----------"));
+    for (Map.Entry<AttributeVersion, Integer> e : counts.entrySet()) {
+      console.print(String.format(fmt, e.getKey().toString(), e.getValue()));
+    }
+    console.println();
+    console.println(counts.size() + " distinct version(s), " + totalAttrsWithSince + " attribute(s) with version metadata.");
+    console.println("Use one of these with -since {version} or -since-after {version}.");
+  }
+
+  static SortedMap<AttributeVersion, Integer> countSinceVersions(Iterable<AttributeInfo> attrs) {
+    SortedMap<AttributeVersion, Integer> counts = new TreeMap<>();
+    for (AttributeInfo ai : attrs) {
+      List<AttributeVersion> since = ai.getSince();
+      if (since == null) {
+        continue;
+      }
+      for (AttributeVersion v : since) {
+        counts.merge(v, 1, Integer::sum);
+      }
+    }
+    return counts;
+  }
+
+  private static String formatSince(AttributeInfo ai) {
+    List<AttributeVersion> since = ai.getSince();
+    if (since == null || since.isEmpty()) {
+      return "-";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (AttributeVersion v : since) {
+      if (sb.length() > 0) sb.append(",");
+      sb.append(v.toString());
+    }
+    return sb.toString();
+  }
+
+  private static String formatAppliesTo(AttributeInfo ai) {
+    Set<AttributeClass> applies = new LinkedHashSet<>();
+    if (ai.getRequiredIn() != null) applies.addAll(ai.getRequiredIn());
+    if (ai.getOptionalIn() != null) applies.addAll(ai.getOptionalIn());
+    if (applies.isEmpty()) {
+      return "-";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (AttributeClass ac : applies) {
+      if (sb.length() > 0) sb.append(",");
+      sb.append(ac.name());
+    }
+    return sb.toString();
+  }
+
+  private static String formatDefaultOrDash(AttributeInfo ai) {
+    String defaults = DescribeArgs.Field.formatDefaults(ai);
+    return defaults.isEmpty() ? "-" : defaults;
   }
 
   private String formatAllEntryTypes() {
@@ -192,6 +369,20 @@ class DescribeCommandHandler implements CommandHandler {
     console.println("zmprov desc -a zimbraId");
     console.println(
             "    print attribute name, description, and all properties of attribute" + " zimbraId\n");
+
+    console.println("zmprov desc -since 26.6");
+    console.println("    print attributes introduced exactly in 26.6.x" + "\n");
+
+    console.println("zmprov desc -since-after 26.5");
+    console.println("    print attributes introduced after 26.5 (use after upgrades to discover");
+    console.println("    new attributes that may need to be set on existing entries)" + "\n");
+
+    console.println("zmprov desc -since-after 26.5 -v cos");
+    console.println("    same as above, restricted to CoS-applicable attributes, with descriptions" + "\n");
+
+    console.println("zmprov desc -list-since-versions");
+    console.println("    list every distinct since-version found in attribute definitions, with");
+    console.println("    a count of attributes per version (use to discover what to query)" + "\n");
 
     console.println("zmprov desc account -a zimbraId");
     console.println("    error: can only specify either an entry type or a specific attribute\n");

--- a/store/src/main/java/com/zimbra/cs/account/commands/DescribeCommandHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/commands/DescribeCommandHandler.java
@@ -37,7 +37,7 @@ class DescribeCommandHandler implements CommandHandler {
   }
 
   private void doDescribe(String[] args) throws ServiceException, InvalidCommandException {
-    DescribeArgs descArgs = null;
+    DescribeArgs descArgs;
     try {
       descArgs = DescribeArgs.parseDescribeArgs(args);
     } catch (ServiceException | NumberFormatException e) {
@@ -62,7 +62,7 @@ class DescribeCommandHandler implements CommandHandler {
       // attrs in a class
       attrs = new TreeSet<>(am.getAllAttrsInClass(descArgs.mAttrClass));
       if (descArgs.mNonInheritedOnly) {
-        Set<String> inheritFrom = null;
+        Set<String> inheritFrom;
         Set<String> netAttrs = null;
         switch (descArgs.mAttrClass) {
           case account:
@@ -293,7 +293,7 @@ class DescribeCommandHandler implements CommandHandler {
     }
     StringBuilder sb = new StringBuilder();
     for (AttributeVersion v : since) {
-      if (sb.length() > 0) sb.append(",");
+      if (!sb.isEmpty()) sb.append(",");
       sb.append(v.toString());
     }
     return sb.toString();
@@ -308,7 +308,7 @@ class DescribeCommandHandler implements CommandHandler {
     }
     StringBuilder sb = new StringBuilder();
     for (AttributeClass ac : applies) {
-      if (sb.length() > 0) sb.append(",");
+      if (!sb.isEmpty()) sb.append(",");
       sb.append(ac.name());
     }
     return sb.toString();

--- a/store/src/test/java/com/zimbra/cs/account/commands/DescribeArgsTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/commands/DescribeArgsTest.java
@@ -1,0 +1,182 @@
+package com.zimbra.cs.account.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AttributeInfo;
+import com.zimbra.cs.account.AttributeManagerException;
+import com.zimbra.cs.account.AttributeType;
+import com.zimbra.cs.account.AttributeVersion;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DescribeArgsTest {
+
+  @Test
+  void parsesSinceFlagAsExactVersion() throws Exception {
+    DescribeArgs args = parse("desc", "-since", "26.6");
+
+    assertNotNull(args.mSince);
+    assertEquals("26.6", args.mSince.toString());
+    assertNull(args.mSinceAfter);
+    assertTrue(args.hasSinceFilter());
+  }
+
+  @Test
+  void parsesSinceAfterFlag() throws Exception {
+    DescribeArgs args = parse("desc", "-since-after", "26.5.0");
+
+    assertNull(args.mSince);
+    assertNotNull(args.mSinceAfter);
+    assertEquals("26.5.0", args.mSinceAfter.toString());
+    assertTrue(args.hasSinceFilter());
+  }
+
+  @Test
+  void rejectsBothSinceAndSinceAfter() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-since", "26.6", "-since-after", "26.5"));
+    assertTrue(e.getMessage().contains("cannot specify both -since and -since-after"));
+  }
+
+  @Test
+  void rejectsSinceWithSpecificAttribute() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-a", "zimbraId", "-since", "26.6"));
+    assertTrue(e.getMessage().contains("cannot specify -since when -a is specified"));
+  }
+
+  @Test
+  void rejectsSinceWithoutVersion() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-since"));
+    assertTrue(e.getMessage().contains("-since requires a version"));
+  }
+
+  @Test
+  void rejectsInvalidVersion() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-since", "26.6.banana"));
+    assertTrue(e.getMessage().contains("invalid version"));
+  }
+
+  @Test
+  void rejectsBareMajorVersion() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-since", "26"));
+    assertTrue(e.getMessage().contains("must include at least major and minor"));
+  }
+
+  @Test
+  void noFilterFlagsLeavesFilterDisabled() throws Exception {
+    DescribeArgs args = parse("desc");
+    assertFalse(args.hasSinceFilter());
+  }
+
+  @Test
+  void parsesListSinceVersionsFlag() throws Exception {
+    DescribeArgs args = parse("desc", "-list-since-versions");
+    assertTrue(args.mListSinceVersions);
+  }
+
+  @Test
+  void rejectsListSinceVersionsCombinedWithSince() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-list-since-versions", "-since", "26.6"));
+    assertTrue(e.getMessage().contains("-list-since-versions cannot be combined"));
+  }
+
+  @Test
+  void rejectsListSinceVersionsCombinedWithEntryType() {
+    ServiceException e = assertThrows(ServiceException.class,
+            () -> parse("desc", "-list-since-versions", "cos"));
+    assertTrue(e.getMessage().contains("-list-since-versions cannot be combined"));
+  }
+
+  @Test
+  void sinceFilterMatchesAttributeIntroducedInSameMinorRelease() throws Exception {
+    DescribeArgs args = parse("desc", "-since", "26.6");
+
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.6.0")));
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.6.5")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.5.0")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("27.0.0")));
+  }
+
+  @Test
+  void sinceFilterMatchesExactPatchWhenFullySpecified() throws Exception {
+    DescribeArgs args = parse("desc", "-since", "26.6.1");
+
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.6.1")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.6.0")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.6.2")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.5.1")));
+  }
+
+  @Test
+  void sinceAfterFilterMatchesLaterMajorMinorReleases() throws Exception {
+    DescribeArgs args = parse("desc", "-since-after", "26.5");
+
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.6.0")));
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("27.0.0")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.5.9")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.4.0")));
+  }
+
+  @Test
+  void sinceAfterFilterMatchesStrictlyLaterWhenFullySpecified() throws Exception {
+    DescribeArgs args = parse("desc", "-since-after", "26.6.0");
+
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.6.1")));
+    assertTrue(args.matchesSinceFilter(attrIntroducedIn("26.7.0")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.6.0")));
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn("26.5.9")));
+  }
+
+  @Test
+  void filterRejectsAttributesWithoutSinceMetadata() throws Exception {
+    DescribeArgs args = parse("desc", "-since-after", "5.0");
+    assertFalse(args.matchesSinceFilter(attrIntroducedIn((List<AttributeVersion>) null)));
+  }
+
+  private static DescribeArgs parse(String... args) throws ServiceException {
+    return DescribeArgs.parseDescribeArgs(args);
+  }
+
+  private static AttributeInfo attrIntroducedIn(String version) throws AttributeManagerException {
+    return attrIntroducedIn(List.of(new AttributeVersion(version)));
+  }
+
+  private static AttributeInfo attrIntroducedIn(List<AttributeVersion> since) {
+    return new AttributeInfo(
+            "carbonioFakeAttr",   // attrName
+            999,                   // id
+            null,                  // parentId
+            0,                     // groupId
+            null,                  // callbackClassName
+            AttributeType.TYPE_STRING,
+            null,                  // order
+            null,                  // value
+            false,                 // immutable
+            null,                  // min
+            null,                  // max
+            null,                  // cardinality
+            null,                  // requiredIn
+            null,                  // optionalIn
+            null,                  // flags
+            null,                  // globalConfigValues
+            null,                  // defaultCOSValues
+            null,                  // defaultExternalCOSValues
+            null,                  // globalConfigValuesUpgrade
+            null,                  // defaultCOSValuesUpgrade
+            "fake",                // description
+            null,                  // requiresRestart
+            since,                 // since
+            null);                 // deprecatedSince
+  }
+}

--- a/store/src/test/java/com/zimbra/cs/account/commands/DescribeCommandHandlerTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/commands/DescribeCommandHandlerTest.java
@@ -49,7 +49,7 @@ class DescribeCommandHandlerTest {
   }
 
   @Test
-  void skipsAttributesWithoutSinceMetadata() throws Exception {
+  void skipsAttributesWithoutSinceMetadata() {
     List<AttributeInfo> attrs = List.of(attrIntroducedIn((List<AttributeVersion>) null));
 
     SortedMap<AttributeVersion, Integer> counts = DescribeCommandHandler.countSinceVersions(attrs);

--- a/store/src/test/java/com/zimbra/cs/account/commands/DescribeCommandHandlerTest.java
+++ b/store/src/test/java/com/zimbra/cs/account/commands/DescribeCommandHandlerTest.java
@@ -1,0 +1,91 @@
+package com.zimbra.cs.account.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zimbra.cs.account.AttributeInfo;
+import com.zimbra.cs.account.AttributeType;
+import com.zimbra.cs.account.AttributeVersion;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import org.junit.jupiter.api.Test;
+
+class DescribeCommandHandlerTest {
+
+  @Test
+  void countsDistinctSinceVersionsAndOrdersOldestFirst() throws Exception {
+    List<AttributeInfo> attrs = new ArrayList<>();
+    attrs.add(attrIntroducedIn("26.6.0"));
+    attrs.add(attrIntroducedIn("26.6.0"));
+    attrs.add(attrIntroducedIn("5.0.0"));
+    attrs.add(attrIntroducedIn("26.7.0"));
+    attrs.add(attrIntroducedIn("5.0.0"));
+    attrs.add(attrIntroducedIn("5.0.0"));
+
+    SortedMap<AttributeVersion, Integer> counts = DescribeCommandHandler.countSinceVersions(attrs);
+
+    assertEquals(3, counts.size());
+    List<String> orderedVersions = new ArrayList<>();
+    counts.keySet().forEach(v -> orderedVersions.add(v.toString()));
+    assertEquals(List.of("5.0.0", "26.6.0", "26.7.0"), orderedVersions);
+
+    assertEquals(3, counts.get(new AttributeVersion("5.0.0")));
+    assertEquals(2, counts.get(new AttributeVersion("26.6.0")));
+    assertEquals(1, counts.get(new AttributeVersion("26.7.0")));
+  }
+
+  @Test
+  void countsAttributeWithMultipleSinceValuesUnderEachVersion() throws Exception {
+    List<AttributeInfo> attrs = List.of(
+            attrIntroducedIn(new ArrayList<>(List.of(
+                    new AttributeVersion("5.0.0"), new AttributeVersion("8.0.0")))));
+
+    SortedMap<AttributeVersion, Integer> counts = DescribeCommandHandler.countSinceVersions(attrs);
+
+    assertEquals(2, counts.size());
+    assertEquals(1, counts.get(new AttributeVersion("5.0.0")));
+    assertEquals(1, counts.get(new AttributeVersion("8.0.0")));
+  }
+
+  @Test
+  void skipsAttributesWithoutSinceMetadata() throws Exception {
+    List<AttributeInfo> attrs = List.of(attrIntroducedIn((List<AttributeVersion>) null));
+
+    SortedMap<AttributeVersion, Integer> counts = DescribeCommandHandler.countSinceVersions(attrs);
+
+    assertTrue(counts.isEmpty());
+  }
+
+  private static AttributeInfo attrIntroducedIn(String version) throws Exception {
+    return attrIntroducedIn(List.of(new AttributeVersion(version)));
+  }
+
+  private static AttributeInfo attrIntroducedIn(List<AttributeVersion> since) {
+    return new AttributeInfo(
+            "carbonioFakeAttr",
+            999,
+            null,
+            0,
+            null,
+            AttributeType.TYPE_STRING,
+            null,
+            null,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "fake",
+            null,
+            since,
+            null);
+  }
+}


### PR DESCRIPTION
  ## Summary

  Adds version-aware filtering to `zmprov desc` so operators can discover attributes                                                                                                  
  introduced in a given Carbonio release without manually grepping `attrs.xml`.
                                                                                                                                                                                      
  After each upgrade, the ops team had to manually identify new attributes and
  decide which to set on existing CoSes — time-consuming and error-prone. This PR                                                                                                     
  solves the **discovery** half of that workflow (applying the values is still                                                                                                        
  manual and out of scope).                                                                                                                                                           
                                                                                                                                                                                      
  ## What changed                                                                                                                                                                     
                                                            
  - `zmprov desc -since {version}` — list attributes introduced in the given version.                                                                                                 
  - `zmprov desc -since-after {version}` — list attributes introduced after the
    given version (the upgrade workflow).                                                                                                                                             
  - `zmprov desc -list-since-versions` — list every distinct `since` value found
    across all attributes, with per-version counts.                                                                                                                                   
  - When a filter is active, output switches to a compact tabular form with                                                                                                           
    `SINCE | APPLIES TO | ATTRIBUTE | DEFAULT`. With `-v` it falls back to the                                                                                                        
    same per-attribute verbose block already used by `desc -a`. Without filters,                                                                                                      
    behavior is unchanged.                                                                                                                                                            
                                                                                                                                                                                      
  ## Match granularity                                                                                                                                                                
                                                            
  Match precision follows the input shape:

  | Input                   | Matches                                                              |                                                                                  
  | ----------------------- | -------------------------------------------------------------------- |
  | `-since 26.6`           | any attr in `26.6.x`                                                 |                                                                                  
  | `-since 26.6.1`         | only attrs whose `since` equals `26.6.1` exactly                     |                                                                                  
  | `-since-after 26.5`     | strictly later major.minor (`26.6.x`, `27.x`; skips all `26.5.x`)    |                                                                                  
  | `-since-after 26.6.0`   | strictly greater (`26.6.1+`, `26.7.x+`; excludes `26.6.0` itself)    |                                                                                  
                                                                                                                                                                                      
  Bare major (`-since 26`) is rejected with a helpful error.                                                                                                                          
                                                                                                                                                                                      
  `-since` and `-since-after` are mutually exclusive. None of the three flags                                                                                                         
  combine with `-a {attr}`. `-list-since-versions` is standalone.
                                                                                                                                                                                      
  ## Help discoverability                                                                                                                                                             
                                                            
  The new flags appear in `zmprov help misc` via the updated `Command.DESCRIBE`                                                                                                       
  syntax string. Worked examples are shown via the existing `descAttrsUsage`
  parse-error path (e.g. `zmprov desc -h`), consistent with how the pre-existing                                                                                                      
  examples are exposed.