### PR TITLE
fix: reject deregistered auth tokens on internal API 

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/api/rest/service/AccountService.java
+++ b/store/src/main/java/com/zextras/mailbox/api/rest/service/AccountService.java
@@ -48,6 +48,9 @@ public class AccountService {
       if (authToken.isExpired()) {
         throw ServiceException.AUTH_EXPIRED("Auth token expired");
       }
+      if (!authToken.isRegistered()) {
+        throw ServiceException.AUTH_EXPIRED("Auth token is no longer valid");
+      }
       return authToken;
     });
   }

--- a/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
+++ b/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
@@ -242,6 +242,20 @@ class AccountResourceIT {
 		assertEquals(401, response.statusCode());
 	}
 
+	@Test
+	void myselfInfoWithDeregisteredToken() throws Exception {
+		final Account account = server.getAccountFactory().create();
+		final ZimbraAuthToken authToken = new ZimbraAuthToken(account);
+		final String token = authToken.getEncoded();
+		authToken.deRegister();
+
+		final Response response = server.getHttpClient()
+				.get(server.getInternalApiEndpoint() + "/accounts/myself",
+						Map.of("Cookie", "ZM_AUTH_TOKEN=" + token));
+
+		assertEquals(401, response.statusCode());
+	}
+
 	// --- GET /accounts?email= tests ---
 
 	@Test


### PR DESCRIPTION
The get myself endpoint doesn't check for invalidated token. This PR fixes that.