### PR TITLE
fix: replace commons-lang with commons-lang3

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,8 +26,8 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>

--- a/client/src/main/java/com/zimbra/client/ZMailbox.java
+++ b/client/src/main/java/com/zimbra/client/ZMailbox.java
@@ -207,7 +207,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -136,8 +136,8 @@
     </dependency>
 
     <dependency>
-      <artifactId>commons-lang</artifactId>
-      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <groupId>org.apache.commons</groupId>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>

--- a/common/src/main/java/com/zimbra/common/util/QuotedTextUtil.java
+++ b/common/src/main/java/com/zimbra/common/util/QuotedTextUtil.java
@@ -24,7 +24,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cyberneko.html.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;

--- a/common/src/test/java/com/zimbra/common/zmime/ZMimeBodyPartTest.java
+++ b/common/src/test/java/com/zimbra/common/zmime/ZMimeBodyPartTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/jython-libs/pom.xml
+++ b/jython-libs/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.graylog2</groupId>
       <artifactId>syslog4j</artifactId>
-      <version>0.9.60</version>
+      <version>0.9.63</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.12.0</version>
+        <version>1.15.0</version>
       </dependency>
       <dependency>
         <groupId>com.kohlschutter.junixsocket</groupId>
@@ -376,9 +376,9 @@
         <version>1.4.5</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.20.0</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -502,7 +502,7 @@
       <dependency>
         <groupId>com.zextras</groupId>
         <artifactId>mailbox-attribute-manager</artifactId>
-        <version>4.31.0</version>
+        <version>4.32.0</version>
       </dependency>
       <dependency>
         <groupId>com.zextras</groupId>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -331,8 +331,8 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-pool</groupId>

--- a/store/src/main/java/com/zimbra/cert/GenerateCSR.java
+++ b/store/src/main/java/com/zimbra/cert/GenerateCSR.java
@@ -114,8 +114,7 @@ public class GenerateCSR extends AdminDocumentHandler {
         return response;
     }
 
