### PR TITLE
fix: revert wrong version bump from bad semantic-release run

### DIFF
--- a/packages/appserver-conf/PKGBUILD
+++ b/packages/appserver-conf/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-appserver-conf"
-pkgver="8.9.0"
+pkgver="4.25.2"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Service Configuration"
 arch=('x86_64')

--- a/packages/appserver-db/PKGBUILD
+++ b/packages/appserver-db/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-appserver-db"
-pkgver="8.9.0"
+pkgver="4.25.2"
 pkgrel="1"
 pkgdesc="Carbonio Appserver DB Files"
 arch=('x86_64')

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-appserver-service"
-pkgver="8.9.0"
+pkgver="4.25.2"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Service"
 arch=('x86_64')

--- a/packages/appserver-service/otel.properties
+++ b/packages/appserver-service/otel.properties
@@ -1,2 +1,2 @@
 otel.service.name=carbonio-mailbox
-otel.service.version=8.9.0
+otel.service.version=4.25.2

--- a/packages/common-appserver-conf/PKGBUILD
+++ b/packages/common-appserver-conf/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-common-appserver-conf"
-pkgver="8.9.0"
+pkgver="4.25.2"
 pkgrel="1"
 pkgdesc="Carbonio Core Mailbox Configuration"
 arch=('x86_64')

--- a/packages/mailbox-jar/PKGBUILD
+++ b/packages/mailbox-jar/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-mailbox-jar"
-pkgver="8.9.0"
+pkgver="4.25.2"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Jars"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -854,7 +854,7 @@
     <!-- Maven revision: https://maven.apache.org/maven-ci-friendly.html -->
     <changelist>-SNAPSHOT</changelist>
     <!-- Mailbox version -->
-    <revision>8.9.0</revision>
+    <revision>4.25.2</revision>
     <mockserver.version>5.13.0</mockserver.version>
     <json-unit.version>4.1.0</json-unit.version>
     <mariadb-java-client.version>2.7.3</mariadb-java-client.version>


### PR DESCRIPTION
## Summary

- semantic-release picked up the old Zimbra `8.8.15.p2` tag as its baseline and incorrectly tagged a release as `8.9.0`
- Reverts `pom.xml`, all `PKGBUILD` files, and `otel.properties` back to `4.25.2` (the correct last release version)
- The root cause (old `8.x.x` Zimbra-era tags polluting the tag namespace) has been resolved separately by deleting all 54 `8.x.x` tags from the repository

## Root cause

`semantic-release` was introduced in #918 but the old Zimbra `8.8.x` tags were still present. Since `8.8.15.p2 > 4.25.2` in semver ordering, semantic-release used it as the baseline and bumped to `8.9.0`.

## Fix

- Deleted the wrong `8.9.0` tag (locally + remote)
- Deleted all 54 `8.x.x` Zimbra-era tags (locally + remote) — backup of tag→SHA mapping preserved
- Reverted version files to `4.25.2`

Next semantic-release run will correctly find `4.25.2` as the last release and bump from there.