### PR TITLE
fix: reject deregistered auth tokens on internal API /accounts/myself

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/api/rest/service/AccountService.java
+++ b/store/src/main/java/com/zextras/mailbox/api/rest/service/AccountService.java
@@ -48,6 +48,9 @@ public class AccountService {
       if (authToken.isExpired()) {
         throw ServiceException.AUTH_EXPIRED("Auth token expired");
       }
+      if (!authToken.isRegistered()) {
+        throw ServiceException.AUTH_EXPIRED("Auth token is no longer valid");
+      }
       return authToken;
     });
   }

--- a/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
+++ b/store/src/test/java/com/zextras/mailbox/api/resource/AccountResourceIT.java
@@ -242,6 +242,20 @@ class AccountResourceIT {
 		assertEquals(401, response.statusCode());
 	}
 
+	@Test
+	void myselfInfoWithDeregisteredToken() throws Exception {
+		final Account account = server.getAccountFactory().create();
+		final ZimbraAuthToken authToken = new ZimbraAuthToken(account);
+		final String token = authToken.getEncoded();
+		authToken.deRegister();
+
+		final Response response = server.getHttpClient()
+				.get(server.getInternalApiEndpoint() + "/accounts/myself",
+						Map.of("Cookie", "ZM_AUTH_TOKEN=" + token));
+
+		assertEquals(401, response.statusCode());
+	}
+
 	// --- GET /accounts?email= tests ---
 
 	@Test


### PR DESCRIPTION
## Summary

- The internal REST endpoint `/accounts/myself` only checked `isExpired()` (timestamp-based) but not `isRegistered()` (LDAP lookup), allowing tokens invalidated via `EndSession`/logout to still pass authentication
- SOAP already performs both checks in `ZimbraSoapContext` and `AuthProvider` — this aligns the internal API behavior
- Added integration test `myselfInfoWithDeregisteredToken` in `AccountResourceIT`

## Root cause

`AccountService.getAuthToken()` deserialized the token and checked the embedded expiry timestamp, but never called `authToken.isRegistered()` which verifies the token ID still exists in `zimbraAuthTokens` LDAP attribute. After `EndSessionRequest` calls `deRegister()` (removes token from LDAP), the internal API continued accepting the token. All downstream services (user-management, WSC) that validate tokens via this internal API were affected.

## Test plan

- [x] Verified fix locally (mvn compile)
- [x] Deployed to dt3-dev1 infra (srv3 + srv4), ran 10-run E2E test: SOAP=422, UM=401, WSC=401 for invalidated tokens, fresh tokens still 200 across all endpoints
- [x] Jenkins CI passes
- [x] Integration test `myselfInfoWithDeregisteredToken` passes in e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)