-    public static StringBuilder appendSubjectArgToCommand(StringBuilder cmd, String subject)
-    throws ServiceException {
+    public static StringBuilder appendSubjectArgToCommand(StringBuilder cmd, String subject) {
         if (Strings.isNullOrEmpty(subject)) {
             return cmd;
         }
@@ -123,7 +122,7 @@ public class GenerateCSR extends AdminDocumentHandler {
         return cmd;
     }
 
-    private static void appendToSubject(StringBuilder subject, String attrName, String attrValue) {
+    private static void appendToSubject(StringBuilder subject, String attrName, String attrValue) throws ServiceException {
         if (!Strings.isNullOrEmpty(attrValue)) {
 
             validateSubjectValue(attrValue);
@@ -135,9 +134,13 @@ public class GenerateCSR extends AdminDocumentHandler {
         }
     }
 
-    private static void validateSubjectValue(String value) {
+    private static void validateSubjectValue(String value)
+            throws ServiceException {
+
         if (value.contains("\n") || value.contains("\r")) {
-            throw new IllegalArgumentException("Invalid subject value");
+            throw ServiceException.INVALID_REQUEST(
+                    "Subject value must not contain CR/LF characters",
+                    null);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cert/GenerateCSR.java
+++ b/store/src/main/java/com/zimbra/cert/GenerateCSR.java
@@ -24,10 +24,11 @@ import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.GenCSRRequest;
 import com.zimbra.soap.base.CertSubjectAttrs;
+import org.apache.commons.text.StringEscapeUtils;
+
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringEscapeUtils;
 
 public class GenerateCSR extends AdminDocumentHandler {
 
@@ -87,7 +88,7 @@ public class GenerateCSR extends AdminDocumentHandler {
 
             String subjectAltNames = getSubjectAltNames(req.getSubjectAltNames()) ;
             if (!Strings.isNullOrEmpty(subjectAltNames)) {
-                cmd.append(" -subjectAltNames '").append(StringEscapeUtils.escapeJavaScript(subjectAltNames))
+                cmd.append(" -subjectAltNames '").append(StringEscapeUtils.escapeEcmaScript(subjectAltNames))
                         .append("'");
             }
             RemoteManager rmgr = RemoteManager.getRemoteManager(server);
@@ -124,7 +125,7 @@ public class GenerateCSR extends AdminDocumentHandler {
 
     private static void appendToSubject(StringBuilder subject, String attrName, String attrValue) {
         if (!Strings.isNullOrEmpty(attrValue)) {
-            subject.append("/").append(attrName).append("=").append(StringEscapeUtils.escapeJavaScript(attrValue));
+            subject.append("/").append(attrName).append("=").append(org.apache.commons.text.StringEscapeUtils.escapeEcmaScript(attrValue));
         }
     }
 

--- a/store/src/main/java/com/zimbra/cert/GenerateCSR.java
+++ b/store/src/main/java/com/zimbra/cert/GenerateCSR.java
@@ -125,7 +125,7 @@ public class GenerateCSR extends AdminDocumentHandler {
 
     private static void appendToSubject(StringBuilder subject, String attrName, String attrValue) {
         if (!Strings.isNullOrEmpty(attrValue)) {
-            subject.append("/").append(attrName).append("=").append(org.apache.commons.text.StringEscapeUtils.escapeEcmaScript(attrValue));
+            subject.append("/").append(attrName).append("=").append(StringEscapeUtils.escapeEcmaScript(attrValue));
         }
     }
 

--- a/store/src/main/java/com/zimbra/cert/GenerateCSR.java
+++ b/store/src/main/java/com/zimbra/cert/GenerateCSR.java
@@ -125,9 +125,26 @@ public class GenerateCSR extends AdminDocumentHandler {
 
     private static void appendToSubject(StringBuilder subject, String attrName, String attrValue) {
         if (!Strings.isNullOrEmpty(attrValue)) {
-            subject.append("/").append(attrName).append("=").append(StringEscapeUtils.escapeEcmaScript(attrValue));
+
+            validateSubjectValue(attrValue);
+
+            subject.append("/")
+                    .append(attrName)
+                    .append("=")
+                    .append(escapeShellSingleQuotedArg(attrValue));
         }
     }
+
+    private static void validateSubjectValue(String value) {
+        if (value.contains("\n") || value.contains("\r")) {
+            throw new IllegalArgumentException("Invalid subject value");
+        }
+    }
+
+    private static String escapeShellSingleQuotedArg(String value) {
+        return value.replace("'", "'\"'\"'");
+    }
+
 
     public static String getSubject(CertSubjectAttrs req)
     throws ServiceException {

--- a/store/src/main/java/com/zimbra/cert/VerifyCertKey.java
+++ b/store/src/main/java/com/zimbra/cert/VerifyCertKey.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Admin Handler class to verify provided private key and certificate using zmcertmgr verifycrt. It

--- a/store/src/main/java/com/zimbra/cs/account/cache/AccountCache.java
+++ b/store/src/main/java/com/zimbra/cs/account/cache/AccountCache.java
@@ -13,7 +13,7 @@ package com.zimbra.cs.account.cache;
 
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.util.MapUtil;
 import com.zimbra.common.stats.Counter;

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
@@ -12,7 +12,7 @@ import java.util.Date;
 
 import javax.security.auth.login.LoginException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -200,7 +200,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * LDAP implementation of {@link Provisioning}.

--- a/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralResult.java
+++ b/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralResult.java
@@ -6,7 +6,7 @@ package com.zimbra.cs.ephemeral;
 
 import java.util.List;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;

--- a/store/src/main/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/main/java/com/zimbra/cs/filter/FilterUtil.java
@@ -29,8 +29,8 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jsieve.exception.SyntaxException;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/store/src/main/java/com/zimbra/cs/filter/FilterUtil.java
+++ b/store/src/main/java/com/zimbra/cs/filter/FilterUtil.java
@@ -29,7 +29,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jsieve.exception.SyntaxException;
 

--- a/store/src/main/java/com/zimbra/cs/filter/SoapToSieve.java
+++ b/store/src/main/java/com/zimbra/cs/filter/SoapToSieve.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;

--- a/store/src/main/java/com/zimbra/cs/filter/ZimbraAsciiNumeric.java
+++ b/store/src/main/java/com/zimbra/cs/filter/ZimbraAsciiNumeric.java
@@ -8,7 +8,7 @@ package com.zimbra.cs.filter;
 import java.math.BigInteger;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jsieve.comparators.AsciiNumeric;
 import org.apache.jsieve.exception.FeatureException;
 

--- a/store/src/main/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/main/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -26,7 +26,7 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.Action;

--- a/store/src/main/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
+++ b/store/src/main/java/com/zimbra/cs/filter/ZimbraMailAdapter.java
@@ -26,7 +26,7 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.Action;

--- a/store/src/main/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
+++ b/store/src/main/java/com/zimbra/cs/filter/jsieve/NotifyMailto.java
@@ -6,7 +6,7 @@
 package com.zimbra.cs.filter.jsieve;
 
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jsieve.Argument;
 import org.apache.jsieve.Arguments;
 import org.apache.jsieve.Block;

--- a/store/src/main/java/com/zimbra/cs/gal/GalSearchControl.java
+++ b/store/src/main/java/com/zimbra/cs/gal/GalSearchControl.java
@@ -57,8 +57,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpException;
 
 public class GalSearchControl {

--- a/store/src/main/java/com/zimbra/cs/gal/GalSearchParams.java
+++ b/store/src/main/java/com/zimbra/cs/gal/GalSearchParams.java
@@ -7,7 +7,7 @@ package com.zimbra.cs.gal;
 
 import java.util.EnumSet;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.QName;
 
 import com.zimbra.common.service.ServiceException;

--- a/store/src/main/java/com/zimbra/cs/gal/GalSyncToken.java
+++ b/store/src/main/java/com/zimbra/cs/gal/GalSyncToken.java
@@ -10,8 +10,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.TimeZone;
 
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;

--- a/store/src/main/java/com/zimbra/cs/html/DefangFilter.java
+++ b/store/src/main/java/com/zimbra/cs/html/DefangFilter.java
@@ -11,18 +11,7 @@ import com.zimbra.common.localconfig.DebugConfig;
 import com.zimbra.common.util.StringUtil;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.servlet.ZThreadLocal;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.xerces.xni.Augmentations;
 import org.apache.xerces.xni.NamespaceContext;
 import org.apache.xerces.xni.QName;
@@ -34,6 +23,18 @@ import org.apache.xerces.xni.XNIException;
 import org.cyberneko.html.filters.DefaultFilter;
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * very Mutated version of ElementRemover.java filter from cyberneko html. change accepted/removed
@@ -814,7 +815,7 @@ public class DefangFilter extends DefaultFilter {
       }
     }
     String temp = sb.toString();
-    temp = StringEscapeUtils.unescapeHtml(temp);
+    temp = StringEscapeUtils.unescapeHtml4(temp);
     if (index != -1
         && (temp.toLowerCase().contains("javascript") || temp.toLowerCase().contains("vbscript"))) {
       sanitizedStr = temp + result.substring(index);

--- a/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/FileUploadServlet.java
@@ -46,6 +46,26 @@ import com.zimbra.cs.servlet.util.CsrfUtil;
 import com.zimbra.cs.store.BlobInputStream;
 import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.cs.util.Zimbra;
+import org.apache.commons.fileupload.DefaultFileItem;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadBase;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import javax.mail.util.SharedByteArrayInputStream;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -66,25 +86,6 @@ import java.util.Map;
 import java.util.TimerTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.mail.util.SharedByteArrayInputStream;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.fileupload.DefaultFileItem;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItem;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpException;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
 
 public class FileUploadServlet extends ZimbraServlet {
 
@@ -851,7 +852,7 @@ public class FileUploadServlet extends ZimbraServlet {
     }
 
     // Unescape the filename so it actually displays correctly
-    filename = StringEscapeUtils.unescapeHtml(filename);
+    filename = StringEscapeUtils.unescapeHtml4(filename);
 
     // store the fetched file as a normal upload
     ServletFileUpload upload = getUploader(account, limitByFileUploadMaxSize);

--- a/store/src/main/java/com/zimbra/cs/service/account/Auth.java
+++ b/store/src/main/java/com/zimbra/cs/service/account/Auth.java
@@ -54,7 +54,7 @@ import java.util.Set;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author schemers

--- a/store/src/main/java/com/zimbra/cs/service/admin/Auth.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/Auth.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class Auth extends AdminDocumentHandler {
 

--- a/store/src/main/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/ChangePrimaryEmail.java
@@ -27,7 +27,7 @@ import com.zimbra.soap.type.AccountSelector;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class ChangePrimaryEmail extends AdminDocumentHandler {
 

--- a/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/CreateDistributionList.java
@@ -18,7 +18,7 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.message.CreateDistributionListRequest;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class CreateDistributionList extends AdminDocumentHandler {
 

--- a/store/src/main/java/com/zimbra/cs/service/admin/VerifyStoreManager.java
+++ b/store/src/main/java/com/zimbra/cs/service/admin/VerifyStoreManager.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.google.common.base.MoreObjects;
 import com.zimbra.common.service.ServiceException;

--- a/store/src/main/java/com/zimbra/cs/service/formatter/LdifFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/LdifFormatter.java
@@ -20,7 +20,7 @@ import javax.mail.Part;
 import javax.servlet.ServletException;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.mime.MimeConstants;

--- a/store/src/main/java/com/zimbra/cs/service/formatter/NetscapeLdifFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/NetscapeLdifFormatter.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.mailbox.ContactConstants;
 import com.zimbra.common.util.StringUtil;

--- a/store/src/main/java/com/zimbra/cs/service/mail/AutoComplete.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/AutoComplete.java
@@ -19,7 +19,7 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.type.GalSearchType;
 import java.util.ArrayList;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class AutoComplete extends MailDocumentHandler {
 

--- a/store/src/main/java/com/zimbra/cs/service/mail/RecoverAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/RecoverAccount.java
@@ -31,7 +31,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public final class RecoverAccount extends MailDocumentHandler {
   public static final String LOG_OPERATION = "RecoverAccount:";

--- a/store/src/main/java/com/zimbra/cs/service/mail/SetRecoveryAccount.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/SetRecoveryAccount.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
 import com.zimbra.common.account.ZAttrProvisioning.PrefPasswordRecoveryAddressStatus;

--- a/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
+++ b/store/src/main/java/com/zimbra/cs/service/mail/ToXML.java
@@ -151,7 +151,6 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 import javax.mail.internet.MimeUtility;
-import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 
 /**

--- a/store/src/main/java/com/zimbra/cs/service/util/JWEUtil.java
+++ b/store/src/main/java/com/zimbra/cs/service/util/JWEUtil.java
@@ -8,7 +8,7 @@ package com.zimbra.cs.service.util;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.BlobMetaData;

--- a/store/src/main/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
+++ b/store/src/main/java/com/zimbra/cs/service/util/ResetPasswordUtil.java
@@ -8,7 +8,7 @@ package com.zimbra.cs.service.util;
 import java.util.Date;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.zimbra.common.account.ForgetPasswordEnums.CodeConstants;
 import com.zimbra.common.account.ZAttrProvisioning.FeatureResetPasswordStatus;

--- a/store/src/main/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilter.java
@@ -17,8 +17,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.text.StrTokenizer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrTokenizer;
 import org.eclipse.jetty.continuation.Continuation;
 import org.eclipse.jetty.continuation.ContinuationSupport;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;

--- a/store/src/main/java/com/zimbra/cs/util/SpamExtract.java
+++ b/store/src/main/java/com/zimbra/cs/util/SpamExtract.java
@@ -35,7 +35,7 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;

--- a/store/src/test/java/com/zimbra/cs/filter/RedirectCopyTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/RedirectCopyTest.java
@@ -11,9 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
@@ -23,12 +22,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.zimbra.common.account.Key;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.mailbox.DeliveryContext;
 import com.zimbra.cs.mailbox.MailItem;
 import com.zimbra.cs.mailbox.Mailbox;
 import com.zimbra.cs.mailbox.MailboxManager;
-import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.mailbox.Message;
 import com.zimbra.cs.mailbox.OperationContext;
 import com.zimbra.cs.mime.ParsedMessage;

--- a/store/src/test/java/com/zimbra/cs/mime/MimeTest.java
+++ b/store/src/test/java/com/zimbra/cs/mime/MimeTest.java
@@ -22,7 +22,7 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 import javax.mail.util.SharedByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import qa.unittest.TestUtil;

--- a/store/src/test/java/com/zimbra/cs/util/JWTBasedAuthTest.java
+++ b/store/src/test/java/com/zimbra/cs/util/JWTBasedAuthTest.java
@@ -43,7 +43,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
This PR:
remove dependency:
- commons-lang:commons-lang

and update to last version: 

- org.apache.commons:commons-lang3
- org.apache.commons:commons-text  
- org.graylog2:syslog4j because both depends on commons-lang3.

see: [CO-3735](https://zextras.atlassian.net/browse/CO-3735)

[CO-3735]: https://zextras.atlassian.net/browse/CO-3735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