### PR TITLE
ci: streamline using dt2 lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ String mvnOpts = "-Ddebug=0 -Dis-production=1 ${profile}"
 
 defaultPipeline(timeoutMin: 120) {
     withEnv(['MAVEN_OPTS=-Xmx2g']) {
+      try {
 
         stage('Build') {
             withMaven {
@@ -173,5 +174,9 @@ defaultPipeline(timeoutMin: 120) {
                     },
             )
         }
+      } catch (err) {
+          notifyJiraOnFailure(project: 'IN')
+          throw err
+      }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,7 @@ defaultPipeline {
                         ])
                     }
                     stage('Publish packages') {
-                        def jfrogHome = tool name: 'jfrog-cli'
-                        withEnv(["PATH+JFROG=${jfrogHome}/bin"]) {
+                        withJfrog {
                             uploadStage(
                                     packages: yapHelper.getPackageNames('staging/packages/yap.json')
                             )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,10 @@ String mvnOpts = "-Ddebug=0 -Dis-production=1 ${profile}"
 defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
     withEnv(['MAVEN_OPTS=-Xmx2g']) {
 
-        stage('Build') {
-            withMaven {
+        withMaven {
+            stage('Build') {
                 sh """
-                    mvn ${mvnOpts} -s \$SETTINGS_PATH \
+                    mvn ${mvnOpts}  \
                         -DskipTests=true \
                         clean install
                     mkdir staging
@@ -27,44 +27,36 @@ defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
                 """
                 stash includes: 'staging/**', name: 'staging'
             }
-        }
 
-        stage('UT, IT') {
-            withMaven {
-                sh "mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
+            stage('UT, IT') {
+                sh "mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
+                junit allowEmptyResults: true,
+                        testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
-            junit allowEmptyResults: true,
-                    testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
-        }
 
-        stage('Flaky, API, E2E tests') {
-            withMaven {
-                sh "cd store && mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
+            stage('Flaky, API, E2E tests') {
+                sh "cd store && mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
+                junit allowEmptyResults: true,
+                        testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
-            junit allowEmptyResults: true,
-                    testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
-        }
 
-        stage('Build and Package API Docs') {
-            withMaven {
+            stage('Build and Package API Docs') {
                 sh """
                     (
                         cd soap || { echo "Directory soap does not exist"; exit 1; }
-                        mvn ${mvnOpts} -s \$SETTINGS_PATH antrun:run@generate-soap-docs
+                        mvn ${mvnOpts}  antrun:run@generate-soap-docs
                     )
-                    VERSION=\$(mvn help:evaluate -s \$SETTINGS_PATH -Dexpression=project.version -q -DforceStdout)
+                    VERSION=\$(mvn help:evaluate  -Dexpression=project.version -q -DforceStdout)
                     mkdir -p docs
                     tar -czf docs/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
                 """
+                archiveArtifacts artifacts: 'docs/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
             }
-            archiveArtifacts artifacts: 'docs/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
-        }
 
-        stage('Sonarqube Analysis') {
-            withMaven {
+            stage('Sonarqube Analysis') {
                 withSonarQube {
                     sh """
-                        mvn ${mvnOpts} -s \$SETTINGS_PATH \
+                        mvn ${mvnOpts}  \
                             jacoco:report \
                             sonar:sonar \
                             -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,8 @@ String profile = env.TAG_NAME ? '-Pprod' :
         (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
 String mvnOpts = "-Ddebug=0 -Dis-production=1 ${profile}"
 
-defaultPipeline(timeoutMin: 120) {
+defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
     withEnv(['MAVEN_OPTS=-Xmx2g']) {
-      try {
 
         stage('Build') {
             withMaven {
@@ -174,9 +173,5 @@ defaultPipeline(timeoutMin: 120) {
                     },
             )
         }
-      } catch (err) {
-          notifyEmailOnFailure(to: 'devops@zextras.com')
-          throw err
-      }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ library(
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
-                remote: 'git@github.com:zextras/jenkins-lib-common.git',
+                remote: 'git@github.com:zextras/jenkins-dt2-lib.git',
         ])
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@maven-refactor',
+        identifier: 'jenkins-dt2-lib@main',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ defaultPipeline(timeoutMin: 120) {
             )
         }
       } catch (err) {
-          notifyJiraOnFailure(project: 'IN')
+          notifyEmailOnFailure(to: 'devops@zextras.com')
           throw err
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@1.7.2',
+        identifier: 'jenkins-lib-common@maven-refactor',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
@@ -7,256 +7,171 @@ library(
         ])
 )
 
-properties(defaultPipelineProperties())
-
-boolean isBuildingTag() {
-    return env.TAG_NAME ? true : false
-}
-
-String profile = isBuildingTag() ? '-Pprod' :
+String profile = env.TAG_NAME ? '-Pprod' :
         (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
+String mvnOpts = "-Ddebug=0 -Dis-production=1 ${profile}"
 
-pipeline {
-    agent {
-        node {
-            label 'zextras-v1'
-        }
-    }
-
-    environment {
-        MVN_OPTS = "-Ddebug=0 -Dis-production=1 ${profile}"
-        GITHUB_BOT_PR_CREDS = credentials('jenkins-integration-with-github-account')
-        JAVA_OPTS = '-Dfile.encoding=UTF8'
-        LC_ALL = 'C.UTF-8'
-        MAVEN_OPTS = '-Xmx2g'
-    }
-
-    options {
-        buildDiscarder(logRotator(numToKeepStr: '25'))
-        skipDefaultCheckout()
-        timeout(time: 2, unit: 'HOURS')
-    }
-
-    triggers {
-        cron(env.BRANCH_NAME == 'devel' ? 'H 5 * * *' : '')
-    }
-
-    stages {
-        stage('Setup') {
-            steps {
-                checkout scm
-                script {
-                    gitMetadata()
-                }
-            }
-        }
+defaultPipeline(timeoutMin: 120) {
+    withEnv(['MAVEN_OPTS=-Xmx2g']) {
 
         stage('Build') {
-            parallel {
-                stage('Maven build') {
-                    steps {
-                        container('jdk-21') {
-                            sh """
-                        mvn ${MVN_OPTS} \
-                            -DskipTests=true \
-                            clean install
-                        mkdir staging
-                        cp -a store* right-manager \
-                                client common packages soap jython-libs \
-                                staging/
-                    """
-                            stash includes: 'staging/**', name: 'staging'
-                        }
-                    }
-                }
+            withMaven {
+                sh """
+                    mvn ${mvnOpts} -s \$SETTINGS_PATH \
+                        -DskipTests=true \
+                        clean install
+                    mkdir staging
+                    cp -a store* right-manager \
+                            client common packages soap jython-libs \
+                            staging/
+                """
+                stash includes: 'staging/**', name: 'staging'
             }
         }
 
         stage('UT, IT') {
-            steps {
-                container('jdk-21') {
-                    sh "mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
-                }
-                junit allowEmptyResults: true,
-                        testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
+            withMaven {
+                sh "mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
             }
+            junit allowEmptyResults: true,
+                    testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
         }
+
         stage('Flaky, API, E2E tests') {
-                    steps {
-                        container('jdk-21') {
-                            sh "cd store && mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
-                        }
-                        junit allowEmptyResults: true,
-                                testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
-                    }
-                }
+            withMaven {
+                sh "cd store && mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${mvnOpts} -s \$SETTINGS_PATH jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
+            }
+            junit allowEmptyResults: true,
+                    testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
+        }
 
         stage('Build and Package API Docs') {
-            steps {
-                container('jdk-21') {
-                    sh """
-                (
-                    cd soap || { echo "Directory soap does not exist"; exit 1; }
-                    mvn ${MVN_OPTS} antrun:run@generate-soap-docs
-                )
-                VERSION=\$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-                mkdir -p docs
-                tar -czf docs/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
-            """
-                }
-                archiveArtifacts artifacts: 'docs/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
+            withMaven {
+                sh """
+                    (
+                        cd soap || { echo "Directory soap does not exist"; exit 1; }
+                        mvn ${mvnOpts} -s \$SETTINGS_PATH antrun:run@generate-soap-docs
+                    )
+                    VERSION=\$(mvn help:evaluate -s \$SETTINGS_PATH -Dexpression=project.version -q -DforceStdout)
+                    mkdir -p docs
+                    tar -czf docs/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
+                """
             }
+            archiveArtifacts artifacts: 'docs/carbonio-mailbox-api-docs-*.tar.gz', allowEmptyArchive: true
         }
 
         stage('Sonarqube Analysis') {
-            steps {
-                container('jdk-21') {
-                    withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        sh """
-                            mvn ${MVN_OPTS} \
-                                jacoco:report \
-                                sonar:sonar \
-                                -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml \
-                                -Dsonar.junit.reportPaths=target/surefire-reports,target/failsafe-reports \
-                                -Dsonar.exclusions=**/com/zimbra/soap/mail/type/*.java,**/com/zimbra/soap/mail/message/*.java,**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java
-                        """
-                    }
+            withMaven {
+                withSonarQube {
+                    sh """
+                        mvn ${mvnOpts} -s \$SETTINGS_PATH \
+                            jacoco:report \
+                            sonar:sonar \
+                            -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml \
+                            -Dsonar.junit.reportPaths=target/surefire-reports,target/failsafe-reports \
+                            -Dsonar.exclusions=**/com/zimbra/soap/mail/type/*.java,**/com/zimbra/soap/mail/message/*.java,**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java
+                    """
                 }
             }
         }
 
-        stage('Build and upload artifacts')
-        {
-            parallel {
-                stage('Packages') {
-                    stages {
+        stage('Build and upload artifacts') {
+            parallel(
+                    'Packages': {
                         stage('Build deb/rpm') {
-                            steps {
-                                echo 'Building deb/rpm packages'
-                                buildStage([
-                                        addCarbonioRepos: true,
-                                        carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
-                                        skipStash: true,
-                                        buildDirs: ['staging/packages'],
-                                ])
-                            }
+                            echo 'Building deb/rpm packages'
+                            buildStage([
+                                    addCarbonioRepos: true,
+                                    carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                                    skipStash: true,
+                                    buildDirs: ['staging/packages'],
+                            ])
                         }
-                        stage ('Publish packages') {
-                            tools {
-                                jfrog 'jfrog-cli'
-                            }
-                            steps {
+                        stage('Publish packages') {
+                            def jfrogHome = tool name: 'jfrog-cli'
+                            withEnv(["PATH+JFROG=${jfrogHome}/bin"]) {
                                 uploadStage(
                                         packages: yapHelper.getPackageNames('staging/packages/yap.json')
                                 )
                             }
                         }
-                    }
-                }
+                    },
 
-                stage('Publish SNAPSHOT to maven') {
-                    when {
-                        allOf {
-                            not { buildingTag() }
-                            branch 'devel'
-                        }
-
-                    }
-                    steps {
-                        container('jdk-21') {
-                            withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                                script {
-                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -DskipTests=true"
+                    'Publish SNAPSHOT to maven': {
+                        if (!env.TAG_NAME && env.BRANCH_NAME == 'devel') {
+                            stage('Publish SNAPSHOT to maven') {
+                                withMaven {
+                                    sh "mvn ${mvnOpts} -s \$SETTINGS_PATH deploy -DskipTests=true"
                                 }
                             }
                         }
-                    }
-                }
+                    },
 
-                stage('Publish to maven') {
-                    when {
-                        buildingTag()
-                    }
-                    steps {
-                        container('jdk-21') {
-                            withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                                script {
-                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -Dchangelist= -DskipTests=true"
+                    'Publish to maven': {
+                        if (env.TAG_NAME) {
+                            stage('Publish to maven') {
+                                withMaven {
+                                    sh "mvn ${mvnOpts} -s \$SETTINGS_PATH deploy -Dchangelist= -DskipTests=true"
                                 }
                             }
                         }
-                    }
-                }
+                    },
 
-                stage('Build and Publish Docker images') {
-                    steps {
-                        dockerStage([
-                                dockerfile: 'docker/mailbox/Dockerfile',
-                                imageName : 'carbonio-mailbox',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title          : 'Carbonio Mailbox',
-                                        descriptionFile: 'docker/mailbox/description.md'
-                                ]
-                        ])
-                        dockerStage([
-                                dockerfile: 'docker/mailbox-sidecar/Dockerfile',
-                                imageName : 'carbonio-mailbox-sidecar',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title : 'Carbonio Mailbox Sidecar',
-                                ]
-                        ])
-                        dockerStage([
-                                dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
-                                imageName : 'carbonio-mailbox-admin-sidecar',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title : 'Carbonio Mailbox Admin Sidecar',
-                                ]
-                        ])
-                        dockerStage([
-                                dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
-                                imageName : 'carbonio-mailbox-nslookup-sidecar',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title : 'Carbonio Mailbox NSLookup Sidecar',
-                                ]
-                        ])
-                        dockerStage([
-                                dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
-                                imageName : 'carbonio-mailbox-internal-api-sidecar',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title : 'Carbonio Mailbox Internal API Sidecar',
-                                ]
-                        ])
-                        dockerStage([
-                                dockerfile: 'docker/mariadb/Dockerfile',
-                                imageName : 'carbonio-mariadb',
-                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                ocLabels  : [
-                                        title          : 'Carbonio MariaDB',
-                                        descriptionFile: 'docker/mariadb/description.md'
-                                ]
-                        ])
-                    }
-                }
-            }
-
-        }
-        stage('Bump version and tag') {
-            when {
-                anyOf {
-                    branch 'main'
-                    branch 'devel'
-                }
-            }
-            steps {
-                script {
-                    dt2_semanticRelease()
-                }
-            }
+                    'Docker images': {
+                        stage('Build and Publish Docker images') {
+                            dockerStage([
+                                    dockerfile: 'docker/mailbox/Dockerfile',
+                                    imageName : 'carbonio-mailbox',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title          : 'Carbonio Mailbox',
+                                            descriptionFile: 'docker/mailbox/description.md'
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'docker/mailbox-sidecar/Dockerfile',
+                                    imageName : 'carbonio-mailbox-sidecar',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title: 'Carbonio Mailbox Sidecar',
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
+                                    imageName : 'carbonio-mailbox-admin-sidecar',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title: 'Carbonio Mailbox Admin Sidecar',
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
+                                    imageName : 'carbonio-mailbox-nslookup-sidecar',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title: 'Carbonio Mailbox NSLookup Sidecar',
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
+                                    imageName : 'carbonio-mailbox-internal-api-sidecar',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title: 'Carbonio Mailbox Internal API Sidecar',
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'docker/mariadb/Dockerfile',
+                                    imageName : 'carbonio-mariadb',
+                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                    ocLabels  : [
+                                            title          : 'Carbonio MariaDB',
+                                            descriptionFile: 'docker/mariadb/description.md'
+                                    ]
+                            ])
+                        }
+                    },
+            )
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,19 +7,18 @@ library(
         ])
 )
 
-String profile = env.TAG_NAME ? '-Pprod' :
-        (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
-String mvnOpts = "-Ddebug=0 -Dis-production=1 ${profile}"
+String profile = env.TAG_NAME ? '-Pprod' : (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
 
-defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
-    withEnv(['MAVEN_OPTS=-Xmx2g']) {
+defaultPipeline {
 
-        withMaven {
+    withMaven {
+        withEnv([
+                'MAVEN_OPTS=-Xmx2g',
+                "MAVEN_ARGS=-s ${SETTINGS_PATH} -Ddebug=0 -Dis-production=1 ${profile}",
+        ]) {
             stage('Build') {
                 sh """
-                    mvn ${mvnOpts}  \
-                        -DskipTests=true \
-                        clean install
+                    mvn -DskipTests=true clean install
                     mkdir staging
                     cp -a store* right-manager \
                             client common packages soap jython-libs \
@@ -29,13 +28,13 @@ defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
             }
 
             stage('UT, IT') {
-                sh "mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
+                sh "mvn jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
                 junit allowEmptyResults: true,
                         testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
 
             stage('Flaky, API, E2E tests') {
-                sh "cd store && mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${mvnOpts}  jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
+                sh "cd store && mvn jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
                 junit allowEmptyResults: true,
                         testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
@@ -44,9 +43,9 @@ defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
                 sh """
                     (
                         cd soap || { echo "Directory soap does not exist"; exit 1; }
-                        mvn ${mvnOpts}  antrun:run@generate-soap-docs
+                        mvn antrun:run@generate-soap-docs
                     )
-                    VERSION=\$(mvn help:evaluate  -Dexpression=project.version -q -DforceStdout)
+                    VERSION=\$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
                     mkdir -p docs
                     tar -czf docs/carbonio-mailbox-api-docs-\${VERSION}.tar.gz -C soap/target/docs/soap .
                 """
@@ -56,114 +55,96 @@ defaultPipeline(timeoutMin: 120, notifyOnFailure: [to: 'devops@zextras.com']) {
             stage('Sonarqube Analysis') {
                 withSonarQube {
                     sh """
-                        mvn ${mvnOpts}  \
-                            jacoco:report \
-                            sonar:sonar \
+                        mvn jacoco:report sonar:sonar \
                             -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml \
                             -Dsonar.junit.reportPaths=target/surefire-reports,target/failsafe-reports \
                             -Dsonar.exclusions=**/com/zimbra/soap/mail/type/*.java,**/com/zimbra/soap/mail/message/*.java,**/com/zimbra/cs/account/ZAttr*.java,**/com/zimbra/common/account/ZAttr*.java
                     """
                 }
             }
-        }
-
-        stage('Build and upload artifacts') {
-            parallel(
-                    'Packages': {
-                        stage('Build deb/rpm') {
-                            echo 'Building deb/rpm packages'
-                            buildStage([
-                                    addCarbonioRepos: true,
-                                    carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
-                                    skipStash: true,
-                                    buildDirs: ['staging/packages'],
-                            ])
-                        }
-                        stage('Publish packages') {
-                            def jfrogHome = tool name: 'jfrog-cli'
-                            withEnv(["PATH+JFROG=${jfrogHome}/bin"]) {
-                                uploadStage(
-                                        packages: yapHelper.getPackageNames('staging/packages/yap.json')
-                                )
-                            }
-                        }
-                    },
-
-                    'Publish SNAPSHOT to maven': {
-                        if (!env.TAG_NAME && env.BRANCH_NAME == 'devel') {
-                            stage('Publish SNAPSHOT to maven') {
-                                withMaven {
-                                    sh "mvn ${mvnOpts} -s \$SETTINGS_PATH deploy -DskipTests=true"
-                                }
-                            }
-                        }
-                    },
-
-                    'Publish to maven': {
-                        if (env.TAG_NAME) {
-                            stage('Publish to maven') {
-                                withMaven {
-                                    sh "mvn ${mvnOpts} -s \$SETTINGS_PATH deploy -Dchangelist= -DskipTests=true"
-                                }
-                            }
-                        }
-                    },
-
-                    'Docker images': {
-                        stage('Build and Publish Docker images') {
-                            dockerStage([
-                                    dockerfile: 'docker/mailbox/Dockerfile',
-                                    imageName : 'carbonio-mailbox',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title          : 'Carbonio Mailbox',
-                                            descriptionFile: 'docker/mailbox/description.md'
-                                    ]
-                            ])
-                            dockerStage([
-                                    dockerfile: 'docker/mailbox-sidecar/Dockerfile',
-                                    imageName : 'carbonio-mailbox-sidecar',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title: 'Carbonio Mailbox Sidecar',
-                                    ]
-                            ])
-                            dockerStage([
-                                    dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
-                                    imageName : 'carbonio-mailbox-admin-sidecar',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title: 'Carbonio Mailbox Admin Sidecar',
-                                    ]
-                            ])
-                            dockerStage([
-                                    dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
-                                    imageName : 'carbonio-mailbox-nslookup-sidecar',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title: 'Carbonio Mailbox NSLookup Sidecar',
-                                    ]
-                            ])
-                            dockerStage([
-                                    dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
-                                    imageName : 'carbonio-mailbox-internal-api-sidecar',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title: 'Carbonio Mailbox Internal API Sidecar',
-                                    ]
-                            ])
-                            dockerStage([
-                                    dockerfile: 'docker/mariadb/Dockerfile',
-                                    imageName : 'carbonio-mariadb',
-                                    platforms : ['linux/amd64', 'linux/arm64'] as Set,
-                                    ocLabels  : [
-                                            title          : 'Carbonio MariaDB',
-                                            descriptionFile: 'docker/mariadb/description.md'
-                                    ]
-                            ])
-                        }
-                    },
-            )
+            stage('Maven deploy') {
+                if (env.TAG_NAME || env.BRANCH_NAME == 'devel') {
+                    sh "mvn deploy -DskipTests=true"
+                }
+            }
         }
     }
+
+    stage('Build and upload artifacts') {
+        parallel(
+                'Packages': {
+                    stage('Build deb/rpm') {
+                        echo 'Building deb/rpm packages'
+                        buildStage([
+                                addCarbonioRepos: true,
+                                carbonioRepoCredentialId: 'artifactory-jenkins-gradle-properties-splitted',
+                                skipStash: true,
+                                buildDirs: ['staging/packages'],
+                        ])
+                    }
+                    stage('Publish packages') {
+                        def jfrogHome = tool name: 'jfrog-cli'
+                        withEnv(["PATH+JFROG=${jfrogHome}/bin"]) {
+                            uploadStage(
+                                    packages: yapHelper.getPackageNames('staging/packages/yap.json')
+                            )
+                        }
+                    }
+                },
+                'Docker images': {
+                    stage('Build and Publish Docker images') {
+                        dockerStage([
+                                dockerfile: 'docker/mailbox/Dockerfile',
+                                imageName : 'carbonio-mailbox',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title          : 'Carbonio Mailbox',
+                                        descriptionFile: 'docker/mailbox/description.md'
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title: 'Carbonio Mailbox Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-admin-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-admin-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title: 'Carbonio Mailbox Admin Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-nslookup-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-nslookup-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title: 'Carbonio Mailbox NSLookup Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mailbox-internal-api-sidecar/Dockerfile',
+                                imageName : 'carbonio-mailbox-internal-api-sidecar',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title: 'Carbonio Mailbox Internal API Sidecar',
+                                ]
+                        ])
+                        dockerStage([
+                                dockerfile: 'docker/mariadb/Dockerfile',
+                                imageName : 'carbonio-mariadb',
+                                platforms : ['linux/amd64', 'linux/arm64'] as Set,
+                                ocLabels  : [
+                                        title          : 'Carbonio MariaDB',
+                                        descriptionFile: 'docker/mariadb/description.md'
+                                ]
+                        ])
+                    }
+                },
+            )
+        }
 }


### PR DESCRIPTION
Changes:
- use small "with" blocks to reuse bits where needed
- allows declaring a single withMaven and defining multiple stages in it
- allows defining args explicitly at the top without having to do string interpolation on every command
- keeps command explicit
- use dt2 library - if jenkins-lib-common has a bug dt2 lib can be updated without changing every repo
- streamline deploy phase (uses profile from MAVEN_ARGS + profile prod sets changelists to empty, resulting in no snapshot)

Rather than shadowing maven commands I prefer to reuse existing jenkins builtins + closure. 
This means you can combine and rearrange things at your will without enforcement, e.g.: withMaven + withEnv (Jenkins built-in, etc) and keep things quite explicit

However using closure means only scripted pipelines can be used and not declarative