### PR TITLE
refactor: [CO-3760] ldap client static methods cleanup

### DIFF
--- a/store/src/main/java/com/zimbra/cert/ZimbraCertMgrExt.java
+++ b/store/src/main/java/com/zimbra/cert/ZimbraCertMgrExt.java
@@ -31,7 +31,9 @@ public class ZimbraCertMgrExt implements ZimbraExtension {
   public static final String CERT_TYPE_SELF = "self";
   public static final String CERT_TYPE_COMM = "comm";
 
-  public void destroy() {}
+  public void destroy() {
+    ExtensionDispatcherServlet.unregister(this);
+  }
 
   public String getName() {
     return NAME;

--- a/store/src/main/java/com/zimbra/cs/account/DistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/account/DistributionList.java
@@ -20,7 +20,6 @@ import com.zimbra.cs.account.Provisioning.MemberOf;
 import com.zimbra.cs.account.SearchDirectoryOptions.ObjectType;
 import com.zimbra.cs.account.ldap.BySearchResultEntrySearcher;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapServerType;
 import com.zimbra.cs.ldap.LdapUsage;
 import com.zimbra.cs.ldap.ZAttributes;
@@ -177,7 +176,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = LdapClient.getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(prov, zlc, null,
                     BASIC_ATTRS, dlUpdator);
@@ -197,7 +196,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                LdapClient.closeContext(zlc);
+                prov.getLdapClient().closeInstanceContext(zlc);
             }
         }
     }
@@ -221,7 +220,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = LdapClient.getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             List<BasicInfo> directDLs = getContainingDLs(prov, zlc, dl, adminGroupsOnly, true /* directOnly */);
             Iterator<BasicInfo> iter = directDLs.iterator();
@@ -247,7 +246,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                LdapClient.closeContext(zlc);
+                prov.getLdapClient().closeInstanceContext(zlc);
             }
         }
     }
@@ -260,7 +259,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = LdapClient.getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             List<BasicInfo> directDLs = getContainingDLs(prov, zlc, dls, adminGroupsOnly, true /* directOnly */);
             Iterator<BasicInfo> iter = directDLs.iterator();
@@ -278,7 +277,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                LdapClient.closeContext(zlc);
+                prov.getLdapClient().closeInstanceContext(zlc);
             }
         }
     }

--- a/store/src/main/java/com/zimbra/cs/account/accesscontrol/ExternalGroup.java
+++ b/store/src/main/java/com/zimbra/cs/account/accesscontrol/ExternalGroup.java
@@ -19,7 +19,6 @@ import com.zimbra.cs.account.accesscontrol.ZimbraACE.ExternalGroupInfo;
 import com.zimbra.cs.account.cache.NamedEntryCache;
 import com.zimbra.cs.account.grouphandler.GroupHandler;
 import com.zimbra.cs.account.ldap.LdapProv;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.ldap.LdapException;
 import com.zimbra.cs.ldap.LdapUtil;
@@ -152,7 +151,7 @@ public class ExternalGroup extends NamedEntry {
                 return null;
             }
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/grouphandler/ADGroupHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/grouphandler/ADGroupHandler.java
@@ -20,7 +20,6 @@ import com.zimbra.cs.account.ldap.LdapHelper;
 import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.ldap.IAttributes;
 import com.zimbra.cs.ldap.ILdapContext;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.ldap.LdapUtil;
 import com.zimbra.cs.ldap.SearchLdapOptions;
@@ -211,7 +210,7 @@ public class ADGroupHandler extends GroupHandler {
             
             return attrs.getMultiAttrStringAsList(MEMBER_OF_ATTR, CheckBinary.NOCHECK);
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
     

--- a/store/src/main/java/com/zimbra/cs/account/grouphandler/GroupHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/grouphandler/GroupHandler.java
@@ -17,9 +17,9 @@ import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.accesscontrol.ExternalGroup;
 import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.gal.ZimbraGalGroupHandler;
+import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.ldap.IAttributes;
 import com.zimbra.cs.ldap.ILdapContext;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapUsage;
 import com.zimbra.cs.ldap.ZLdapContext;
 import com.zimbra.cs.ldap.LdapServerConfig.ExternalLdapConfig;
@@ -110,7 +110,7 @@ public abstract class GroupHandler {
                 null, bindDN, bindPassword, null,
                 "search external group");
 
-        return LdapClient.getExternalContext(ldapConfig, LdapUsage.EXTERNAL_GROUP);
+        return LdapProv.getInst().getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.EXTERNAL_GROUP);
     }
 
 }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvision.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvision.java
