### PR TITLE
refactor!: remove static methods and singleton of LdapClient.java

### DIFF
--- a/store/src/main/java/com/zimbra/cs/account/DistributionList.java
+++ b/store/src/main/java/com/zimbra/cs/account/DistributionList.java
@@ -176,7 +176,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(prov, zlc, null,
                     BASIC_ATTRS, dlUpdator);
@@ -196,7 +196,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                prov.getLdapClient().closeInstanceContext(zlc);
+                prov.getLdapClient().closeContext(zlc);
             }
         }
     }
@@ -220,7 +220,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             List<BasicInfo> directDLs = getContainingDLs(prov, zlc, dl, adminGroupsOnly, true /* directOnly */);
             Iterator<BasicInfo> iter = directDLs.iterator();
@@ -246,7 +246,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                prov.getLdapClient().closeInstanceContext(zlc);
+                prov.getLdapClient().closeContext(zlc);
             }
         }
     }
@@ -259,7 +259,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
         try {
             if (zlc == null) {
                 ownContext = true;
-                zlc = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
+                zlc = prov.getLdapClient().getContext(LdapServerType.get(false /* useMaster */), LdapUsage.SEARCH);
             }
             List<BasicInfo> directDLs = getContainingDLs(prov, zlc, dls, adminGroupsOnly, true /* directOnly */);
             Iterator<BasicInfo> iter = directDLs.iterator();
@@ -277,7 +277,7 @@ public abstract class DistributionList extends ZAttrDistributionList implements 
             return membership;
         } finally {
             if (ownContext) {
-                prov.getLdapClient().closeInstanceContext(zlc);
+                prov.getLdapClient().closeContext(zlc);
             }
         }
     }

--- a/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
@@ -34,6 +34,7 @@ import com.zimbra.cs.account.accesscontrol.TargetType;
 import com.zimbra.cs.account.commands.ProvUtilCommandHandlersFactory;
 import com.zimbra.cs.account.ldap.LdapAttributeCallbackHelper;
 import com.zimbra.cs.account.ldap.LdapProv;
+import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.account.soap.SoapProvisioning;
 import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.util.BuildInfo;
