### PR TITLE
feat(IN-951): set arch=any for noarch packages

### DIFF
--- a/packages/appserver-conf/PKGBUILD
+++ b/packages/appserver-conf/PKGBUILD
@@ -2,7 +2,7 @@ pkgname="carbonio-appserver-conf"
 pkgver="4.26.0"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Service Configuration"
-arch=('x86_64')
+arch=('any')
 maintainer="Zextras <packages@zextras.com>"
 copyright=(
   "2022-2024, Zextras <https://www.zextras.com>"

--- a/packages/appserver-db/PKGBUILD
+++ b/packages/appserver-db/PKGBUILD
@@ -2,7 +2,7 @@ pkgname="carbonio-appserver-db"
 pkgver="4.26.0"
 pkgrel="1"
 pkgdesc="Carbonio Appserver DB Files"
-arch=('x86_64')
+arch=('any')
 maintainer="Zextras <packages@zextras.com>"
 copyright=(
   "2022-2024, Zextras <https://www.zextras.com>"

--- a/packages/appserver-service/PKGBUILD
+++ b/packages/appserver-service/PKGBUILD
@@ -2,7 +2,7 @@ pkgname="carbonio-appserver-service"
 pkgver="4.26.0"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Service"
-arch=('x86_64')
+arch=('any')
 maintainer="Zextras <packages@zextras.com>"
 copyright=(
   "2022-2024, Zextras <https://www.zextras.com>"

--- a/packages/common-appserver-conf/PKGBUILD
+++ b/packages/common-appserver-conf/PKGBUILD
@@ -2,7 +2,7 @@ pkgname="carbonio-common-appserver-conf"
 pkgver="4.26.0"
 pkgrel="1"
 pkgdesc="Carbonio Core Mailbox Configuration"
-arch=('x86_64')
+arch=('any')
 maintainer="Zextras <packages@zextras.com>"
 copyright=(
   "2022-2024, Zextras <https://www.zextras.com>"

--- a/packages/mailbox-jar/PKGBUILD
+++ b/packages/mailbox-jar/PKGBUILD
@@ -2,7 +2,7 @@ pkgname="carbonio-mailbox-jar"
 pkgver="4.26.0"
 pkgrel="1"
 pkgdesc="Carbonio Mailbox Jars"
-arch=('x86_64')
+arch=('any')
 maintainer="Zextras <packages@zextras.com>"
 copyright=(
   "2022-2024, Zextras <https://www.zextras.com>"


### PR DESCRIPTION
## Summary

- All five mailbox packages contain no architecture-specific compiled artifacts (JVM JARs, scripts, SQL, XML/config files)
- Mark as `arch=('any')` so yap produces `_all.deb` / `.noarch.rpm`
- Enables aarch64 support without per-arch rebuilds

Part of IN-951 aarch64 cross-compilation support.