### PR TITLE
fix: ci-friendly vars are not expanded correctly in final flatten pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1095,7 +1095,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.1.0</version>
+          <version>1.6.0</version>
           <configuration>
             <updatePomFile>true</updatePomFile>
             <flattenMode>resolveCiFriendliesOnly</flattenMode>


### PR DESCRIPTION
## Problem

While using the latest mailbox artifacts in the `carbonio-proxy` project, dependency resolution fails with:

Could not resolve com.zextras:zm-mailbox:pom:${revision}${changelist}

Maven attempts to resolve the literal placeholder `${revision}${changelist}` instead of an expanded version string.

## Root Cause

The upstream published POMs are malformed/unflattened.

`flatten-maven-plugin` was pinned to version `1.1.0` (released around 2018). That version contains a known issue where CI-friendly placeholders such as:

`${revision}${changelist}`

inside the `<version>` element are not fully resolved during POM flattening.

As a result, deployed artifacts contain unresolved placeholders in their published POM metadata, causing downstream dependency resolution failures.

## Impact

Downstream projects such as `carbonio-proxy` cannot resolve mailbox dependencies when using newer mailbox artifacts (e.g. `mailbox.version=4.27.1`).

## Fix

Upgrade `flatten-maven-plugin` to a newer version that correctly resolves CI-friendly version placeholders before publishing artifacts.

This ensures deployed POMs contain concrete version values instead of unresolved placeholders.