@@ -263,10 +264,10 @@ public class ProvUtil implements HttpDebugListener, ProvUtilDumperOptions {
 
   public void initProvisioning() throws ServiceException {
     if (useLdap) {
-      if (useLdapMaster) {
-        LdapClient.masterOnly();
-      }
       prov = Provisioning.getInstance();
+      if (useLdapMaster) {
+        ((LdapProvisioning) prov).alwaysUseMaster();
+      }
     } else {
       SoapProvisioning sp = new SoapProvisioning();
       sp.soapSetURI(

--- a/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
+++ b/store/src/main/java/com/zimbra/cs/account/ProvUtil.java
@@ -36,7 +36,6 @@ import com.zimbra.cs.account.ldap.LdapAttributeCallbackHelper;
 import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.account.ldap.LdapProvisioning;
 import com.zimbra.cs.account.soap.SoapProvisioning;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.util.BuildInfo;
 import com.zimbra.cs.util.SoapCLI;
 import com.zimbra.soap.admin.type.GranteeSelector.GranteeBy;

--- a/store/src/main/java/com/zimbra/cs/account/accesscontrol/ExternalGroup.java
+++ b/store/src/main/java/com/zimbra/cs/account/accesscontrol/ExternalGroup.java
@@ -151,7 +151,7 @@ public class ExternalGroup extends NamedEntry {
                 return null;
             }
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/grouphandler/ADGroupHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/grouphandler/ADGroupHandler.java
@@ -210,7 +210,7 @@ public class ADGroupHandler extends GroupHandler {
             
             return attrs.getMultiAttrStringAsList(MEMBER_OF_ATTR, CheckBinary.NOCHECK);
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
     

--- a/store/src/main/java/com/zimbra/cs/account/grouphandler/GroupHandler.java
+++ b/store/src/main/java/com/zimbra/cs/account/grouphandler/GroupHandler.java
@@ -110,7 +110,7 @@ public abstract class GroupHandler {
                 null, bindDN, bindPassword, null,
                 "search external group");
 
-        return LdapProv.getInst().getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.EXTERNAL_GROUP);
+        return LdapProv.getInst().getLdapClient().getExternalContext(ldapConfig, LdapUsage.EXTERNAL_GROUP);
     }
 
 }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvision.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvision.java
@@ -349,10 +349,10 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
 
         try {
-            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getExternalContext(config, LdapUsage.AUTO_PROVISION);
             return prov.getHelper().getAttributes(zlc, dn, getAttrsToFetch());
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
 
@@ -389,7 +389,7 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
 
         try {
-            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getExternalContext(config, LdapUsage.AUTO_PROVISION);
 
             String searchFilterTemplate = domain.getAutoProvLdapSearchFilter();
             if (searchFilterTemplate != null) {
@@ -419,7 +419,7 @@ public abstract class AutoProvision {
             }
 
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
 
         throw ServiceException.FAILURE("One of " + Provisioning.A_zimbraAutoProvLdapBindDn +
@@ -660,7 +660,7 @@ public abstract class AutoProvision {
         ZLdapContext zlc = null;
         ZLdapFilter zFilter = null;
         try {
-            zlc = prov.getLdapClient().getInstanceExternalContext(config, LdapUsage.AUTO_PROVISION_ADMIN_SEARCH);
+            zlc = prov.getLdapClient().getExternalContext(config, LdapUsage.AUTO_PROVISION_ADMIN_SEARCH);
 
             String searchFilter = null;
             String searchFilterWithoutLastPolling = null;
@@ -725,7 +725,7 @@ public abstract class AutoProvision {
                 throw AccountServiceException.TOO_MANY_SEARCH_RESULTS("too many search results returned", e);
             }
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
         return hitSizeLimitExceededException;
     }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvisionEager.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/AutoProvisionEager.java
@@ -50,7 +50,7 @@ public class AutoProvisionEager extends AutoProvision {
             Server localServer = prov.getLocalServer();
             String[] scheduledDomains = localServer.getAutoProvScheduledDomains();
 
-            zlc = prov.getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.AUTO_PROVISION);
+            zlc = prov.getLdapClient().getContext(LdapServerType.MASTER, LdapUsage.AUTO_PROVISION);
 
             for (String domainName : scheduledDomains) {
                 if (scheduler.isShutDownRequested()) {
@@ -102,7 +102,7 @@ public class AutoProvisionEager extends AutoProvision {
             // unable to get ldap context
             ZimbraLog.autoprov.warn("Unable to auto provision accounts", e);
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapGalSearch.java
@@ -163,7 +163,7 @@ public class LdapGalSearch {
                     credential.getBindDn(), credential.getBindPassword(),
                     rules.getBinaryLdapAttrs(), "external GAL");
 
-            zlc = prov.getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.fromGalOpLegacy(galOp));
+            zlc = prov.getLdapClient().getExternalContext(ldapConfig, LdapUsage.fromGalOpLegacy(galOp));
             searchGal(zlc,
                       GalSearchConfig.GalType.ldap,
                       galParams.pageSize(),
@@ -174,7 +174,7 @@ public class LdapGalSearch {
                       token,
                       result);
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
 
@@ -204,14 +204,14 @@ public class LdapGalSearch {
             GalSearchConfig.GalType galType =  params.getConfig().getGalType();
 
             if (galType == GalSearchConfig.GalType.zimbra) {
-                zlc = prov.getLdapClient().getInstanceContext(LdapUsage.fromGalOp(params.getOp()));
+                zlc = prov.getLdapClient().getContext(LdapUsage.fromGalOp(params.getOp()));
             } else {
                 ExternalLdapConfig ldapConfig = new ExternalLdapConfig(
                         cfg.getUrl(), cfg.getStartTlsEnabled(), cfg.getAuthMech(),
                         cfg.getBindDn(), cfg.getBindPassword(), cfg.getRules().getBinaryLdapAttrs(),
                         "external GAL");
 
-                zlc = prov.getLdapClient().getInstanceExternalContext(ldapConfig, LdapUsage.fromGalOp(params.getOp()));
+                zlc = prov.getLdapClient().getExternalContext(ldapConfig, LdapUsage.fromGalOp(params.getOp()));
             }
 
             String fetchEntryByDn = params.getSearchEntryByDn();
@@ -251,7 +251,7 @@ public class LdapGalSearch {
                 getGalEntryByDn(zlc, galType, fetchEntryByDn, cfg.getRules(), params.getResult());
             }
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlc);
+            prov.getLdapClient().closeContext(zlc);
         }
     }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapHelper.java
@@ -264,12 +264,12 @@ public abstract class LdapHelper {
             ZLdapContext zlc = initZlc;
             try {
                 if (zlc == null) {
-                    zlc = ldapProv.getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
+                    zlc = ldapProv.getLdapClient().getContext(ldapServerType, LdapUsage.SEARCH);
                 }
                 zlc.searchPaged(searchOptions);
             } finally {
                 if (initZlc == null) {
-                    ldapProv.getLdapClient().closeInstanceContext(zlc);
+                    ldapProv.getLdapClient().closeContext(zlc);
                 }
             }
 

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -251,7 +251,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 	}
 
   public LdapProvisioning(CacheMode cacheMode) throws LdapException {
-    this(cacheMode, LdapClient.getInstanceIfLDAPavailable());
+    this(cacheMode, LdapClient.createNew());
   }
 
   public LdapProvisioning() throws LdapException {
@@ -9281,7 +9281,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
   @Override
   public void alwaysUseMaster() {
-    ldapClient.masterOnly();
+    ldapClient.forceUsingMaster();
   }
 
   @Override

--- a/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/LdapProvisioning.java
@@ -673,7 +673,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     try {
       if (zlc == null) {
         zlc =
-            ldapClient.getInstanceContext(
+            ldapClient.getContext(
                 LdapServerType.MASTER, LdapUsage.modifyEntryfromEntryType(entry.getEntryType()));
       }
       helper.modifyAttrs(zlc, ((LdapEntry) entry).getDN(), attrs, entry);
@@ -688,7 +688,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         refreshEntry(entry, zlc);
       }
       if (initZlc == null) {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
   }
@@ -698,7 +698,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = initZlc;
     try {
       if (zlc == null) {
-        zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.SET_PASSWORD);
+        zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.SET_PASSWORD);
       }
       zlc.setPassword(((LdapEntry) entry).getDN(), newPassword);
     } catch (ServiceException e) {
@@ -708,7 +708,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         refreshEntry(entry, zlc);
       }
       if (initZlc == null) {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
   }
@@ -724,10 +724,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.get(master), LdapUsage.GET_ENTRY);
+      zlc = ldapClient.getContext(LdapServerType.get(master), LdapUsage.GET_ENTRY);
       refreshEntry(e, zlc);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -1323,7 +1323,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     String dn = null;
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
 
       Domain d = getDomainByAsciiName(domain, zlc);
       if (d == null) {
@@ -1334,7 +1334,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         throw ServiceException.INVALID_REQUEST("domain type must be local", null);
       }
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(acctAttrs);
 
       for (String a : sInvalidAccountCreateModifyAttrs) {
@@ -1549,7 +1549,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create account: " + emailAddress, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
 
       if (!restoring && acct != null) {
         for (PostCreateAccountListener listener : ProvisioningExt.getPostCreateAccountListeners()) {
@@ -1571,7 +1571,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   public void searchOCsForSuperClasses(Map<String, Set<String>> ocs) {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
       ZLdapSchema schema = zlc.getSchema();
 
       for (Map.Entry<String, Set<String>> entry : ocs.entrySet()) {
@@ -1597,7 +1597,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to get LDAP schema", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -1606,7 +1606,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
       ZLdapSchema schema = zlc.getSchema();
 
       for (String oc : ocs) {
@@ -1628,7 +1628,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to get LDAP schema", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -2236,7 +2236,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = null;
     try {
       zlc =
-          ldapClient.getInstanceContext(
+          ldapClient.getContext(
               LdapServerType.get(opts.getOnMaster()), opts.getUseConnPool(), LdapUsage.SEARCH);
 
       SearchObjectsVisitor searchObjectsVisitor =
@@ -2260,7 +2260,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to list all objects", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -2432,7 +2432,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = null;
     String aliasDn = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, ldapUsage);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, ldapUsage);
 
       Domain domain = getDomainByAsciiName(aliasDomain, zlc);
       if (domain == null) throw AccountServiceException.NO_SUCH_DOMAIN(aliasDomain);
@@ -2524,7 +2524,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create alias: " + e.getMessage(), e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -2561,7 +2561,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, ldapUsage);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, ldapUsage);
 
       alias = alias.toLowerCase();
       alias = IDNUtil.toAsciiEmail(alias);
@@ -2647,7 +2647,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         throw AccountServiceException.NO_SUCH_ALIAS(alias);
 
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -2684,7 +2684,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
 
       LdapDomain d = (LdapDomain) getDomainByAsciiName(name, zlc);
       if (d != null) {
@@ -2718,7 +2718,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       String[] dns = mDIT.domainToDNs(parts);
       createParentDomains(zlc, parts, dns);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(domainAttrs);
 
       Set<String> ocs = LdapObjectClass.getDomainObjectClasses(this);
@@ -2785,7 +2785,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create domain: " + name, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3130,9 +3130,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(allAttrs);
 
       Set<String> ocs = LdapObjectClass.getCosObjectClasses(this);
@@ -3156,7 +3156,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create cos: " + destCosName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3171,7 +3171,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     newName = newName.toLowerCase().trim();
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_COS);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_COS);
       String newDn = mDIT.cosNametoDN(newName);
       zlc.renameEntry(cos.getDN(), newDn);
       // remove old cos from cache
@@ -3183,7 +3183,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename cos: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3321,7 +3321,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     final Map<String, Object> attrs = new HashMap<>(acc.getAttrs());
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_ACCOUNT);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_ACCOUNT);
 
       zlc.deleteChildren(entry.getDN());
       zlc.deleteEntry(entry.getDN());
@@ -3330,7 +3330,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to purge account: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3353,7 +3353,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     boolean domainChanged = false;
     Account oldAccount = acct;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_ACCOUNT);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_ACCOUNT);
 
       String oldDn = entry.getDN();
       String[] parts = EmailUtil.getLocalPartAndDomain(oldEmail);
@@ -3500,7 +3500,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename account: " + newName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
       // prune cache
       accountCache.remove(oldAccount);
     }
@@ -3516,7 +3516,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   private void deleteDomain(String zimbraId, boolean deleteDomainAliases) throws ServiceException {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_DOMAIN);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_DOMAIN);
 
       Domain domain = getDomainById(zimbraId, zlc);
       if (domain == null) {
@@ -3542,7 +3542,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw e;
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3759,7 +3759,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = null;
 
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_DOMAIN);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_DOMAIN);
 
       RenameDomain.RenameDomainLdapHelper helper =
           new RenameDomain.RenameDomainLdapHelper(this, zlc) {
@@ -3771,7 +3771,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
             @Override
             public void createEntry(String dn, Map<String, Object> attrs) throws ServiceException {
 
-              ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+              ZMutableEntry entry = ldapClient.createMutableEntry();
               entry.mapToAttrs(attrs);
               entry.setDN(dn);
 
@@ -3845,7 +3845,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       RenameDomain rd = new RenameDomain(this, helper, oldDomain, newDomainName);
       rd.execute();
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3860,13 +3860,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     // TODO: should we go through all accounts with this cos and remove the zimbraCOSId attr?
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_COS);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_COS);
       zlc.deleteEntry(c.getDN());
       cosCache.remove(c);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to purge cos: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3888,9 +3888,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_SHARELOCATOR);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_SHARELOCATOR);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(attrs);
 
       Set<String> ocs = LdapObjectClass.getShareLocatorObjectClasses(this);
@@ -3913,7 +3913,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create share locator: " + id, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3924,13 +3924,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_SHARELOCATOR);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_SHARELOCATOR);
       zlc.deleteEntry(shloc.getDN());
       shareLocatorCache.remove(shloc);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to delete share locator: " + id, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -3943,9 +3943,9 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_SERVER);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_SERVER);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(serverAttrs);
 
       Set<String> ocs = LdapObjectClass.getServerObjectClasses(this);
@@ -3975,7 +3975,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create server: " + name, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -4254,14 +4254,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_SERVER);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_SERVER);
       removeServerFromAllCOSes(zimbraId, server.getName(), zlc);
       zlc.deleteEntry(server.getDN());
       serverCache.remove(server);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to purge server: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -4298,7 +4298,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
 
       Domain d = getDomainByAsciiName(domain, zlc);
       if (d == null) throw AccountServiceException.NO_SUCH_DOMAIN(domain);
@@ -4307,7 +4307,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
         throw ServiceException.INVALID_REQUEST("domain type must be local", null);
       }
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(listAttrs);
 
       Set<String> ocs = LdapObjectClass.getDistributionListObjectClasses(this);
@@ -4362,7 +4362,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create distribution list: " + listAddress, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -4410,7 +4410,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     boolean domainChanged = false;
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_DISTRIBUTIONLIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_DISTRIBUTIONLIST);
 
       LdapDistributionList dl = (LdapDistributionList) getDistributionListById(zimbraId, zlc);
       if (dl == null) {
@@ -4531,7 +4531,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename distribution list: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     if (domainChanged) {
@@ -4620,14 +4620,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_DISTRIBUTIONLIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_DISTRIBUTIONLIST);
       zlc.deleteEntry(dl.getDN());
       groupCache.remove(dl);
       allDLs.removeGroup(addrs);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to purge distribution list: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     PermissionCache.invalidateCache();
@@ -4641,13 +4641,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     }
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_ADDRESSLIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_ADDRESSLIST);
       zlc.deleteEntry(adl.getDn());
     } catch (ServiceException e) {
       throw ServiceException.FAILURE(
           String.format("unable to purge address list: %s", addressListId), e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -5525,7 +5525,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceExternalContext(config, LdapUsage.LDAP_AUTH_EXTERNAL);
+      zlc = ldapClient.getExternalContext(config, LdapUsage.LDAP_AUTH_EXTERNAL);
       ZSearchResultEnumeration ne =
           zlc.searchDir(
               searchBase,
@@ -5543,7 +5543,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       }
       ne.close();
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     if (tooMany != null) {
@@ -6379,14 +6379,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_ZIMLET);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_ZIMLET);
 
       String hasKeyword = LdapConstants.LDAP_FALSE;
       if (zimletAttrs.containsKey(A_zimbraZimletKeyword)) {
         hasKeyword = ProvisioningConstants.TRUE;
       }
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(zimletAttrs);
 
       entry.setAttr(A_objectClass, "zimbraZimletEntry");
@@ -6408,7 +6408,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create zimlet: " + name, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -6416,7 +6416,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   public void deleteZimlet(String name) throws ServiceException {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_ZIMLET);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_ZIMLET);
       LdapZimlet zimlet = (LdapZimlet) getZimlet(name, zlc, true);
       if (zimlet != null) {
         zimletCache.remove(zimlet);
@@ -6425,7 +6425,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to delete zimlet: " + name, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -7417,7 +7417,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapUsage.fromGalOpLegacy(galOp));
+      zlc = ldapClient.getContext(LdapUsage.fromGalOpLegacy(galOp));
       LdapGalSearch.searchGal(
           zlc,
           GalSearchConfig.GalType.zimbra,
@@ -7429,7 +7429,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
           token,
           result);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     // Collections.sort(result);
@@ -7788,11 +7788,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_IDENTITY);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_IDENTITY);
 
       String dn = getIdentityDn(ldapEntry, identityName);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.setDN(dn);
       entry.mapToAttrs(identityAttrs);
 
