### PR TITLE
test: monitor flaky test and avoid crashing surefire VM

### DIFF
--- a/docs/zimbra-halt-cleanup.md
+++ b/docs/zimbra-halt-cleanup.md
@@ -1,0 +1,115 @@
+# Zimbra.halt cleanup
+
+## Problem
+
+`Zimbra.halt(String, Throwable)` (and the no-arg variant) terminates the JVM
+after logging a fatal:
+
+```java
+ZimbraLog.system.fatal(message, t);
+System.exit(1);   // or Runtime.getRuntime().halt(1)
+```
+
+It is used in two distinct patterns:
+
+1. **Genuine fatal errors.** DB commit failures (`Mailbox.endTransaction`,
+   line 10684) and OOMs in indexing (`MailboxIndex` lines 532, 610, 1421).
+   Killing the JVM is the right call.
+
+2. **Defensive checks in singleton accessors.** E.g. `LdapClient.getInstance()`
+   calls halt when the singleton is null. The intent is "if this is null in
+   production something is catastrophically wrong" — but in tests it fires
+   every time we cleanly shut down the LDAP layer. Background threads
+   (GAL sync, indexing, scheduled tasks) outlive the test lifecycle, call
+   `getInstance()` after `tearDown` has nulled the singleton, and halt the
+   forked JVM. Surefire then times out waiting for "Good Bye" and SIGKILLs.
+
+Pattern (2) is the bug we want to remove.
+
+## Current state (this commit)
+
+`Zimbra.halt` checks a system property and skips `System.exit(1)` when set:
+
+```java
+} finally {
+  if (!Objects.equals("true", System.getProperty("runningTests"))) {
+    System.exit(1);
+  }
+}
+```
+
+`store/pom.xml` sets `-DrunningTests=true` for surefire and failsafe argLines.
+In tests, halt logs and returns; the calling thread typically NPEs on the
+post-null code path and terminates cleanly. The JVM exits naturally because
+no non-daemon user threads remain alive (sync-only — daemon flag was not
+changed).
+
+This is **a stopgap**. Production code branches on "are we in tests", which:
+- Couples main and test code.
+- Is easy to miss at new halt call-sites.
+- Leaves the underlying design (halt-as-assertion) in place.
+
+## Plan to remove the stopgap
+
+Goal: drop the `runningTests` guard and the `-DrunningTests=true` argLines.
+
+### Step 1 — Audit halt call-sites
+
+Grep for `Zimbra.halt(` across `main/`. For each, classify:
+
+- **Genuine fatal** — keep halting. Examples: DB commit failure, OOM.
+- **Defensive assertion** — convert per Step 2.
+
+### Step 2 — Replace defensive halts with `IllegalStateException`
+
+Pattern, e.g. in `LdapClient.getInstance`:
+
+```java
+public static LdapClient getInstance() {
+  LdapClient i = instance;
+  if (i == null) {
+    throw new IllegalStateException("LdapClient not initialized");
+  }
+  return i;
+}
+```
+
+Effects:
+- Production callers that hit a null singleton see the same fast-fail signal,
+  no JVM kill. If a thread can't continue without it, the thread dies, the
+  exception is logged, the rest of the server keeps running.
+- Test background threads die cleanly on the exception instead of triggering
+  shutdown hooks.
+
+For each replacement, run the full store test suite to verify no caller
+relied on the JVM-kill behaviour.
+
+### Step 3 — Remove the stopgap
+
+- Delete the `runningTests` check from `Zimbra.halt`.
+- Remove `-DrunningTests=true` from both argLines in `store/pom.xml`.
+
+### Step 4 (optional follow-up) — Subsystem lifecycle
+
+If audit reveals widespread halt-as-assertion (it likely does), introduce a
+small `Lifecycle` interface with Starting/Running/Stopping/Stopped states.
+Background loops check state and exit on Stopping. tearDown order becomes a
+non-issue. Bigger change, separate effort.
+
+## Out of scope
+
+- `Mailbox.endTransaction`'s halt on DB commit failure. Genuine fatal — leave
+  it.
+- The `Zimbra.halt("out of memory", e)` sites in `MailboxIndex`. OOMEs are
+  defensibly fatal. Re-evaluate independently if/when we want to do graceful
+  per-task recovery; not part of this cleanup.
+
+## Acceptance criteria
+
+- `mvn -pl store -am test -Dtest='ContactAutoCompleteTest#lastNameFirstName'
+  -Dmaven.build.cache.enabled=false` passes without `-DrunningTests=true`.
+- `grep -r "runningTests" store/src/main common/src/main` returns no
+  matches (only test/build configuration may reference it, and that should
+  also be removed in Step 3).
+- No `Zimbra.halt` frame appears in any thread dump captured during teardown
+  of the in-memory test harness.

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -913,6 +913,7 @@ EOF
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties
             -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
