### PR TITLE
chore: upgrade maven exec plugin

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -193,7 +193,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>generate-ZAttrAccount</id>

--- a/pom.xml
+++ b/pom.xml
@@ -941,6 +941,11 @@
           <version>3.11.0</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-antrun-plugin</artifactId>
           <groupId>org.apache.maven.plugins</groupId>
           <version>3.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -943,7 +943,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>

--- a/right-manager/pom.xml
+++ b/right-manager/pom.xml
@@ -55,7 +55,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>generate-rights-constants</id>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -640,7 +640,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>generate-rights-message-properties</id>


### PR DESCRIPTION
- 3.1.0 has a bugs about stream handling.

See: https://github.com/mojohaus/exec-maven-plugin/releases/tag/3.5.0 for stream issues

Upgraded to 3.6.3