@@ -7818,7 +7818,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create identity " + identityName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -7867,13 +7867,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_IDENTITY);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_IDENTITY);
       String newDn = getIdentityDn(entry, newIdentityName);
       zlc.renameEntry(identity.getDN(), newDn);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename identity: " + newIdentityName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -7890,7 +7890,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_IDENTITY);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_IDENTITY);
       Identity identity = getIdentityByName(ldapEntry, identityName, zlc);
       if (identity == null) throw AccountServiceException.NO_SUCH_IDENTITY(identityName);
       String dn = getIdentityDn(ldapEntry, identityName);
@@ -7898,7 +7898,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to delete identity: " + identityName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -8107,11 +8107,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_SIGNATURE);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_SIGNATURE);
 
       String dn = getSignatureDn(ldapEntry, signatureName);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(signatureAttrs);
 
       entry.setAttr(A_objectClass, "zimbraSignature");
@@ -8134,7 +8134,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create signature: " + signatureName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -8197,13 +8197,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       throws ServiceException {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_SIGNATURE);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_SIGNATURE);
       String newDn = getSignatureDn(entry, newSignatureName);
       zlc.renameEntry(signature.getDN(), newDn);
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename signature: " + newSignatureName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -8220,7 +8220,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } else {
       ZLdapContext zlc = null;
       try {
-        zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_SIGNATURE);
+        zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_SIGNATURE);
         Signature signature = getSignatureById(account, ldapEntry, signatureId, zlc);
         if (signature == null) throw AccountServiceException.NO_SUCH_SIGNATURE(signatureId);
         String dn = getSignatureDn(ldapEntry, signature.getName());
