### PR TITLE
ci: immediate bump + cleanup maven deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,6 @@ boolean isBuildingTag() {
     return env.TAG_NAME ? true : false
 }
 
-String profile = isBuildingTag() ? '-Pprod' : ''
-
 pipeline {
     agent {
         node {
@@ -23,7 +21,7 @@ pipeline {
     }
 
     environment {
-        MVN_OPTS = "-Ddebug=0 -Dis-production=1 ${profile}"
+        MVN_OPTS = "-Ddebug=0 -Dis-production=1 -Pprod"
         GITHUB_BOT_PR_CREDS = credentials('jenkins-integration-with-github-account')
         JAVA_OPTS = '-Dfile.encoding=UTF8'
         LC_ALL = 'C.UTF-8'
@@ -43,12 +41,6 @@ pipeline {
     stages {
 
         stage('Bump version and tag') {
-            when {
-                anyOf {
-                    branch 'main'
-                    branch 'devel'
-                }
-            }
             steps {
                 script {
                     dt2_semanticRelease()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,7 @@ boolean isBuildingTag() {
     return env.TAG_NAME ? true : false
 }
 
-String profile = isBuildingTag() ? '-Pprod' :
-        (env.BRANCH_NAME == 'devel' ? '-Pdev' : '')
+String profile = isBuildingTag() ? '-Pprod' : ''
 
 pipeline {
     agent {
@@ -42,6 +41,21 @@ pipeline {
     }
 
     stages {
+
+        stage('Bump version and tag') {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch 'devel'
+                }
+            }
+            steps {
+                script {
+                    dt2_semanticRelease()
+                }
+            }
+        }
+
         stage('Setup') {
             steps {
                 checkout scm
@@ -154,25 +168,6 @@ pipeline {
                     }
                 }
 
-                stage('Publish SNAPSHOT to maven') {
-                    when {
-                        allOf {
-                            not { buildingTag() }
-                            branch 'devel'
-                        }
-
-                    }
-                    steps {
-                        container('jdk-21') {
-                            withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                                script {
-                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -DskipTests=true"
-                                }
-                            }
-                        }
-                    }
-                }
-
                 stage('Publish to maven') {
                     when {
                         buildingTag()
@@ -181,7 +176,7 @@ pipeline {
                         container('jdk-21') {
                             withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
                                 script {
-                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -Dchangelist= -DskipTests=true"
+                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -DskipTests=true"
                                 }
                             }
                         }
@@ -244,19 +239,6 @@ pipeline {
                 }
             }
 
-        }
-        stage('Bump version and tag') {
-            when {
-                anyOf {
-                    branch 'main'
-                    branch 'devel'
-                }
-            }
-            steps {
-                script {
-                    dt2_semanticRelease()
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
- moves semantic release as first stage (no need to wait 15 minutes to get tag)
- removes -Pdev (does not exist)
- removes maven snapshot publish
- uses profile to alter changelist, no need to pass it during deploy (see maven pom.xml)