### PR TITLE
fix(CO-3485): improve handling of shared folder notifications and mountpoint

### DIFF
--- a/store/src/main/java/com/zimbra/cs/mailbox/Folder.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/Folder.java
@@ -19,7 +19,6 @@ import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.AccessManager;
 import com.zimbra.cs.account.Account;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.db.DbMailItem;
 import com.zimbra.cs.db.DbTag;
 import com.zimbra.cs.imap.ImapSession;
@@ -1789,86 +1788,6 @@ public class Folder extends MailItem implements FolderStore {
       for (Folder sub : subfolders.values()) {
         if (sub.isShare() || sub.containsShare()) {
           return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Checks if this folder is directly shared with a specific user via ACL grants.
-   *
-   * <p>This method determines whether this folder has been shared with the specified user, either
-   * directly (via a {@link ACL#GRANTEE_USER} grant whose ID matches the user) or indirectly
-   * through group/distribution-list membership (via a {@link ACL#GRANTEE_GROUP} grant whose group
-   * the user belongs to). The check uses {@link ACL.Grant#isGrantee(String)} for direct matches
-   * and {@link Provisioning#inACLGroup(Account, String)} for group grants.
-   *
-   * <p>If the folder's ACL is not loaded (null), this method will attempt to load the effective ACL
-   * from the database before performing the check.
-   *
-   * @param authenticatedUserId the Zimbra account ID of the user to check
-   * @return {@code true} if the folder has an ACL grant for the specified user (directly or via a
-   *     group), {@code false} otherwise
-   */
-  public boolean isSharedWithUser(String authenticatedUserId) {
-    try {
-      ACL folderAcl = getOrLoadAcl();
-      if (folderAcl == null) {
-        return false;
-      }
-
-      Provisioning prov = Provisioning.getInstance();
-      Account account = prov.getAccountById(authenticatedUserId);
-      return hasGrantForUser(folderAcl, authenticatedUserId, account, prov);
-    } catch (Exception e) {
-      // Suppress exceptions and default to not shared
-      return false;
-    }
-  }
-
-  /**
-   * Retrieves this folder's ACL, loading it from the database if not already loaded.
-   *
-   * @return the folder's ACL, or {@code null} if unavailable
-   */
-  private ACL getOrLoadAcl() {
-    ACL acl = getACL();
-    if (acl == null) {
-      // ACL not loaded - fetch the effective ACL from the database
-      acl = getEffectiveACL();
-    }
-    return acl;
-  }
-
-  /**
-   * Checks if the ACL contains a grant that covers the specified user, either by direct user grant
-   * or by group/distribution-list membership.
-   *
-   * @param acl the ACL to check
-   * @param userId the account ID of the user to look for
-   * @param account the resolved {@link Account} for the user (maybe {@code null})
-   * @param prov the {@link Provisioning} instance used for group-membership lookups
-   * @return {@code true} if a matching grant exists, {@code false} otherwise
-   */
-  private boolean hasGrantForUser(ACL acl, String userId, Account account, Provisioning prov) {
-    for (ACL.Grant grant : acl.getGrants()) {
-      // Direct user/public/authuser/guest/key match
-      if (grant.isGrantee(userId)) {
-        return true;
-      }
-      // Group / distribution-list grant: check whether the user is a member
-      if (grant.getGranteeType() == ACL.GRANTEE_GROUP
-          && account != null
-          && grant.getGranteeId() != null) {
-        try {
-          if (prov.inACLGroup(account, grant.getGranteeId())) {
-            return true;
-          }
-        } catch (Exception e) {
-          ZimbraLog.mailbox.warn(
-              "Failed to check group membership for account %s in group %s",
-              userId, grant.getGranteeId(), e);
         }
       }
     }

--- a/store/src/main/java/com/zimbra/cs/mailbox/OperationContext.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/OperationContext.java
@@ -104,7 +104,7 @@ public class OperationContext implements OpContext {
     return this;
   }
 
-  Session getSession() {
+  public Session getSession() {
     return session;
   }
 

--- a/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/FolderAction.java
@@ -30,6 +30,7 @@ import com.zimbra.cs.fb.FreeBusyProvider;
 import com.zimbra.cs.ldap.ZLdapFilterFactory.FilterId;
 import com.zimbra.cs.mailbox.ACL;
 import com.zimbra.cs.mailbox.Flag;
+import com.zimbra.cs.mailbox.Folder;
 import com.zimbra.cs.mailbox.FolderActionEmptyOpTypes;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.MailServiceException;
@@ -38,6 +39,8 @@ import com.zimbra.cs.mailbox.Mailbox.FolderNode;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.cs.service.util.ItemIdFormatter;
+import com.zimbra.cs.session.Session;
+import com.zimbra.cs.session.SoapSession;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.mail.type.RetentionPolicy;
@@ -136,7 +139,17 @@ public class FolderAction extends ItemAction {
             mbox.alterTag(octxt, iid.getId(), MailItem.Type.FOLDER, Flag.FlagInfo.EXCLUDE_FREEBUSY, fb, null);
             FreeBusyProvider.mailboxChanged(zsc.getRequestedAccountId());
         } else if (operation.equals(OP_CHECK) || operation.equals(OP_UNCHECK)) {
-            mbox.alterTag(octxt, iid.getId(), MailItem.Type.FOLDER, Flag.FlagInfo.CHECKED, operation.equals(OP_CHECK), null);
+            boolean check = operation.equals(OP_CHECK);
+            Folder folder = mbox.getFolderById(octxt, iid.getId());
+            boolean wasChecked = folder.isTagged(Flag.FlagInfo.CHECKED);
+            mbox.alterTag(octxt, iid.getId(), MailItem.Type.FOLDER, Flag.FlagInfo.CHECKED, check, null);
+            if (wasChecked == check) {
+                // No-op on the server: the caller's UI cache may be stale (e.g. an earlier
+                // toggle by the folder's owner was filtered out for them via delegation). Queue
+                // a session-private FLAGS notification so their UI can re-sync to the current
+                // server state without us broadcasting to other listeners.
+                queueFlagsRefreshForCaller(octxt, folder);
+            }
         } else if (operation.equals(OP_SET_URL)) {
             String url = action.getAttribute(MailConstants.A_URL, "");
             mbox.setFolderUrl(octxt, iid.getId(), url);
@@ -287,6 +300,19 @@ public class FolderAction extends ItemAction {
         }
 
         return ifmt.formatItemId(iid);
+    }
+
+    private static void queueFlagsRefreshForCaller(OperationContext octxt, Folder folder) {
+        Session caller = octxt.getSession();
+        SoapSession soapSession = null;
+        if (caller instanceof SoapSession.DelegateSession ds) {
+            soapSession = ds.getParentSession();
+        } else if (caller instanceof SoapSession ss) {
+            soapSession = ss;
+        }
+        if (soapSession != null) {
+            soapSession.queueFolderFlagsRefresh(folder);
+        }
     }
 
     private void handleFolderEmptyOperation(Element action, Mailbox mbox, OperationContext octxt, ItemId iid) throws ServiceException {

--- a/store/src/main/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/main/java/com/zimbra/cs/session/SoapSession.java
@@ -136,9 +136,13 @@ public class SoapSession extends Session {
     public void notifyPendingChanges(PendingModifications pmsIn, int changeId, Session source) {
       PendingLocalModifications pms = (PendingLocalModifications) pmsIn;
       try {
-        if (calculateVisibleFolders(false)) pms = filterNotifications(pms);
-        if (pms != null && pms.hasNotifications())
-          handleNotifications(pms, source == this || source == SoapSession.this);
+        boolean changesAreOurs =
+            source != null
+                && (source == this
+                    || source == SoapSession.this
+                    || mAuthenticatedAccountId.equalsIgnoreCase(source.getAuthenticatedAccountId()));
+        if (calculateVisibleFolders(false)) pms = filterNotifications(pms, changesAreOurs);
+        if (pms != null && pms.hasNotifications()) handleNotifications(pms, changesAreOurs);
       } catch (ServiceException e) {
         ZimbraLog.session.warn("exception during delegated notifyPendingChanges", e);
       }
@@ -269,8 +273,8 @@ public class SoapSession extends Session {
     private static final int RESTRICTED_MOUNTED_FOLDER_CHANGES =
         Change.NAME | Change.COLOR | Change.FLAGS;
 
-    private PendingLocalModifications filterNotifications(PendingLocalModifications pms)
-        throws ServiceException {
+    private PendingLocalModifications filterNotifications(
+        PendingLocalModifications pms, boolean changesAreOurs) throws ServiceException {
       // first, recalc visible folders if any folders got created or moved or had their ACL changed
       if (folderRecalcRequired(pms) && !calculateVisibleFolders(true)) {
         return pms;
@@ -316,11 +320,21 @@ public class SoapSession extends Session {
                   item, chg.why | MODIFIED_CONVERSATION_FLAGS, (MailItem) chg.preModifyObj);
             } else if (isVisible) {
               int why = chg.why;
-              // A folder the user mounted as a share carries its own (mountpoint) name/color/flags,
-              // so don't forward the owner's changes to those attributes. Folders only seen through
-              // delegated access (no mountpoint of their own) keep the owner's metadata.
-              if (item instanceof Folder && mMountedTargetFolderIds.contains(item.getId())) {
-                why &= ~RESTRICTED_MOUNTED_FOLDER_CHANGES;
+              // Don't filter changes the delegate itself made: the client UI relies on the
+              // notification to update its store, so toggling a folder must echo back to its
+              // own session.
+              if (!changesAreOurs && item instanceof Folder folder) {
+                if (mMountedTargetFolderIds.contains(folder.getId())) {
+                  // Directly mounted share: the mountpoint carries its own name/color/flags,
+                  // so don't forward the owner's changes to those attributes.
+                  why &= ~RESTRICTED_MOUNTED_FOLDER_CHANGES;
+                } else if ((why & Change.FLAGS) != 0
+                    && chg.preModifyObj instanceof Folder pre
+                    && (pre.getFlagBitmask() ^ folder.getFlagBitmask()) == Flag.BITMASK_CHECKED) {
+                  // Delegated access (no mountpoint of its own): both accounts often work in the
+                  // mailbox concurrently, so don't echo the owner's calendar-visibility toggle.
+                  why &= ~Change.FLAGS;
+                }
               }
               if (why != 0) {
                 filtered.recordModified(item, why, (MailItem) chg.preModifyObj);
@@ -963,6 +977,16 @@ public class SoapSession extends Session {
     if (pms == null || mbox == null || !pms.hasNotifications()) {
       return;
     }
+    // \Checked is folder state shared across delegates and the owner. When another user (e.g. a
+    // delegate working in our mailbox) toggles it, don't echo the toggle to us — concurrent
+    // users would otherwise keep stomping on each other's calendar-visibility selection.
+    if (source != null
+        && !mAuthenticatedAccountId.equalsIgnoreCase(source.getAuthenticatedAccountId())) {
+      pms = stripForeignCheckedToggles(pms);
+      if (!pms.hasNotifications()) {
+        return;
+      }
+    }
     if (source == this) {
       updateLastWrite(mbox);
     } else {
@@ -991,6 +1015,57 @@ public class SoapSession extends Session {
     }
 
     handleNotifications(pms, source == this);
+  }
+
+  /**
+   * Returns a copy of {@code pms} with the {@link Change#FLAGS} bit cleared on any modification
+   * that represents nothing but a {@code \Checked} toggle on a folder. Returns the input
+   * unchanged when nothing matches.
+   */
+  private PendingLocalModifications stripForeignCheckedToggles(PendingLocalModifications pms) {
+    if (pms.modified == null || pms.modified.isEmpty()) {
+      return pms;
+    }
+    boolean needsRewrite = false;
+    for (Change chg : pms.modified.values()) {
+      if (isCheckedOnlyToggle(chg)) {
+        needsRewrite = true;
+        break;
+      }
+    }
+    if (!needsRewrite) {
+      return pms;
+    }
+    PendingLocalModifications copy = new PendingLocalModifications();
+    copy.changedTypes = pms.changedTypes;
+    copy.addChangedParentFolderIds(pms.getChangedParentFolders());
+    if (pms.created != null && !pms.created.isEmpty()) {
+      for (BaseItemInfo item : pms.created.values()) {
+        copy.recordCreated(item);
+      }
+    }
+    if (pms.deleted != null && !pms.deleted.isEmpty()) {
+      copy.recordDeleted(pms.deleted);
+    }
+    for (Change chg : pms.modified.values()) {
+      int why = isCheckedOnlyToggle(chg) ? (chg.why & ~Change.FLAGS) : chg.why;
+      if (why == 0) {
+        continue;
+      }
+      if (chg.what instanceof MailItem mi) {
+        copy.recordModified(mi, why, (MailItem) chg.preModifyObj);
+      } else if (chg.what instanceof Mailbox mb) {
+        copy.recordModified(mb, why);
+      }
+    }
+    return copy;
+  }
+
+  private static boolean isCheckedOnlyToggle(Change chg) {
+    return (chg.why & Change.FLAGS) != 0
+        && chg.what instanceof Folder folder
+        && chg.preModifyObj instanceof Folder pre
+        && (pre.getFlagBitmask() ^ folder.getFlagBitmask()) == Flag.BITMASK_CHECKED;
   }
 
   boolean hasSerializableChanges(PendingLocalModifications pms) {

--- a/store/src/main/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/main/java/com/zimbra/cs/session/SoapSession.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -76,6 +77,13 @@ public class SoapSession extends Session {
   public class DelegateSession extends Session {
     private long mNextFolderCheck;
     private Set<Integer> mVisibleFolderIds;
+    /**
+     * IDs (in the target mailbox) of the folders this user has mounted as a share. A mountpoint
+     * carries its own name/color/flags, so the owner's changes to those attributes on these folders
+     * must not be forwarded; folders only seen through delegated access (no mountpoint of their own)
+     * keep the owner's metadata.
+     */
+    private Set<Integer> mMountedTargetFolderIds = Collections.emptySet();
     private boolean mParentHasFullAccess = false;
 
     DelegateSession(String authId, String targetId) {
@@ -187,6 +195,7 @@ public class SoapSession extends Session {
       cacheAccountAccess(mAuthenticatedAccountId, mTargetAccountId);
       if (mbox == null) {
         mVisibleFolderIds = Collections.emptySet();
+        mMountedTargetFolderIds = Collections.emptySet();
         return true;
       }
 
@@ -196,17 +205,44 @@ public class SoapSession extends Session {
           return mVisibleFolderIds != null;
         }
 
-        Set<Integer> visible =
+        mVisibleFolderIds =
             MailItem.toId(
                 mbox.getVisibleFolders(new OperationContext(getAuthenticatedAccountId())));
-        mVisibleFolderIds = visible;
         mNextFolderCheck =
             DebugConfig.visibileFolderRecalcInterval > 0
                 ? now + DebugConfig.visibileFolderRecalcInterval
                 : -1;
-        return visible != null;
       } finally {
         mbox.lock.release();
+      }
+      // Done outside the target mailbox lock: this reads the *parent* (delegating) mailbox.
+      mMountedTargetFolderIds = collectMountedTargetFolderIds();
+      return mVisibleFolderIds != null;
+    }
+
+    /**
+     * Returns the IDs (in the target mailbox) of the folders the delegating user has mounted from
+     * the target account.
+     */
+    private Set<Integer> collectMountedTargetFolderIds() {
+      Mailbox parentMbox = getParentSession().getMailboxOrNull();
+      if (parentMbox == null) {
+        return Collections.emptySet();
+      }
+      try {
+        Set<Integer> ids = new HashSet<>();
+        OperationContext octxt = new OperationContext(getAuthenticatedAccountId());
+        for (MailItem item : parentMbox.getItemList(octxt, MailItem.Type.MOUNTPOINT)) {
+          if (item instanceof Mountpoint mountpoint
+              && mTargetAccountId.equalsIgnoreCase(mountpoint.getOwnerId())) {
+            ids.add(mountpoint.getRemoteId());
+          }
+        }
+        return ids;
+      } catch (ServiceException e) {
+        ZimbraLog.session.warn(
+            "delegate session: unable to enumerate mountpoints into %s", mTargetAccountId, e);
+        return Collections.emptySet();
       }
     }
 
@@ -230,6 +266,8 @@ public class SoapSession extends Session {
     private static final int BASIC_CONVERSATION_FLAGS = Change.FLAGS | Change.TAGS | Change.UNREAD;
     private static final int MODIFIED_CONVERSATION_FLAGS =
         BASIC_CONVERSATION_FLAGS | Change.SIZE | Change.SENDERS;
+    private static final int RESTRICTED_MOUNTED_FOLDER_CHANGES =
+        Change.NAME | Change.COLOR | Change.FLAGS;
 
     private PendingLocalModifications filterNotifications(PendingLocalModifications pms)
         throws ServiceException {
@@ -278,13 +316,11 @@ public class SoapSession extends Session {
                   item, chg.why | MODIFIED_CONVERSATION_FLAGS, (MailItem) chg.preModifyObj);
             } else if (isVisible) {
               int why = chg.why;
-              // Filter out name/color/flags changes on shared folders to prevent notification spam
-              boolean isSharedFolder =
-                  item instanceof Folder folder
-                      && folder.isSharedWithUser(mAuthenticatedAccountId);
-              if (isSharedFolder) {
-                int restrictedChangesForSharedFolders = Change.NAME | Change.COLOR | Change.FLAGS;
-                why &= ~restrictedChangesForSharedFolders;
+              // A folder the user mounted as a share carries its own (mountpoint) name/color/flags,
+              // so don't forward the owner's changes to those attributes. Folders only seen through
+              // delegated access (no mountpoint of their own) keep the owner's metadata.
+              if (item instanceof Folder && mMountedTargetFolderIds.contains(item.getId())) {
+                why &= ~RESTRICTED_MOUNTED_FOLDER_CHANGES;
               }
               if (why != 0) {
                 filtered.recordModified(item, why, (MailItem) chg.preModifyObj);

--- a/store/src/main/java/com/zimbra/cs/session/SoapSession.java
+++ b/store/src/main/java/com/zimbra/cs/session/SoapSession.java
@@ -1018,6 +1018,21 @@ public class SoapSession extends Session {
   }
 
   /**
+   * Queues a synthetic {@link Change#FLAGS} notification for the given folder onto this
+   * session's outbound queue, bypassing the mailbox-level broadcast.
+   *
+   * <p>Used to refresh the caller's UI cache after a folder-flag toggle that the server treated
+   * as a no-op (e.g. when the caller's cached state had drifted from the server's). Since the
+   * notification is queued directly here, it only reaches this session — not other listeners
+   * on the mailbox.
+   */
+  public void queueFolderFlagsRefresh(Folder folder) {
+    PendingLocalModifications pms = new PendingLocalModifications();
+    pms.recordModified(folder, Change.FLAGS);
+    handleNotifications(pms, true);
+  }
+
+  /**
    * Returns a copy of {@code pms} with the {@link Change#FLAGS} bit cleared on any modification
    * that represents nothing but a {@code \Checked} toggle on a folder. Returns the input
    * unchanged when nothing matches.

--- a/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
@@ -337,6 +337,65 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
   }
 
   /**
+   * Suppression lets the two sides' UI caches drift, so a "toggle" from one side that happens to
+   * match the server state becomes a no-op and the cache never re-syncs. To break the deadlock,
+   * the no-op still queues a session-private FLAGS notification to the caller so their UI can
+   * refresh to the current server value.
+   */
+  @Test
+  void noopCheckedToggleByDelegateStillRefreshesDelegateUi() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+    // Owner pre-checks the subfolder so the grantee's later "check" is a no-op on the server.
+    // The grantee's session never saw the owner's toggle (suppressed by the filter), so its UI
+    // cache is stale.
+    var ownerCheckAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(ownerCheckAction));
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    SoapResponse actionResponse =
+        getSoapClient()
+            .newRequest()
+            .setCaller(granteeAccount)
+            .setRequestedAccount(ownerAccount)
+            .setSessionId(setup.sessionId)
+            .setSoapBody(new FolderActionRequest(checkAction))
+            .execute();
+
+    Assertions.assertTrue(
+        actionResponse.body().contains("<notify"),
+        "No-op \\Checked toggle by delegate must still refresh their UI via a session-private "
+            + "FLAGS notification");
+  }
+
+  /**
+   * The session-private refresh used by {@link #noopCheckedToggleByDelegateStillRefreshesDelegateUi}
+   * must NOT escape to the owner — only the caller's session should get the synthetic notification.
+   */
+  @Test
+  void noopCheckedToggleByDelegateIsNotBroadcastToOwner() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+    var ownerCheckAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(ownerCheckAction));
+    String ownerSessionId = createSessionForOwner();
+    acknowledgeOwnerRefresh(ownerSessionId);
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    getSoapClient()
+        .newRequest()
+        .setCaller(granteeAccount)
+        .setRequestedAccount(ownerAccount)
+        .setSessionId(setup.sessionId)
+        .setSoapBody(new FolderActionRequest(checkAction))
+        .execute();
+
+    SoapResponse ownerResponse = checkForOwnerNotifications(ownerSessionId);
+
+    Assertions.assertFalse(
+        ownerResponse.body().contains("<notify"),
+        "Delegate's no-op refresh must be session-private, not broadcast to the owner");
+  }
+
+  /**
    * Sanity guard for the symmetric filter: the owner's own \Checked toggle must still reach the
    * owner's session — otherwise the owner's UI would stop updating on local actions.
    */

--- a/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
@@ -202,6 +202,43 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
   }
 
   /**
+   * Tests that name changes on a sub-folder of a shared folder are still delivered to the grantee.
+   *
+   * <p>The sub-folder is reached through an inherited grant (it has no grant of its own), which is
+   * also what happens when a whole mailbox is shared for delegated access; such changes must not be
+   * filtered out.
+   */
+  @Test
+  void nameChangeOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+    var ownerMailbox = mailboxManager.getMailboxByAccount(ownerAccount);
+    var sharedParent =
+        ownerMailbox.createFolder(
+            null, "SharedParent", new Folder.FolderOptions().setDefaultView(Type.MESSAGE));
+    var subFolder =
+        ownerMailbox.createFolder(
+            null,
+            "SubFolder",
+            sharedParent.getId(),
+            new Folder.FolderOptions().setDefaultView(Type.MESSAGE));
+
+    shareFolder(ownerAccount, granteeAccount, sharedParent.getId());
+    createMountpoint(granteeAccount, sharedParent, "Shared Parent", Type.MESSAGE.toString());
+
+    String sessionId = createSessionForGrantee();
+    acknowledgeRefresh(sessionId);
+
+    var renameAction = new FolderActionSelector(String.valueOf(subFolder.getId()), "rename");
+    renameAction.setName("Renamed SubFolder");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(renameAction));
+
+    SoapResponse response = checkForNotifications(sessionId);
+
+    Assertions.assertTrue(
+        response.body().contains("<notify"),
+        "Name changes on a sub-folder of a shared folder must still be delivered to the grantee");
+  }
+
+  /**
    * Tests that name changes on a calendar folder shared with a distribution list (group) are
    * filtered out from notifications for a member of that group.
    */

--- a/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
@@ -277,6 +277,38 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
         "Flag toggles on a sub-folder of a shared folder must still be delivered to the grantee");
   }
 
+  /**
+   * The grantee mounts shared folders from two different accounts. A rename on the owner's folder
+   * must still be filtered for the owner's delegate session, even though the grantee has another
+   * mountpoint pointing at an unrelated account: the mountpoint-enumeration step must scope the set
+   * of mounted folders to the delegate session's target account.
+   */
+  @Test
+  void mountpointToUnrelatedAccountDoesNotInterfereWithSuppression() throws Exception {
+    Account otherAccount = createAccount().create();
+    var otherCalendar = getFirstCalendar(otherAccount);
+    shareFolder(otherAccount, granteeAccount, otherCalendar.getId());
+    createMountpoint(granteeAccount, otherCalendar, "other shared calendar", "appointment");
+
+    var ownerCalendar = getFirstCalendar(ownerAccount);
+    shareFolder(ownerAccount, granteeAccount, ownerCalendar.getId());
+    createMountpoint(granteeAccount, ownerCalendar, "owner shared calendar", "appointment");
+
+    String sessionId = createSessionForGrantee();
+    acknowledgeRefresh(sessionId);
+
+    var renameAction = new FolderActionSelector(ownerCalendar.getFolderIdAsString(), "rename");
+    renameAction.setName("Renamed Owner Calendar");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(renameAction));
+
+    SoapResponse response = checkForNotifications(sessionId);
+
+    Assertions.assertFalse(
+        response.body().contains("<notify"),
+        "A mountpoint to another account must not leak into the suppression set for the owner's "
+            + "delegate session");
+  }
+
   private record SubfolderSetup(int subFolderId, String sessionId) {}
 
   private SubfolderSetup setupSubfolderUnderSharedFolder() throws Exception {

--- a/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
@@ -202,6 +202,29 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
   }
 
   /**
+   * Tests that the \Checked flag toggle on a shared calendar folder is filtered out (the grantee
+   * only sees the mountpoint, which has its own flags).
+   */
+  @Test
+  void flagToggleOnSharedCalendarFolderIsFilteredOut() throws Exception {
+    var userACalendar = getFirstCalendar(ownerAccount);
+    shareFolder(ownerAccount, granteeAccount, userACalendar.getId());
+    createMountpoint(granteeAccount, userACalendar, "test shared calendar", "appointment");
+
+    String sessionId = createSessionForGrantee();
+    acknowledgeRefresh(sessionId);
+
+    var checkAction = new FolderActionSelector(userACalendar.getFolderIdAsString(), "check");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(checkAction));
+
+    final SoapResponse response = checkForNotifications(sessionId);
+
+    Assertions.assertFalse(
+        response.body().contains("<notify"),
+        "Flag toggles on shared calendar folders should be filtered out from notifications");
+  }
+
+  /**
    * Tests that name changes on a sub-folder of a shared folder are still delivered to the grantee.
    *
    * <p>The sub-folder is reached through an inherited grant (it has no grant of its own), which is
@@ -210,14 +233,63 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
    */
   @Test
   void nameChangeOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+
+    var renameAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "rename");
+    renameAction.setName("Renamed SubFolder");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(renameAction));
+
+    SoapResponse response = checkForNotifications(setup.sessionId);
+
+    Assertions.assertTrue(
+        response.body().contains("<notify"),
+        "Name changes on a sub-folder of a shared folder must still be delivered to the grantee");
+  }
+
+  /** Color changes on a sub-folder of a shared folder must still reach the grantee. */
+  @Test
+  void colorChangeOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+
+    var colorAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "color");
+    colorAction.setColor((byte) 4);
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(colorAction));
+
+    SoapResponse response = checkForNotifications(setup.sessionId);
+
+    Assertions.assertTrue(
+        response.body().contains("<notify"),
+        "Color changes on a sub-folder of a shared folder must still be delivered to the grantee");
+  }
+
+  /** Flag toggles on a sub-folder of a shared folder must still reach the grantee. */
+  @Test
+  void flagToggleOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(checkAction));
+
+    SoapResponse response = checkForNotifications(setup.sessionId);
+
+    Assertions.assertTrue(
+        response.body().contains("<notify"),
+        "Flag toggles on a sub-folder of a shared folder must still be delivered to the grantee");
+  }
+
+  private record SubfolderSetup(int subFolderId, String sessionId) {}
+
+  private SubfolderSetup setupSubfolderUnderSharedFolder() throws Exception {
     var ownerMailbox = mailboxManager.getMailboxByAccount(ownerAccount);
     var sharedParent =
         ownerMailbox.createFolder(
-            null, "SharedParent", new Folder.FolderOptions().setDefaultView(Type.MESSAGE));
+            null,
+            "SharedParent-" + UUID.randomUUID(),
+            new Folder.FolderOptions().setDefaultView(Type.MESSAGE));
     var subFolder =
         ownerMailbox.createFolder(
             null,
-            "SubFolder",
+            "SubFolder-" + UUID.randomUUID(),
             sharedParent.getId(),
             new Folder.FolderOptions().setDefaultView(Type.MESSAGE));
 
@@ -226,16 +298,7 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
 
     String sessionId = createSessionForGrantee();
     acknowledgeRefresh(sessionId);
-
-    var renameAction = new FolderActionSelector(String.valueOf(subFolder.getId()), "rename");
-    renameAction.setName("Renamed SubFolder");
-    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(renameAction));
-
-    SoapResponse response = checkForNotifications(sessionId);
-
-    Assertions.assertTrue(
-        response.body().contains("<notify"),
-        "Name changes on a sub-folder of a shared folder must still be delivered to the grantee");
+    return new SubfolderSetup(subFolder.getId(), sessionId);
   }
 
   /**

--- a/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/mail/SharedFolderNotificationFilteringTest.java
@@ -262,9 +262,13 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
         "Color changes on a sub-folder of a shared folder must still be delivered to the grantee");
   }
 
-  /** Flag toggles on a sub-folder of a shared folder must still reach the grantee. */
+  /**
+   * The \Checked toggle on a delegated folder (no mountpoint of its own) must NOT reach the
+   * grantee: both accounts often work the mailbox concurrently and echoing the owner's
+   * calendar-visibility toggle stomps on the delegate's UI.
+   */
   @Test
-  void flagToggleOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+  void checkedToggleOnSubfolderOfSharedFolderIsFilteredOut() throws Exception {
     SubfolderSetup setup = setupSubfolderUnderSharedFolder();
 
     var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
@@ -272,9 +276,106 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
 
     SoapResponse response = checkForNotifications(setup.sessionId);
 
+    Assertions.assertFalse(
+        response.body().contains("<notify"),
+        "\\Checked toggles on delegated folders must be suppressed for the grantee");
+  }
+
+  /**
+   * When the delegate themselves toggles \Checked on a delegated folder, the change must echo
+   * back to their own session — the client UI updates its store off the notification.
+   */
+  @Test
+  void checkedToggleByDelegateOnSubfolderIsDeliveredToDelegate() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    SoapResponse actionResponse =
+        getSoapClient()
+            .newRequest()
+            .setCaller(granteeAccount)
+            .setRequestedAccount(ownerAccount)
+            .setSessionId(setup.sessionId)
+            .setSoapBody(new FolderActionRequest(checkAction))
+            .execute();
+
+    // The delegate's UI relies on the notification to update its store. It is piggybacked on
+    // the same SOAP response as the action itself, so the change must appear in the action's
+    // <notify> block.
+    Assertions.assertTrue(
+        actionResponse.body().contains("<notify"),
+        "Delegate's own \\Checked toggle must echo back to their session "
+            + "— the UI relies on the notification to update its store");
+  }
+
+  /**
+   * Symmetric to {@link #checkedToggleOnSubfolderOfSharedFolderIsFilteredOut} — when the
+   * delegate toggles \Checked on the owner's folder, the owner must NOT see the toggle echoed
+   * into their own session. The bit is shared mailbox state and concurrent users would
+   * otherwise keep stomping on each other's calendar-visibility selection.
+   */
+  @Test
+  void checkedToggleByDelegateIsNotEchoedToOwner() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+    String ownerSessionId = createSessionForOwner();
+    acknowledgeOwnerRefresh(ownerSessionId);
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    getSoapClient()
+        .newRequest()
+        .setCaller(granteeAccount)
+        .setRequestedAccount(ownerAccount)
+        .setSessionId(setup.sessionId)
+        .setSoapBody(new FolderActionRequest(checkAction))
+        .execute();
+
+    SoapResponse ownerResponse = checkForOwnerNotifications(ownerSessionId);
+
+    Assertions.assertFalse(
+        ownerResponse.body().contains("<notify"),
+        "Delegate's \\Checked toggle on the owner's folder must NOT be echoed back to the owner");
+  }
+
+  /**
+   * Sanity guard for the symmetric filter: the owner's own \Checked toggle must still reach the
+   * owner's session — otherwise the owner's UI would stop updating on local actions.
+   */
+  @Test
+  void checkedToggleByOwnerIsDeliveredToOwner() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+    String ownerSessionId = createSessionForOwner();
+    acknowledgeOwnerRefresh(ownerSessionId);
+
+    var checkAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "check");
+    SoapResponse actionResponse =
+        getSoapClient()
+            .newRequest()
+            .setCaller(ownerAccount)
+            .setSessionId(ownerSessionId)
+            .setSoapBody(new FolderActionRequest(checkAction))
+            .execute();
+
+    Assertions.assertTrue(
+        actionResponse.body().contains("<notify"),
+        "Owner's own \\Checked toggle must echo back to their session");
+  }
+
+  /**
+   * Flag changes other than \Checked on a delegated folder must still reach the grantee — the
+   * suppression is scoped to the calendar-visibility bit.
+   */
+  @Test
+  void nonCheckedFlagChangeOnSubfolderOfSharedFolderIsDeliveredToGrantee() throws Exception {
+    SubfolderSetup setup = setupSubfolderUnderSharedFolder();
+
+    var syncAction = new FolderActionSelector(String.valueOf(setup.subFolderId), "syncon");
+    getSoapClient().executeSoap(ownerAccount, new FolderActionRequest(syncAction));
+
+    SoapResponse response = checkForNotifications(setup.sessionId);
+
     Assertions.assertTrue(
         response.body().contains("<notify"),
-        "Flag toggles on a sub-folder of a shared folder must still be delivered to the grantee");
+        "Non-\\Checked flag changes on delegated folders must still be delivered to the grantee");
   }
 
   /**
@@ -412,6 +513,37 @@ class SharedFolderNotificationFilteringTest extends SoapTestSuite {
         .newSessionRequest(sessionId)
         .setCaller(granteeAccount)
         .setSoapBody(noOpReq)
+        .execute();
+  }
+
+  private String createSessionForOwner() throws Exception {
+    Element getFolderReq = new Element.XMLElement(MailConstants.GET_FOLDER_REQUEST);
+    final SoapResponse response =
+        getSoapClient()
+            .newSessionRequest()
+            .setCaller(ownerAccount)
+            .setSoapBody(getFolderReq)
+            .execute();
+    String sessionId = SoapUtils.getSessionId(response);
+    Assertions.assertNotNull(sessionId, "Owner session ID should be present");
+    return sessionId;
+  }
+
+  private void acknowledgeOwnerRefresh(String sessionId) throws Exception {
+    Element noOpReq = new Element.XMLElement(MailConstants.NO_OP_REQUEST);
+    getSoapClient()
+        .newSessionRequest(sessionId)
+        .setCaller(ownerAccount)
+        .setSoapBody(noOpReq)
+        .execute();
+  }
+
+  private SoapResponse checkForOwnerNotifications(String sessionId) throws Exception {
+    Element getFolderReq = new Element.XMLElement(MailConstants.GET_FOLDER_REQUEST);
+    return getSoapClient()
+        .newSessionRequest(sessionId)
+        .setCaller(ownerAccount)
+        .setSoapBody(getFolderReq)
         .execute();
   }
 


### PR DESCRIPTION
## What Changed

Tightened the delegate-session notification filter so folder changes only reach the sessions that should see them:

- Mountpoint attribute changes on a directly-mounted folder stay with the owner (existing fix).
- `\Checked` toggles are per-session UI state and never cross between owner and delegate, in either direction.
- All other folder changes (rename, color, non-`\Checked` flags, subscribe, etc.) continue to flow normally.
- No-op `\Checked` toggles (delegate's local state already matches server) now emit a session-private `FLAGS` refresh to the caller so their UI un-sticks, without broadcasting to other sessions.

## Behaviour

| Scenario | Action | Owner session | Delegate session |
|---|---|---|---|
| Delegate mounted folder `F` directly | rename / color on `F` | delivered | suppressed |
| Delegate mounted folder `F` directly | rename / color on a sub-folder of `F` | delivered | delivered |
| Delegate has delegated access (mounted parent / whole mailbox) | rename / color on any folder | delivered | delivered |
| Owner toggles `\Checked` on a shared folder | — | delivered | suppressed |
| Delegate toggles `\Checked` on owner's folder | — | suppressed | delivered |
| Delegate re-toggles `\Checked` to current server state (no-op) | — | not notified | session-private `FLAGS` refresh |
| Owner toggles `\Checked` on own (non-shared) folder | — | delivered | n/a |
| Delegate changes non-`\Checked` flags on a shared folder | — | delivered | delivered |
| Recipient has mountpoints into two accounts | actions in either account | — | scoped to that account's mountpoints |

## Notes

The remaining reported missing coverage is primarily around null-check paths and similar branches that require extensive mocking, so it was intentionally deferred.