@@ -8228,7 +8228,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       } catch (ServiceException e) {
         throw ServiceException.FAILURE("unable to delete signarure: " + signatureId, e);
       } finally {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
 
@@ -8463,11 +8463,11 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DATASOURCE);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DATASOURCE);
 
       String dn = getDataSourceDn(ldapEntry, dsName);
 
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.setDN(dn);
       entry.mapToAttrs(dataSourceAttrs);
 
@@ -8510,7 +8510,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to create data source: " + dsName, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -8524,7 +8524,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_DATASOURCE);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_DATASOURCE);
       DataSource dataSource = getDataSourceById(ldapEntry, dataSourceId, zlc);
       if (dataSource == null) throw AccountServiceException.NO_SUCH_DATA_SOURCE(dataSourceId);
       String dn = getDataSourceDn(ldapEntry, dataSource.getName());
@@ -8532,7 +8532,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to delete data source: " + dataSourceId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -8600,13 +8600,13 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       account.setCachedData(DATA_SOURCE_LIST_CACHE_KEY, null);
       ZLdapContext zlc = null;
       try {
-        zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_DATASOURCE);
+        zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_DATASOURCE);
         String newDn = getDataSourceDn(ldapEntry, name);
         zlc.renameEntry(ds.getDN(), newDn);
       } catch (ServiceException e) {
         throw ServiceException.FAILURE("unable to rename datasource: " + name, e);
       } finally {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
   }
@@ -9267,10 +9267,10 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
+      zlc = ldapClient.getContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
       zlc.searchPaged(searchOptions);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -9293,7 +9293,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
   public void dumpLdapSchema(PrintWriter writer) throws ServiceException {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.GET_SCHEMA);
       ZLdapSchema schema = zlc.getSchema();
 
       for (ZLdapSchema.ZObjectClassDefinition oc : schema.getObjectClasses()) {
@@ -9305,7 +9305,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to get LDAP schema", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -9570,7 +9570,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       String[] members = getGroupMembers(group);
       Set<String> internalMembers = Sets.newHashSet();
       Set<String> externalMembers = Sets.newHashSet();
-      ZLdapContext zlc = ldapClient.getInstanceContext(LdapServerType.REPLICA, LdapUsage.SEARCH);
+      ZLdapContext zlc = ldapClient.getContext(LdapServerType.REPLICA, LdapUsage.SEARCH);
       try {
         for (String member : members) {
           if (addressExists(zlc, new String[] {member})) {
@@ -9580,7 +9580,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
           }
         }
       } finally {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
       if (!externalMembers.isEmpty()) {
         if (!internalMembers.isEmpty()) {
@@ -9746,7 +9746,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DYNAMICGROUP);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DYNAMICGROUP);
 
       Domain domain = getDomainByAsciiName(domainName, zlc);
       if (domain == null) {
@@ -9764,7 +9764,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
        * create the main dynamic group entry
        * ====================================
        */
-      ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+      ZMutableEntry entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(groupAttrs);
 
       Set<String> ocs = LdapObjectClass.getGroupObjectClasses(this);
@@ -9847,7 +9847,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
          */
         String dynamicUnitLocalpart = dynamicGroupDynamicUnitLocalpart(localPart);
         String dynamicUnitAddr = EmailAddress.getAddress(dynamicUnitLocalpart, domainName);
-        entry = ldapClient.createInstanceMutableEntry();
+        entry = ldapClient.createMutableEntry();
         ocs = LdapObjectClass.getGroupDynamicUnitObjectClasses(this);
         entry.addAttr(A_objectClass, ocs);
 
@@ -9875,7 +9875,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
          * create the static group unit entry, for external addresses
          * ==========================================================
          */
-        entry = ldapClient.createInstanceMutableEntry();
+        entry = ldapClient.createMutableEntry();
         ocs = LdapObjectClass.getGroupStaticUnitObjectClasses(this);
         entry.addAttr(A_objectClass, ocs);
 
@@ -9910,7 +9910,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (LdapException | AccountServiceException e) {
       throw e;
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -9953,7 +9953,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.DELETE_DYNAMICGROUP);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.DELETE_DYNAMICGROUP);
 
       String dn = group.getDN();
       zlc.deleteChildren(dn);
@@ -9966,7 +9966,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to purge group: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     PermissionCache.invalidateCache();
@@ -10034,7 +10034,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     boolean domainChanged = false;
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.RENAME_DYNAMICGROUP);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.RENAME_DYNAMICGROUP);
 
       LdapDynamicGroup group = (LdapDynamicGroup) getDynamicGroupById(zimbraId, zlc, false);
       if (group == null) {
@@ -10147,7 +10147,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
           String dynamicUnitDN =
               mDIT.dynamicGroupUnitNameToDN(DYNAMIC_GROUP_DYNAMIC_UNIT_NAME, newDn);
 
-          ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+          ZMutableEntry entry = ldapClient.createMutableEntry();
           entry.setAttr(A_mail, dynamicUnitNewEmail);
           entry.setAttr(A_zimbraMailAlias, dynamicUnitNewEmail);
           zlc.replaceAttributes(dynamicUnitDN, entry.getAttributes());
@@ -10171,7 +10171,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("unable to rename dynamic group: " + zimbraId, e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     if (domainChanged) {
@@ -10287,7 +10287,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.ADD_GROUP_MEMBER);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.ADD_GROUP_MEMBER);
 
       // check non of the addrs in externalAddrs can be an email address
       // on the system
@@ -10327,7 +10327,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       }
 
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
     PermissionCache.invalidateCache();
     cleanGroupMembersCache(group);
