### PR TITLE
ci: remove -Pdev

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ library(
         ])
 )
 
-String profile = env.TAG_NAME ? '-Pprod' : (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
+String profile = env.TAG_NAME ? '-Pprod' : ''
 
 defaultPipeline {
 


### PR DESCRIPTION
dev profile does not exist on mailbox, it is the default (empty)

See log line: [WARNING] The requested profile "dev" could not be activated because it does not exist.