### PR TITLE
chore: fix local build_packages.sh by using release of ubuntu jammy

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -4,13 +4,23 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
-OS=${1:-"ubuntu-jammy"}
+OS="ubuntu-jammy"
 
 echo "Building for OS: $OS"
 
+
 docker run -it --rm \
-    --entrypoint=yap \
+    --entrypoint=/bin/bash \
     -v "$(pwd)/artifacts/${OS}":/artifacts \
-    -v "$(pwd)":/tmp/build \
+    -v "$(pwd)":/project \
     "docker.io/m0rf30/yap-${OS}:1.53" \
-    build "${OS}" /tmp/build/packages
+    -c "
+        set -e
+        apt update
+        apt install -y --no-install-recommends gnupg wget ca-certificates
+        wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x5dc7680bc4378c471a7fa80f52fd40243e584a21' | gpg --dearmor > /usr/share/keyrings/zextras.gpg
+        chmod 644 /usr/share/keyrings/zextras.gpg
+        echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/zextras.gpg] https://repo.zextras.io/release/ubuntu jammy main' > /etc/apt/sources.list.d/zextras.list
+        apt-get update -qq
+        yap build ${OS} /project/packages
+    "


### PR DESCRIPTION
- the package build now needs to install packages, but this is not possible without defining a zextras repo. This means that for devel build we should technically use devel, however it requires access to jfrog with credentials, so for now I used release.

We should think if we want to actually mantain these build packages. The downside is that we have to strictly rely to CI if we want to get deb packages and try them in a VM

- [ ] decide if it's worth having these scripts