@@ -10398,7 +10398,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.REMOVE_GROUP_MEMBER);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.REMOVE_GROUP_MEMBER);
 
       /*
        * remove internal members
@@ -10430,7 +10430,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       }
 
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
     PermissionCache.invalidateCache();
     cleanGroupMembersCache(group);
@@ -10502,7 +10502,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = initZlc;
     try {
       if (zlc == null) {
-        zlc = ldapClient.getInstanceContext(LdapServerType.REPLICA, LdapUsage.SEARCH);
+        zlc = ldapClient.getContext(LdapServerType.REPLICA, LdapUsage.SEARCH);
       }
       String base = mDIT.mailBranchBaseDN();
       ZLdapFilter filter = filterFactory.dynamicGroupsStaticUnitByMemberAddr(addr);
@@ -10523,7 +10523,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       ZimbraLog.account.warn("unable to search dynamic groups for guest acct", e);
     } finally {
       if (initZlc == null) {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
 
@@ -10564,7 +10564,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = null;
     try {
       // always use master to search for dynamic group members
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.SEARCH);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.SEARCH);
 
       // search internal members
       searchDynamicGroupInternalMemberDeliveryAddresses(zlc, group.getId(), members);
@@ -10578,7 +10578,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to search dynamic group members", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     return members;
@@ -10607,14 +10607,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     try {
       if (zlc == null) {
         // always use master to search for dynamic group members
-        zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.SEARCH);
+        zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.SEARCH);
       }
       searchDynamicGroupInternalMembers(zlc, dynGroupId, visitor);
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to search dynamic group members", e);
     } finally {
       if (initZlc == null) {
-        ldapClient.closeInstanceContext(zlc);
+        ldapClient.closeContext(zlc);
       }
     }
   }
@@ -10624,7 +10624,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.REPLICA, LdapUsage.GET_GROUP_MEMBER);
+      zlc = ldapClient.getContext(LdapServerType.REPLICA, LdapUsage.GET_GROUP_MEMBER);
 
       /*
        * this DynamicGroup object must not be a basic group with minimum
@@ -10649,7 +10649,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       ZimbraLog.account.warn("unable to get dynamic group members", e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     return members.toArray(new String[0]);
@@ -10675,7 +10675,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     ZLdapContext zlc = null;
 
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.REPLICA, LdapUsage.GET_ENTRY);
+      zlc = ldapClient.getContext(LdapServerType.REPLICA, LdapUsage.GET_ENTRY);
       String[] returnAttrs = {
         "userPassword",
         "zimbraAuthTokens",
@@ -10694,7 +10694,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       throw ServiceException.FAILURE(
           String.format("unable to refresh user credentials for '%s'", account.getName()), e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 
@@ -10704,7 +10704,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     String domainDn = ((LdapEntry) domain).getDN();
     Set<String> oc = new HashSet<>();
     oc.add(AttributeClass.OC_zimbraAddressList);
-    ZMutableEntry entry = ldapClient.createInstanceMutableEntry();
+    ZMutableEntry entry = ldapClient.createMutableEntry();
     if (attrs != null && attrs.size() > 0) {
       entry.mapToAttrs(attrs);
     }
@@ -10731,14 +10731,14 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
 
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_ADDRESS_LIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_ADDRESS_LIST);
       zlc.createEntry(entry);
     } catch (ServiceException se) {
       ZimbraLog.addresslist.debug(
           "Exception occured while creating addresslist in ldap: %s", se.getMessage());
       throw se;
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
 
     return zimbraIdStr;
@@ -10812,7 +10812,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
       throws ServiceException {
     ZLdapContext zlc = null;
     try {
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.MODIFY_ADDRESS_LIST);
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.MODIFY_ADDRESS_LIST);
       // replace all given attrs
       modifyAttrs(addressList, attrs);
       ZimbraLog.addresslist.debug("Modified address list attributes %s", attrs);
@@ -10830,7 +10830,7 @@ public class LdapProvisioning extends LdapProv implements CacheAwareProvisioning
     } catch (ServiceException e) {
       throw ServiceException.FAILURE("error modifying address list: " + addressList.getId(), e);
     } finally {
-      ldapClient.closeInstanceContext(zlc);
+      ldapClient.closeContext(zlc);
     }
   }
 }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/ZLdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/ZLdapHelper.java
@@ -55,10 +55,10 @@ public class ZLdapHelper extends LdapHelper {
     public void deleteEntry(String dn, LdapUsage ldapUsage) throws ServiceException {
         ZLdapContext zlc = null;
         try {
-            zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.MASTER, ldapUsage);
+            zlc = getProv().getLdapClient().getContext(LdapServerType.MASTER, ldapUsage);
             zlc.deleteEntry(dn);
         } finally {
-            getProv().getLdapClient().closeInstanceContext(zlc);
+            getProv().getLdapClient().closeContext(zlc);
         }
     }
 
@@ -162,10 +162,10 @@ public class ZLdapHelper extends LdapHelper {
     throws ServiceException {
         ZLdapContext zlc = null;
         try {
-            zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.MASTER, ldapUsage);
+            zlc = getProv().getLdapClient().getContext(LdapServerType.MASTER, ldapUsage);
             modifyAttrs(zlc, dn, attrs, entry);
         } finally {
-            getProv().getLdapClient().closeInstanceContext(zlc);
+            getProv().getLdapClient().closeContext(zlc);
         }
     }
 
@@ -186,7 +186,7 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getContext(LdapServerType.get(useMaster), LdapUsage.SEARCH);
             }
 
             ZSearchControls sc = (returnAttrs == null) ? ZSearchControls.SEARCH_CTLS_SUBTREE() :
@@ -215,7 +215,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null)
-                getProv().getLdapClient().closeInstanceContext(zlc);
+                getProv().getLdapClient().closeContext(zlc);
         }
         return null;
     }
@@ -237,13 +237,13 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = getProv().getLdapClient().getInstanceContext(LdapServerType.get(useMaster), LdapUsage.COMPARE);
+                zlc = getProv().getLdapClient().getContext(LdapServerType.get(useMaster), LdapUsage.COMPARE);
             }
 
             return zlc.compare(dn, attributeName, assertionValue);
         } finally {
             if (initZlc == null)
-                getProv().getLdapClient().closeInstanceContext(zlc);
+                getProv().getLdapClient().closeContext(zlc);
         }
     }
 
@@ -261,7 +261,7 @@ public class ZLdapHelper extends LdapHelper {
                 if (usage == null) {
                     throw ServiceException.FAILURE("Unexpected null usage with null ldap context.", null);
                 }
-                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, usage);
+                zlc = getProv().getLdapClient().getContext(ldapServerType, usage);
             }
             return zlc.getAttributes(dn, returnAttrs);
         /*  all callsites with the following @TODOEXCEPTIONMAPPING pattern can have ease of mind now and remove the
@@ -276,7 +276,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null) {
-                getProv().getLdapClient().closeInstanceContext(zlc);
+                getProv().getLdapClient().closeContext(zlc);
             }
         }
     }
@@ -288,7 +288,7 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getContext(ldapServerType, LdapUsage.SEARCH);
             }
             return zlc.searchDir(baseDN, filter, searchControls);
         /*
@@ -299,7 +299,7 @@ public class ZLdapHelper extends LdapHelper {
         */
         } finally {
             if (initZlc == null) {
-                getProv().getLdapClient().closeInstanceContext(zlc);
+                getProv().getLdapClient().closeContext(zlc);
             }
         }
     }