+            -DrunningTests=true
           </argLine>
           <environmentVariables>
             <LC_ALL>C.UTF-8</LC_ALL>
@@ -929,6 +930,7 @@ EOF
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
             -Dfile.encoding=UTF-8 -Djava.locale.providers=COMPAT,SPI
+            -DrunningTests=true
           </argLine>
           <environmentVariables>
             <LC_ALL>C.UTF-8</LC_ALL>

--- a/store/src/main/java/com/zimbra/cs/mailbox/MailboxIndex.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/MailboxIndex.java
@@ -378,7 +378,9 @@ public final class MailboxIndex {
     if (wait) {
       indexLock.acquireUninterruptibly();
     } else if (!indexLock.tryAcquire()) {
-      ZimbraLog.index.debug("index is in progress by other thread, skipping");
+      ZimbraLog.index.info(
+          "indexDeferredItems skipped: lock held by another thread mboxId=%d types=%s deferredCount=%d",
+          mailbox.getId(), types, getDeferredCount(types));
       return;
     }
     lastFailedTime = -1; // reset

--- a/store/src/main/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/main/java/com/zimbra/cs/util/Zimbra.java
@@ -46,6 +46,7 @@ import com.zimbra.znative.Util;
 import java.io.File;
 import java.io.IOException;
 import java.security.Security;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 import org.apache.mina.core.buffer.IoBuffer;
@@ -456,7 +457,11 @@ public final class Zimbra {
     try {
       ZimbraLog.system.fatal(message, t);
     } finally {
-      Runtime.getRuntime().halt(1);
-    }
+      // Fixme: there should be no need to halt the system. However this codebase has so many threads
+      //  that during tests they keep the process live and maven surefire crashes because it does not receieve goodbye.
+      if (!Objects.equals("true", System.getProperty("runningTests"))) {
+        Runtime.getRuntime().halt(1);
+      }
+      }
   }
 }


### PR DESCRIPTION
The test suite mailbox has these problems:
- **ContactAutocompleteTest fails randomly** -> **I was not able to make it fail, so for now I've added a log where failures might happen.** 

It was found **the index (Lucene) implementation is asynchronous**, so it's possible that when a Contact is created it is not flushed immediately. Moreover, **since it is a static singleton, there could be interferences with other tests**. 
- **Sometimes the surefire VM crashes** -> **I was able to reproduce it most of the time.** 

After debugging I've found that the cause is likely to be **the code calling Zimbra#halt.** For now I've added a system property to skip it during tests. The reason is, **when the system shuts down there are threads still calling LdapClient#getInstance() which calls Zimbra#halt** because no instance is found and tries to allocate a new one. This is a protection system that makes very little sense in a modern application and we should try to find another way to handle it (e.g.: throw exception). I've added a doc with a future plan for halt calls. The downside is also that halting the system exits immediately and no log is produced (even in production). Moreover I've found there are so many threads executor (final static) that could cause this leak