@@ -54,7 +54,6 @@ import com.zimbra.cs.account.Provisioning.DirectoryEntryVisitor;
 import com.zimbra.cs.account.names.NameUtil.EmailAddress;
 import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.ldap.IAttributes;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.ldap.LdapException.LdapInvalidAttrValueException;
 import com.zimbra.cs.ldap.LdapException.LdapSizeLimitExceededException;
@@ -350,10 +349,10 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
 
         try {
-            zlc = LdapClient.getExternalContext(config, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION);
             return prov.getHelper().getAttributes(zlc, dn, getAttrsToFetch());
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
 
@@ -390,7 +389,7 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
 
         try {
-            zlc = LdapClient.getExternalContext(config, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION);
 
             String searchFilterTemplate = domain.getAutoProvLdapSearchFilter();
             if (searchFilterTemplate != null) {
@@ -420,7 +419,7 @@ public abstract class AutoProvision {
             }
 
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
 
         throw ServiceException.FAILURE("One of " + Provisioning.A_zimbraAutoProvLdapBindDn +
@@ -661,7 +660,7 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
         ZLdapFilter zFilter = null;
         try {
-            zlc = LdapClient.getExternalContext(config, LdapUsage.AUTO_PROVISION_ADMIN_SEARCH);
+            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION_ADMIN_SEARCH);
 
             String searchFilter = null;
             String searchFilterWithoutLastPolling = null;
@@ -726,7 +725,7 @@ public abstract class AutoProvision {
                 throw AccountServiceException.TOO_MANY_SEARCH_RESULTS("too many search results returned", e);
             }
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
         return hitSizeLimitExceededException;
     }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvisionEager.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvisionEager.java
@@ -22,7 +22,6 @@ import com.zimbra.cs.account.Provisioning.EagerAutoProvisionScheduler;
 import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.ldap.entry.LdapEntry;
 import com.zimbra.cs.ldap.IAttributes;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapDateUtil;
 import com.zimbra.cs.ldap.LdapServerType;
 import com.zimbra.cs.ldap.LdapUsage;
@@ -51,7 +50,7 @@ public class AutoProvisionEager extends AutoProvision {
             Server localServer = prov.getLocalServer();
             String[] scheduledDomains = localServer.getAutoProvScheduledDomains();
 
-            zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.AUTO_PROVISION);
 
             for (String domainName : scheduledDomains) {
                 if (scheduler.isShutDownRequested()) {
@@ -103,7 +102,7 @@ public class AutoProvisionEager extends AutoProvision {
             // unable to get ldap context
             ZimbraLog.autoprov.warn("Unable to auto provision accounts", e);
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
@@ -26,7 +26,6 @@ import com.zimbra.cs.account.krb5.Krb5Login;
 import com.zimbra.cs.gal.GalSearchConfig;
 import com.zimbra.cs.gal.GalSearchParams;
 import com.zimbra.cs.ldap.IAttributes;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.ldap.LdapDateUtil;
 import com.zimbra.cs.ldap.LdapException.LdapEntryNotFoundException;
@@ -154,6 +153,7 @@ public class LdapGalSearch {
             String token,
             SearchGalResult result) throws ServiceException {
 
+        LdapProv prov = LdapProv.getInst();
         ZLdapContext zlc = null;
         try {
             LdapGalCredential credential = galParams.credential();
@@ -163,7 +163,7 @@ public class LdapGalSearch {
                     credential.getBindDn(), credential.getBindPassword(),
                     rules.getBinaryLdapAttrs(), "external GAL");
 
-            zlc = LdapClient.getExternalContext(ldapConfig, LdapUsage.fromGalOpLegacy(galOp));
+            zlc = prov.getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.fromGalOpLegacy(galOp));
             searchGal(zlc,
                       GalSearchConfig.GalType.ldap,
                       galParams.pageSize(),
@@ -174,7 +174,7 @@ public class LdapGalSearch {
                       token,
                       result);
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
 
@@ -197,20 +197,21 @@ public class LdapGalSearch {
 
     private static void doGalSearch(GalSearchParams params) throws ServiceException {
 
+        LdapProv prov = LdapProv.getInst();
         ZLdapContext zlc = null;
         try {
             GalSearchConfig cfg = params.getConfig();
             GalSearchConfig.GalType galType =  params.getConfig().getGalType();
 
             if (galType == GalSearchConfig.GalType.zimbra) {
-                zlc = LdapClient.getContext(LdapUsage.fromGalOp(params.getOp()));
+                zlc = prov.getLdapClient().getInstanceContext(LdapUsage.fromGalOp(params.getOp()));
             } else {
                 ExternalLdapConfig ldapConfig = new ExternalLdapConfig(
                         cfg.getUrl(), cfg.getStartTlsEnabled(), cfg.getAuthMech(),
                         cfg.getBindDn(), cfg.getBindPassword(), cfg.getRules().getBinaryLdapAttrs(),
                         "external GAL");
 
-                zlc = LdapClient.getExternalContext(ldapConfig, LdapUsage.fromGalOp(params.getOp()));
+                zlc = prov.getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.fromGalOp(params.getOp()));
             }
 
             String fetchEntryByDn = params.getSearchEntryByDn();
@@ -250,7 +251,7 @@ public class LdapGalSearch {
                 getGalEntryByDn(zlc, galType, fetchEntryByDn, cfg.getRules(), params.getResult());
             }
         } finally {
-            LdapClient.closeContext(zlc);
+            prov.getLdapClient().closeInstanceContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapHelper.java
@@ -10,7 +10,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.ldap.IAttributes;
 import com.zimbra.cs.ldap.ILdapContext;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapException;
 import com.zimbra.cs.ldap.LdapException.LdapEntryNotFoundException;
 import com.zimbra.cs.ldap.LdapException.LdapMultipleEntriesMatchedException;
@@ -265,12 +264,12 @@ public abstract class LdapHelper {
             ZLdapContext zlc = initZlc;
             try {
                 if (zlc == null) {
-                    zlc = LdapClient.getContext(ldapServerType, LdapUsage.SEARCH);
+                    zlc = ldapProv.getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
                 }
                 zlc.searchPaged(searchOptions);
             } finally {
                 if (initZlc == null) {
-                    LdapClient.closeContext(zlc);
+                    ldapProv.getLdapClient().closeInstanceContext(zlc);
                 }
             }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProv.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProv.java
@@ -55,6 +55,8 @@ public abstract class LdapProv extends Provisioning implements ProvisioningCache
     return helper;
   }
 
+  public abstract LdapClient getLdapClient();
+
   public abstract int getAccountCacheSize();
 
   public abstract double getAccountCacheHitRate();

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -9285,6 +9285,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   }
 
   @Override
+  public LdapClient getLdapClient() {
+    return ldapClient;
+  }
+
+  @Override
   public void dumpLdapSchema(PrintWriter writer) throws ServiceException {
     ZLdapContext zlc = null;
     try {

--- a/store/src/main/java/com/zimbra/cs/account/ldap/ZLdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/ZLdapHelper.java
@@ -13,7 +13,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.AttributeManager;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.cs.ldap.ILdapContext;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapException;
 import com.zimbra.cs.ldap.LdapException.LdapEntryNotFoundException;
 import com.zimbra.cs.ldap.LdapException.LdapMultipleEntriesMatchedException;
@@ -48,7 +47,7 @@ public class ZLdapHelper extends LdapHelper {
     public void searchLdap(ILdapContext ldapContext, SearchLdapOptions searchOptions)
     throws ServiceException {
 
-        ZLdapContext zlc = LdapClient.toZLdapContext(getProv(), ldapContext);
+        ZLdapContext zlc = getProv().getLdapClient().toZLdapContext(ldapContext);
         zlc.searchPaged(searchOptions);
     }
 
@@ -56,10 +55,10 @@ public class ZLdapHelper extends LdapHelper {
     public void deleteEntry(String dn, LdapUsage ldapUsage) throws ServiceException {
         ZLdapContext zlc = null;
         try {
-            zlc = LdapClient.getContext(LdapServerType.MASTER, ldapUsage);
+            zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.MASTER, ldapUsage);
             zlc.deleteEntry(dn);
         } finally {
-            LdapClient.closeContext(zlc);
+            getProv().getLdapClient().closeInstanceContext(zlc);
         }
     }
 
@@ -163,10 +162,10 @@ public class ZLdapHelper extends LdapHelper {
     throws ServiceException {
         ZLdapContext zlc = null;
         try {
-            zlc = LdapClient.getContext(LdapServerType.MASTER, ldapUsage);
+            zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.MASTER, ldapUsage);
             modifyAttrs(zlc, dn, attrs, entry);
         } finally {
-            LdapClient.closeContext(zlc);
+            getProv().getLdapClient().closeInstanceContext(zlc);
         }
     }
 
@@ -187,7 +186,7 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = LdapClient.getContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
             }
 
             ZSearchControls sc = (returnAttrs == null) ? ZSearchControls.SEARCH_CTLS_SUBTREE() :
@@ -216,7 +215,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null)
-                LdapClient.closeContext(zlc);
+                getProv().getLdapClient().closeInstanceContext(zlc);
         }
         return null;
     }
@@ -238,13 +237,13 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = LdapClient.getContext(LdapServerType.get(useMaster), LdapUsage.COMPARE);
+                zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.get(useMaster), LdapUsage.COMPARE);
             }
 
             return zlc.compare(dn, attributeName, assertionValue);
         } finally {
             if (initZlc == null)
-                LdapClient.closeContext(zlc);
+                getProv().getLdapClient().closeInstanceContext(zlc);
         }
     }
 
@@ -262,7 +261,7 @@ public class ZLdapHelper extends LdapHelper {
                 if (usage == null) {
                     throw ServiceException.FAILURE("Unexpected null usage with null ldap context.", null);
                 }
-                zlc = LdapClient.getContext(ldapServerType, usage);
+                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, usage);
             }
             return zlc.getAttributes(dn, returnAttrs);
         /*  all callsites with the following @TODOEXCEPTIONMAPPING pattern can have ease of mind now and remove the
@@ -277,7 +276,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null) {
-                LdapClient.closeContext(zlc);
+                getProv().getLdapClient().closeInstanceContext(zlc);
             }
         }
     }
@@ -289,7 +288,7 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = LdapClient.getContext(ldapServerType, LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
             }
             return zlc.searchDir(baseDN, filter, searchControls);
         /*
@@ -300,7 +299,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null) {
-                LdapClient.closeContext(zlc);
+                getProv().getLdapClient().closeInstanceContext(zlc);
             }
         }
     }
@@ -312,12 +311,12 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = LdapClient.getContext(ldapServerType, LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
             }
             return zlc.countEntries(baseDN, filter, searchControls);
         } finally {
             if (initZlc == null) {
-                LdapClient.closeContext(zlc);
+                getProv().getLdapClient().closeInstanceContext(zlc);
             }
         }
     }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/entry/LdapDynamicGroup.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/entry/LdapDynamicGroup.java
@@ -20,7 +20,6 @@ import com.zimbra.cs.account.Provisioning.MemberOf;
 import com.zimbra.cs.account.SearchDirectoryOptions.ObjectType;
 import com.zimbra.cs.account.ldap.BySearchResultEntrySearcher;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapException;
 import com.zimbra.cs.ldap.LdapServerType;
 import com.zimbra.cs.ldap.LdapUsage;
@@ -183,13 +182,13 @@ public class LdapDynamicGroup extends DynamicGroup implements LdapEntry {
         ZLdapFilter filter = ZLdapFilterFactory.getInstance().allDynamicGroups();
         ZLdapContext zlcCompare = null;
         try {
-            zlcCompare = LdapClient.getContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
+            zlcCompare = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(
                     prov, null, domain, BASIC_ATTRS, new GroupMembershipUpdator(prov, zlcCompare,
                             acctDN, membership, adminGroupsOnly, true, false));
             searcher.doSearch(filter, DYNAMIC_GROUPS_TYPE);
         } finally {
-            LdapClient.closeContext(zlcCompare);
+            prov.getLdapClient().closeInstanceContext(zlcCompare);
         }
         return membership;
     }
@@ -208,13 +207,13 @@ public class LdapDynamicGroup extends DynamicGroup implements LdapEntry {
         ZLdapFilter filter = ZLdapFilterFactory.getInstance().dynamicGroupByIds(ids.toArray(new String[0]));
         ZLdapContext zlcCompare = null;
         try {
-            zlcCompare = LdapClient.getContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
+            zlcCompare = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(
                     prov, null, null, BASIC_ATTRS, new GroupMembershipUpdator(prov, zlcCompare,
                             acctDN, membership, adminGroupsOnly, customGroupsOnly, nonCustomGroupsOnly));
             searcher.doSearch(filter, DYNAMIC_GROUPS_TYPE);
         } finally {
-            LdapClient.closeContext(zlcCompare);
+            prov.getLdapClient().closeInstanceContext(zlcCompare);
         }
         return membership;
     }

--- a/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -30,8 +30,12 @@ public class ExtensionUtil {
   private static List<ZimbraExtensionClassLoader> sClassLoaders = new ArrayList<>();
   private static ClassLoader sExtParentClassLoader;
   private static Map<String, ZimbraExtension> sInitializedExtensions = new LinkedHashMap<>();
+  private static boolean sBootstrapDone = false;
 
-  static {
+  private static synchronized void bootstrap() {
+    if (sBootstrapDone) {
+      return;
+    }
     File extCommonDir = new File(LC.zimbra_extension_common_directory.value());
     URL[] extCommonURLs = dirListToURLs(extCommonDir);
     if (extCommonURLs == null) {
@@ -41,10 +45,14 @@ public class ExtensionUtil {
       sExtParentClassLoader =
           new URLClassLoader(extCommonURLs, ExtensionUtil.class.getClassLoader());
     }
-    ExtensionUtil.initInternalExtension(new ZimbraCertMgrExt());
-    ExtensionUtil.initInternalExtension(new NginxLookupExtension());
-    ExtensionUtil.initInternalExtension(new ClamScannerExtension());
     loadExtensionsFromDefaultDirectory();
+    sBootstrapDone = true;
+  }
+
+  public static synchronized void initInternalExtensions() {
+    initInternalExtension(new ZimbraCertMgrExt());
+    initInternalExtension(new NginxLookupExtension());
+    initInternalExtension(new ClamScannerExtension());
   }
 
   public static URL[] dirListToURLs(File dir) {
@@ -107,6 +115,9 @@ public class ExtensionUtil {
 
   private static synchronized void initInternalExtension(ZimbraExtension ext) {
     String extName = ext.getName();
+    if (sInitializedExtensions.containsKey(extName)) {
+      return;
+    }
     final String className = ext.getClass().getName();
     try {
       ext.init();
@@ -124,6 +135,8 @@ public class ExtensionUtil {
    * @param matcher - Used to filter which extensions to initialize. Can be null
    */
   public static synchronized void initAllMatching(ExtensionMatcher matcher) {
+    bootstrap();
+    initInternalExtensions();
     ZimbraLog.extensions.info("Initializing extensions");
     List<ZimbraExtensionClassLoader> sClassLoadersToRemove = new ArrayList<>();
     for (ZimbraExtensionClassLoader zcl : sClassLoaders) {

--- a/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -5,6 +5,7 @@
 
 package com.zimbra.cs.extension;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.zimbra.cert.ZimbraCertMgrExt;
 import com.zimbra.clam.ClamScannerExtension;
 import com.zimbra.common.localconfig.LC;
@@ -30,12 +31,12 @@ public class ExtensionUtil {
   private static List<ZimbraExtensionClassLoader> sClassLoaders = new ArrayList<>();
   private static ClassLoader sExtParentClassLoader;
   private static Map<String, ZimbraExtension> sInitializedExtensions = new LinkedHashMap<>();
-  private static boolean sBootstrapDone = false;
+
+  static {
+    bootstrap();
+  }
 
   private static synchronized void bootstrap() {
-    if (sBootstrapDone) {
-      return;
-    }
     File extCommonDir = new File(LC.zimbra_extension_common_directory.value());
     URL[] extCommonURLs = dirListToURLs(extCommonDir);
     if (extCommonURLs == null) {
@@ -46,10 +47,10 @@ public class ExtensionUtil {
           new URLClassLoader(extCommonURLs, ExtensionUtil.class.getClassLoader());
     }
     loadExtensionsFromDefaultDirectory();
-    sBootstrapDone = true;
+    initInternalExtensions();
   }
 
-  public static synchronized void initInternalExtensions() {
+  private static synchronized void initInternalExtensions() {
     initInternalExtension(new ZimbraCertMgrExt());
     initInternalExtension(new NginxLookupExtension());
     initInternalExtension(new ClamScannerExtension());
@@ -115,9 +116,6 @@ public class ExtensionUtil {
 
   private static synchronized void initInternalExtension(ZimbraExtension ext) {
     String extName = ext.getName();
-    if (sInitializedExtensions.containsKey(extName)) {
-      return;
-    }
     final String className = ext.getClass().getName();
     try {
       ext.init();
@@ -172,8 +170,12 @@ public class ExtensionUtil {
   }
 
   public static synchronized void initAll() {
+    initAllMatching(null);
+  }
+
+  @VisibleForTesting
+  public static synchronized void initAllForTests() {
     bootstrap();
-    initInternalExtensions();
     initAllMatching(null);
   }
 

--- a/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
+++ b/store/src/main/java/com/zimbra/cs/extension/ExtensionUtil.java
@@ -135,8 +135,6 @@ public class ExtensionUtil {
    * @param matcher - Used to filter which extensions to initialize. Can be null
    */
   public static synchronized void initAllMatching(ExtensionMatcher matcher) {
-    bootstrap();
-    initInternalExtensions();
     ZimbraLog.extensions.info("Initializing extensions");
     List<ZimbraExtensionClassLoader> sClassLoadersToRemove = new ArrayList<>();
     for (ZimbraExtensionClassLoader zcl : sClassLoaders) {
@@ -174,6 +172,8 @@ public class ExtensionUtil {
   }
 
   public static synchronized void initAll() {
+    bootstrap();
+    initInternalExtensions();
     initAllMatching(null);
   }
 

--- a/store/src/main/java/com/zimbra/cs/nginx/NginxLookupLdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/nginx/NginxLookupLdapHelper.java
@@ -12,7 +12,6 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.ldap.ILdapContext;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapConstants;
 import com.zimbra.cs.ldap.LdapException;
 import com.zimbra.cs.ldap.LdapUsage;
@@ -39,21 +38,21 @@ public class NginxLookupLdapHelper extends AbstractNginxLookupLdapHelper {
 
     @Override
     ILdapContext getLdapContext() throws ServiceException {
-        return LdapClient.getContext(LdapUsage.NGINX_LOOKUP);
+        return prov.getLdapClient().getInstanceContext(LdapUsage.NGINX_LOOKUP);
     }
 
     @Override
     void closeLdapContext(ILdapContext ldapContext) {
-        ZLdapContext zlc = LdapClient.toZLdapContext(prov, ldapContext);
-        LdapClient.closeContext(zlc);
+        ZLdapContext zlc = prov.getLdapClient().toZLdapContext(ldapContext);
+        prov.getLdapClient().closeInstanceContext(zlc);
     }
 
     @Override
     Map<String, Object> searchDir(ILdapContext ldapContext, String[] returnAttrs,
             Config config, ZLdapFilter filter, String searchBaseConfigAttr)
     throws NginxLookupException {
-        
-        ZLdapContext zlc = LdapClient.toZLdapContext(prov, ldapContext);
+
+        ZLdapContext zlc = prov.getLdapClient().toZLdapContext(ldapContext);
         
         Map<String, Object> attrs = null;
         
@@ -91,9 +90,9 @@ public class NginxLookupLdapHelper extends AbstractNginxLookupLdapHelper {
     SearchDirResult searchDirectory(ILdapContext ldapContext, String[] returnAttrs,
             Config config, FilterId filterId, String queryTemplate, String searchBase,
             String templateKey, String templateVal, Map<String, Boolean> attrs,
-            Set<String> extraAttrs) 
+            Set<String> extraAttrs)
     throws NginxLookupException {
-        ZLdapContext zlc = LdapClient.toZLdapContext(prov, ldapContext);
+        ZLdapContext zlc = prov.getLdapClient().toZLdapContext(ldapContext);
         
         HashMap<String, String> kv = new HashMap<String,String>();
         kv.put(templateKey, ZLdapFilterFactory.getInstance().encodeValue(templateVal));

--- a/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
@@ -15,7 +15,6 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.LdapServerType;
 import com.zimbra.cs.ldap.LdapUsage;
 import com.zimbra.cs.ldap.ZLdapContext;
@@ -258,9 +257,10 @@ public static void run(String[] args) throws ServiceException, CommandExitExcept
         // get domain alias from the given the domain
         // this logic works for for all cases account=addr@<alias domain> or alias-name@<alias domain>
         if (prov instanceof LdapProvisioning) {
-          ZLdapContext ldpCtx = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
+          LdapProvisioning ldapProv = (LdapProvisioning) prov;
+          ZLdapContext ldpCtx = ldapProv.getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
           try {
-            List<String> aliasDomainIds = ((LdapProvisioning) prov).getEmptyAliasDomainIds(ldpCtx,
+            List<String> aliasDomainIds = ldapProv.getEmptyAliasDomainIds(ldpCtx,
                 d, false);
             if (aliasDomainIds != null) {
               for (String aliasDomainId : aliasDomainIds) {
@@ -277,7 +277,7 @@ public static void run(String[] args) throws ServiceException, CommandExitExcept
               }
             }
           } finally {
-            LdapClient.closeContext(ldpCtx);
+            ldapProv.getLdapClient().closeInstanceContext(ldpCtx);
           }
         }
 

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
@@ -18,7 +18,6 @@ import com.zimbra.cs.account.auth.ZimbraCustomAuth;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.db.DbPool;
 import com.zimbra.cs.db.HSQLDB;
-import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.index.IndexStore;
 import com.zimbra.cs.index.ZimbraAnalyzer;
 import com.zimbra.cs.ldap.LdapClient;
@@ -157,7 +156,6 @@ public class MailboxSetupHelper {
 	}
 
 	public void tearDown() throws Exception {
-		ExtensionUtil.destroyAll();
 		inMemoryLdapServer.clear();
 		// Clear cached Lucene index searchers before shutting down the DB and deleting directories.
 		// The static SEARCHER_CACHE in LuceneIndex is keyed by mailbox ID. Without clearing it,

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
@@ -18,6 +18,7 @@ import com.zimbra.cs.account.auth.ZimbraCustomAuth;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.db.DbPool;
 import com.zimbra.cs.db.HSQLDB;
+import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.index.IndexStore;
 import com.zimbra.cs.index.ZimbraAnalyzer;
 import com.zimbra.cs.ldap.LdapClient;
@@ -156,6 +157,7 @@ public class MailboxSetupHelper {
 	}
 
 	public void tearDown() throws Exception {
+		ExtensionUtil.destroyAll();
 		inMemoryLdapServer.clear();
 		// Clear cached Lucene index searchers before shutting down the DB and deleting directories.
 		// The static SEARCHER_CACHE in LuceneIndex is keyed by mailbox ID. Without clearing it,

--- a/store/src/test/java/com/zimbra/cs/extension/ExtensionUtilTest.java
+++ b/store/src/test/java/com/zimbra/cs/extension/ExtensionUtilTest.java
@@ -36,7 +36,7 @@ public class ExtensionUtilTest extends MailboxTestSuite {
 	void simple() {
 		ExtensionUtil.addClassLoader(new ZimbraExtensionClassLoader(classpath,
 				SimpleExtension.class.getName()));
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		SimpleExtension ext =
 				(SimpleExtension) ExtensionUtil.getExtension("simple");
 		Assertions.assertNotNull(ext);
@@ -48,26 +48,26 @@ public class ExtensionUtilTest extends MailboxTestSuite {
 	void resign() {
 		ExtensionUtil.addClassLoader(new ZimbraExtensionClassLoader(classpath,
 				ResignExtension.class.getName()));
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		Assertions.assertNull(ExtensionUtil.getExtension("resign"));
 		Assertions.assertTrue(ResignExtension.isDestroyed());
 	}
 
 	@Test
 	void initAll_shouldInitNginxLookupExtension() {
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		Assertions.assertNotNull(ExtensionUtil.getExtension(NginxLookupExtension.NAME));
 	}
 
 	@Test
 	void initAll_shouldInitClamScannerExtension() {
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		Assertions.assertNotNull(ExtensionUtil.getExtension(ClamScannerExtension.NAME));
 	}
 
 	@Test
 	void initAll_shouldInitZimbraCertMgrExt() {
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		Assertions.assertNotNull(ExtensionUtil.getExtension(ZimbraCertMgrExt.NAME));
 	}
 

--- a/store/src/test/java/com/zimbra/cs/filter/RuleManagerWithCustomActionFilterTest.java
+++ b/store/src/test/java/com/zimbra/cs/filter/RuleManagerWithCustomActionFilterTest.java
@@ -78,7 +78,7 @@ public final class RuleManagerWithCustomActionFilterTest extends MailboxTestSuit
 		// register custom action extensions
 		ExtensionTestUtil.registerExtension("com.zimbra.extensions.DummyCustomDiscard");
 		ExtensionTestUtil.registerExtension("com.zimbra.extensions.DummyCustomTag");
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 	}
 
 	@AfterAll
@@ -108,7 +108,7 @@ public final class RuleManagerWithCustomActionFilterTest extends MailboxTestSuit
 
 		// register custom action extension
 		// ExtensionTestUtil.registerExtension("com.zimbra.extensions.DummyCustomDiscard");
-		// ExtensionUtil.initAll();
+		// ExtensionUtil.initAllForTests();
 
 		JsieveConfigMapHandler.registerCommand("discard", "com.zimbra.extensions.DummyCustomDiscard");
 		JsieveConfigMapHandler.registerCommand("tag", "com.zimbra.cs.filter.jsieve.Tag");
@@ -155,7 +155,7 @@ public final class RuleManagerWithCustomActionFilterTest extends MailboxTestSuit
 		// register custom action extensions
 		// ExtensionTestUtil.registerExtension("com.zimbra.extensions.DummyCustomDiscard");
 		// ExtensionTestUtil.registerExtension("com.zimbra.extensions.DummyCustomTag");
-		// ExtensionUtil.initAll();
+		// ExtensionUtil.initAllForTests();
 
 		JsieveConfigMapHandler.registerCommand("discard", "com.zimbra.extensions.DummyCustomDiscard");
 		JsieveConfigMapHandler.registerCommand("tag", "com.zimbra.extensions.DummyCustomTag");

--- a/store/src/test/java/com/zimbra/cs/nginx/NginxLookupExtensionTest.java
+++ b/store/src/test/java/com/zimbra/cs/nginx/NginxLookupExtensionTest.java
@@ -36,7 +36,7 @@ class NginxLookupExtensionTest extends MailboxTestSuite {
 
 	@BeforeAll
 	static void setup() throws Exception {
-		ExtensionUtil.initAll();
+		ExtensionUtil.initAllForTests();
 		final var extensionDispatcherServlet = new ServletHolder(ExtensionDispatcherServlet.class);
 		extensionDispatcherServlet.setName("ExtensionDispatcherServlet");
 		var servlet = new JettyServerFactory().addServlet("/", extensionDispatcherServlet);


### PR DESCRIPTION
Use only instance-level methods of LdapClient.
The downside is that methods surface using `prov.getLdapClient().getContext()` (Law of Demeter).
However my idea is that it will be easier to cleanup these references or perhaps move them to another unit

---
## Note on ExtenionsUtil

The static blocks register some code with pre-allocated provisioning, causing tests to fail (same JVM, multiple test runs).

Before making breaking changes in extensions lifecycle, I think it's better to intoduce a `visible for testing` method so we can setup/teardown extensions on demand in tests.
Ideally that code should be mvoed from static {} block and registration can happen on demand at startup (it is already happening). So in next PRs I will probably remove that code, but first it's important to keep the small changes focused and tight so that the reasoning behind and refactor is clear to everyone.

---
## Next
- remove deprecated methods
- remove singleton pattern from LdapClient
- cleanup singletons and extension mechanism -> NginxLookupExtension registered from multiple static blocks (second is harmless but useless)