@@ -311,12 +311,12 @@ public class ZLdapHelper extends LdapHelper {
         ZLdapContext zlc = initZlc;
         try {
             if (zlc == null) {
-                zlc = getProv().getLdapClient().getInstanceContext(ldapServerType, LdapUsage.SEARCH);
+                zlc = getProv().getLdapClient().getContext(ldapServerType, LdapUsage.SEARCH);
             }
             return zlc.countEntries(baseDN, filter, searchControls);
         } finally {
             if (initZlc == null) {
-                getProv().getLdapClient().closeInstanceContext(zlc);
+                getProv().getLdapClient().closeContext(zlc);
             }
         }
     }

--- a/store/src/main/java/com/zimbra/cs/account/ldap/entry/LdapDynamicGroup.java
+++ b/store/src/main/java/com/zimbra/cs/account/ldap/entry/LdapDynamicGroup.java
@@ -182,13 +182,13 @@ public class LdapDynamicGroup extends DynamicGroup implements LdapEntry {
         ZLdapFilter filter = ZLdapFilterFactory.getInstance().allDynamicGroups();
         ZLdapContext zlcCompare = null;
         try {
-            zlcCompare = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
+            zlcCompare = prov.getLdapClient().getContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(
                     prov, null, domain, BASIC_ATTRS, new GroupMembershipUpdator(prov, zlcCompare,
                             acctDN, membership, adminGroupsOnly, true, false));
             searcher.doSearch(filter, DYNAMIC_GROUPS_TYPE);
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlcCompare);
+            prov.getLdapClient().closeContext(zlcCompare);
         }
         return membership;
     }
@@ -207,13 +207,13 @@ public class LdapDynamicGroup extends DynamicGroup implements LdapEntry {
         ZLdapFilter filter = ZLdapFilterFactory.getInstance().dynamicGroupByIds(ids.toArray(new String[0]));
         ZLdapContext zlcCompare = null;
         try {
-            zlcCompare = prov.getLdapClient().getInstanceContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
+            zlcCompare = prov.getLdapClient().getContext(LdapServerType.get(false /* useMaster */), LdapUsage.COMPARE);
             BySearchResultEntrySearcher searcher = new BySearchResultEntrySearcher(
                     prov, null, null, BASIC_ATTRS, new GroupMembershipUpdator(prov, zlcCompare,
                             acctDN, membership, adminGroupsOnly, customGroupsOnly, nonCustomGroupsOnly));
             searcher.doSearch(filter, DYNAMIC_GROUPS_TYPE);
         } finally {
-            prov.getLdapClient().closeInstanceContext(zlcCompare);
+            prov.getLdapClient().closeContext(zlcCompare);
         }
         return membership;
     }

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -16,6 +16,9 @@ public class LdapClient {
 
     private final UBIDLdapPoolConfig poolConfig;
 
+    // TODO: remove this, kept it for legacy zmconfigd, hopefully we will get rid of it
+    private static LdapClient zmconfigdLdapClient;
+    // TODO: remove this, kept it for legacy zmconfigd, hopefully we will get rid of itnewIns
     private LdapClient(UBIDLdapPoolConfig poolConfig) {
         this.poolConfig = poolConfig;
     }
@@ -36,14 +39,15 @@ public class LdapClient {
         return createNew(false);
     }
 
-    private static synchronized LdapClient newInstance() {
-         try {
-             return LdapClient.createNew();
-         } catch (LdapException e) {
-             Zimbra.halt("failed to initialize LDAP client", e);
-         }
-         // FIXME: unreachable code?
-         throw new RuntimeException("LdapCLient not available");
+    private static synchronized LdapClient getLdapClientForZmconfigd() {
+        if (zmconfigdLdapClient == null) {
+            try {
+                zmconfigdLdapClient = LdapClient.createNew();
+            } catch (LdapException e) {
+                Zimbra.halt("failed to initialize LDAP client", e);
+            }
+        }
+        return zmconfigdLdapClient;
     }
 
     public ZLdapContext toZLdapContext(ILdapContext ldapContext) {
@@ -101,7 +105,7 @@ public class LdapClient {
     public static ZLdapContext getContext(GenericLdapConfig ldapConfig,
             LdapUsage usage)
     throws ServiceException {
-        return newInstance().getExternalContextImpl(ldapConfig, usage);
+        return getLdapClientForZmconfigd().getExternalContextImpl(ldapConfig, usage);
     }
 
     public ZLdapContext getExternalContext(ExternalLdapConfig ldapConfig,

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -5,7 +5,6 @@
 
 package com.zimbra.cs.ldap;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.ldap.LdapServerConfig.ExternalLdapConfig;
 import com.zimbra.cs.ldap.LdapServerConfig.GenericLdapConfig;
@@ -14,9 +13,6 @@ import com.zimbra.cs.util.Zimbra;
 import java.util.Date;
 
 public class LdapClient {
-
-    private static LdapClient ldapClient;
-    private static boolean ALWAYS_USE_MASTER = false;
 
     private final UBIDLdapPoolConfig poolConfig;
 
@@ -36,48 +32,22 @@ public class LdapClient {
         return createNew(poolConfig);
     }
 
-    @VisibleForTesting
-    public static void setInstance(LdapClient client) {
-        ldapClient = client;
-    }
-
-    public static synchronized LdapClient getInstanceIfLDAPavailable() throws LdapException {
-        if (ldapClient == null) {
-            ldapClient = createNew(ALWAYS_USE_MASTER);
-        }
-        return ldapClient;
+    public static synchronized LdapClient createNew() throws LdapException {
+        return createNew(false);
     }
 
      private static synchronized LdapClient getInstance() {
          try {
-             LdapClient.getInstanceIfLDAPavailable();
+             return LdapClient.createNew();
          } catch (LdapException e) {
              Zimbra.halt("failed to initialize LDAP client", e);
          }
-         return ldapClient;
+         // FIXME: unreachable code?
+         throw new RuntimeException("LdapCLient not available");
      }
-
-    private static synchronized void unsetInstance() {
-        ldapClient = null;
-    }
-
-    public static synchronized void masterOnly() {
-        ALWAYS_USE_MASTER = true;
-
-        if (ldapClient != null) {
-            // already initialized
-            ldapClient.forceUsingMaster();
-        }
-    }
 
     public static void initialize() {
         LdapClient.getInstance();
-    }
-
-    // called from unittest only
-    public static void shutdown() {
-        LdapClient.getInstance().terminate();
-        unsetInstance();
     }
 
     @Deprecated
@@ -206,11 +176,11 @@ public class LdapClient {
         this.zimbraLdapAuthenticateImpl(bindDN, password);
     }
 
-    protected void terminate() {
+    public void terminate() {
         poolConfig.shutdown();
     }
 
-    protected void forceUsingMaster() {
+    public void forceUsingMaster() {
         poolConfig.setReplicaToMasterPool();
     }
 

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -18,7 +18,6 @@ public class LdapClient {
 
     // TODO: remove this, kept it for legacy zmconfigd, hopefully we will get rid of it
     private static LdapClient zmconfigdLdapClient;
-    // TODO: remove this, kept it for legacy zmconfigd, hopefully we will get rid of itnewIns
     private LdapClient(UBIDLdapPoolConfig poolConfig) {
         this.poolConfig = poolConfig;
     }

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -139,7 +139,7 @@ public class LdapClient {
         this.zimbraLdapAuthenticateImpl(bindDN, password);
     }
 
-    public void terminate() {
+    public void shutdown() {
         poolConfig.shutdown();
     }
 

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -36,7 +36,7 @@ public class LdapClient {
         return createNew(false);
     }
 
-     private static synchronized LdapClient getInstance() {
+    private static synchronized LdapClient newInstance() {
          try {
              return LdapClient.createNew();
          } catch (LdapException e) {
@@ -44,23 +44,6 @@ public class LdapClient {
          }
          // FIXME: unreachable code?
          throw new RuntimeException("LdapCLient not available");
-     }
-
-    public static void initialize() {
-        LdapClient.getInstance();
-    }
-
-    @Deprecated
-    public static ZLdapContext toZLdapContext(
-            com.zimbra.cs.account.Provisioning prov, ILdapContext ldapContext) {
-
-        // just a safety check, this should really not happen at this point
-        if (ldapContext != null && !(ldapContext instanceof ZLdapContext)) {
-            Zimbra.halt("ILdapContext instance is not ZLdapContext",
-                    ServiceException.FAILURE("internal error, wrong ldap context instance", null));
-        }
-
-        return (ZLdapContext)ldapContext;
     }
 
     public ZLdapContext toZLdapContext(ILdapContext ldapContext) {
@@ -74,40 +57,36 @@ public class LdapClient {
         return (ZLdapContext)ldapContext;
     }
 
-    /*
-     * ========================================================
-     * static methods just to short-hand the getInstance() call
-     * ========================================================
-     */
-    public static void waitForLdapServer() {
-        getInstance().waitForLdapServerImpl();
+    public void waitForLdapServer() {
+        while (true) {
+            ZLdapContext zlc = null;
+            try {
+                zlc = new ZLdapContext(poolConfig, LdapServerType.REPLICA, LdapUsage.PING);
+                break;
+            } catch (ServiceException e) {
+                // may be called at server startup when logging is not up yet.
+                System.err.println(new Date() + ": error communicating with LDAP (will retry)");
+                e.printStackTrace();
+                try {
+                    Thread.sleep(LdapConstants.CHECK_LDAP_SLEEP_MILLIS);
+                } catch (InterruptedException ie) {
+                }
+            } finally {
+                if (zlc != null) {
+                    zlc.closeContext(false);
+                }
+            }
+        }
     }
 
-    @Deprecated
-    public static ZLdapContext getContext(LdapUsage usage) throws ServiceException {
-        return getContext(LdapServerType.REPLICA, usage);
-    }
 
     public ZLdapContext getInstanceContext(LdapUsage usage) throws ServiceException {
         return this.getInstanceContext(LdapServerType.REPLICA, usage);
     }
 
-    @Deprecated
-    public static ZLdapContext getContext(LdapServerType serverType, LdapUsage usage)
-    throws ServiceException {
-        return getInstance().getContextImpl(serverType, usage);
-    }
-
     public ZLdapContext getInstanceContext(LdapServerType serverType, LdapUsage usage)
         throws ServiceException {
         return this.getContextImpl(serverType, usage);
-    }
-
-    @Deprecated
-    public static ZLdapContext getContext(LdapServerType serverType, boolean useConnPool,
-            LdapUsage usage)
-    throws ServiceException {
-        return getInstance().getContextImpl(serverType, useConnPool, usage);
     }
 
     public ZLdapContext getInstanceContext(LdapServerType serverType, boolean useConnPool,
@@ -122,14 +101,7 @@ public class LdapClient {
     public static ZLdapContext getContext(GenericLdapConfig ldapConfig,
             LdapUsage usage)
     throws ServiceException {
-        return getInstance().getExternalContextImpl(ldapConfig, usage);
-    }
-
-    @Deprecated
-    public static ZLdapContext getExternalContext(ExternalLdapConfig ldapConfig,
-            LdapUsage usage)
-    throws ServiceException {
-        return getInstance().getExternalContextImpl(ldapConfig, usage);
+        return newInstance().getExternalContextImpl(ldapConfig, usage);
     }
 
     public ZLdapContext getInstanceExternalContext(ExternalLdapConfig ldapConfig,
@@ -138,32 +110,20 @@ public class LdapClient {
         return this.getExternalContextImpl(ldapConfig, usage);
     }
 
-    @Deprecated
-    public static void closeContext(ZLdapContext lctxt) {
-        if (lctxt != null) {
-            lctxt.closeContext(false);
-        }
-    }
-
     public void closeInstanceContext(ZLdapContext lctxt) {
         if (lctxt != null) {
             lctxt.closeContext(false);
         }
     }
 
-    @Deprecated
-    public static ZMutableEntry createMutableEntry() {
-        return getInstance().createMutableEntryImpl();
-    }
-
     public ZMutableEntry createInstanceMutableEntry() {
         return this.createMutableEntryImpl();
     }
 
-    public static void externalLdapAuthenticate(String[] urls, boolean wantStartTLS,
+    public void externalLdapAuthenticate(String[] urls, boolean wantStartTLS,
             String bindDN, String password, String note)
     throws ServiceException {
-        getInstance().externalLdapAuthenticateImpl(urls, wantStartTLS,
+        this.externalLdapAuthenticateImpl(urls, wantStartTLS,
                 bindDN, password, note);
     }
 
@@ -187,28 +147,6 @@ public class LdapClient {
     protected ZLdapFilterFactory getLdapFilterFactoryInstance() throws LdapException {
         ZLdapFilterFactory.initialize();
         return new ZLdapFilterFactory();
-    }
-
-    protected void waitForLdapServerImpl() {
-        while (true) {
-            ZLdapContext zlc = null;
-            try {
-                zlc = new ZLdapContext(poolConfig, LdapServerType.REPLICA, LdapUsage.PING);
-                break;
-            } catch (ServiceException e) {
-                // may be called at server startup when logging is not up yet.
-                System.err.println(new Date() + ": error communicating with LDAP (will retry)");
-                e.printStackTrace();
-                try {
-                    Thread.sleep(LdapConstants.CHECK_LDAP_SLEEP_MILLIS);
-                } catch (InterruptedException ie) {
-                }
-            } finally {
-                if (zlc != null) {
-                    zlc.closeContext(false);
-                }
-            }
-        }
     }
 
     protected ZLdapContext getContextImpl(LdapServerType serverType, LdapUsage usage)

--- a/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
+++ b/store/src/main/java/com/zimbra/cs/ldap/LdapClient.java
@@ -80,16 +80,16 @@ public class LdapClient {
     }
 
 
-    public ZLdapContext getInstanceContext(LdapUsage usage) throws ServiceException {
-        return this.getInstanceContext(LdapServerType.REPLICA, usage);
+    public ZLdapContext getContext(LdapUsage usage) throws ServiceException {
+        return this.getContext(LdapServerType.REPLICA, usage);
     }
 
-    public ZLdapContext getInstanceContext(LdapServerType serverType, LdapUsage usage)
+    public ZLdapContext getContext(LdapServerType serverType, LdapUsage usage)
         throws ServiceException {
         return this.getContextImpl(serverType, usage);
     }
 
-    public ZLdapContext getInstanceContext(LdapServerType serverType, boolean useConnPool,
+    public ZLdapContext getContext(LdapServerType serverType, boolean useConnPool,
         LdapUsage usage)
         throws ServiceException {
         return this.getContextImpl(serverType, useConnPool, usage);
@@ -104,19 +104,19 @@ public class LdapClient {
         return newInstance().getExternalContextImpl(ldapConfig, usage);
     }
 
-    public ZLdapContext getInstanceExternalContext(ExternalLdapConfig ldapConfig,
+    public ZLdapContext getExternalContext(ExternalLdapConfig ldapConfig,
         LdapUsage usage)
         throws ServiceException {
         return this.getExternalContextImpl(ldapConfig, usage);
     }
 
-    public void closeInstanceContext(ZLdapContext lctxt) {
+    public void closeContext(ZLdapContext lctxt) {
         if (lctxt != null) {
             lctxt.closeContext(false);
         }
     }
 
-    public ZMutableEntry createInstanceMutableEntry() {
+    public ZMutableEntry createMutableEntry() {
         return this.createMutableEntryImpl();
     }
 

--- a/store/src/main/java/com/zimbra/cs/nginx/NginxLookupLdapHelper.java
+++ b/store/src/main/java/com/zimbra/cs/nginx/NginxLookupLdapHelper.java
@@ -38,13 +38,13 @@ public class NginxLookupLdapHelper extends AbstractNginxLookupLdapHelper {
 
     @Override
     ILdapContext getLdapContext() throws ServiceException {
-        return prov.getLdapClient().getInstanceContext(LdapUsage.NGINX_LOOKUP);
+        return prov.getLdapClient().getContext(LdapUsage.NGINX_LOOKUP);
     }
 
     @Override
     void closeLdapContext(ILdapContext ldapContext) {
         ZLdapContext zlc = prov.getLdapClient().toZLdapContext(ldapContext);
-        prov.getLdapClient().closeInstanceContext(zlc);
+        prov.getLdapClient().closeContext(zlc);
     }
 
     @Override

--- a/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
+++ b/store/src/main/java/com/zimbra/cs/util/ProxyPurgeUtil.java
@@ -258,7 +258,7 @@ public static void run(String[] args) throws ServiceException, CommandExitExcept
         // this logic works for for all cases account=addr@<alias domain> or alias-name@<alias domain>
         if (prov instanceof LdapProvisioning) {
           LdapProvisioning ldapProv = (LdapProvisioning) prov;
-          ZLdapContext ldpCtx = ldapProv.getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
+          ZLdapContext ldpCtx = ldapProv.getLdapClient().getContext(LdapServerType.MASTER, LdapUsage.GET_DOMAIN);
           try {
             List<String> aliasDomainIds = ldapProv.getEmptyAliasDomainIds(ldpCtx,
                 d, false);
@@ -277,7 +277,7 @@ public static void run(String[] args) throws ServiceException, CommandExitExcept
               }
             }
           } finally {
-            ldapProv.getLdapClient().closeInstanceContext(ldpCtx);
+            ldapProv.getLdapClient().closeContext(ldpCtx);
           }
         }
 

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
@@ -22,7 +22,6 @@ import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.index.IndexStore;
 import com.zimbra.cs.index.ZimbraAnalyzer;
 import com.zimbra.cs.ldap.LdapClient;
-import com.zimbra.cs.ldap.LdapClient;
 import com.zimbra.cs.ldap.unboundid.UBIDLdapPoolConfig;
 import com.zimbra.cs.mailbox.MailboxManager;
 import com.zimbra.cs.mailbox.ScheduledTaskManager;
@@ -46,6 +45,7 @@ public class MailboxSetupHelper {
 	private final int ldapPort;
 
 	private final InMemoryLdapServer inMemoryLdapServer;
+	private LdapClient ldapClient;
 
 	private MailboxSetupHelper(Path mailboxHome, Path tmpDirectory, String timezoneFilePath, String datasourceFilePath, int ldapPort, InMemoryLdapServer inMemoryLdapServer) {
 		this.mailboxHome = mailboxHome;
@@ -111,9 +111,8 @@ public class MailboxSetupHelper {
 
 		LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
 		final UBIDLdapPoolConfig poolConfig = UBIDLdapPoolConfig.createNewPool(true);
-		final LdapClient client = LdapClient.createNew(poolConfig);
-		LdapClient.setInstance(client);
-		Provisioning.setInstance(new LdapProvisioningWithMockMime(client));
+		ldapClient = LdapClient.createNew(poolConfig);
+		Provisioning.setInstance(new LdapProvisioningWithMockMime(ldapClient));
 		this.initData(mailboxTestData);
 		HSQLDB.createDatabase(getVolumeDirectory());
 		DbPool.startup();
@@ -169,7 +168,7 @@ public class MailboxSetupHelper {
 		DbPool.shutDownAndClear();
 		inMemoryLdapServer.shutDown(true);
 		// TODO: avoid shutting down with explicit static method calls
-		LdapClient.shutdown();
+		ldapClient.terminate();
 		FileUtils.deleteDirectory(mailboxHome.toFile());
 		FileUtils.deleteDirectory(mailboxTmpDirectory.toFile());
 	}

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
@@ -168,7 +168,7 @@ public class MailboxSetupHelper {
 		DbPool.shutDownAndClear();
 		inMemoryLdapServer.shutDown(true);
 		// TODO: avoid shutting down with explicit static method calls
-		ldapClient.terminate();
+		ldapClient.shutdown();
 		FileUtils.deleteDirectory(mailboxHome.toFile());
 		FileUtils.deleteDirectory(mailboxTmpDirectory.toFile());
 	}


### PR DESCRIPTION
- can still set master pool by accessing it throughLdapProvisioning alwaysUseMaster
- static methods are only factories, user is responsible of tearing up/down the ldap client
- removed static methods of LdapClient
Requires updating the ZAL: https://github.com/zextras/zal/pull/116