### PR TITLE
refactor: [CO-3760] NginxLookupExtension is internally managed, no need to register it in static

### DIFF
--- a/store/src/main/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/store/src/main/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -93,13 +93,6 @@ public class NginxLookupExtension implements ZimbraExtension {
                 REV_PROXY_MAILHOST_EXTRA_ATTRS.add(Provisioning.A_zimbraExternalPop3SSLHostname);
                 REV_PROXY_MAILHOST_EXTRA_ATTRS.add(Provisioning.A_zimbraExternalImapHostname);
                 REV_PROXY_MAILHOST_EXTRA_ATTRS.add(Provisioning.A_zimbraExternalImapSSLHostname);
-                ExtensionUtil.initAllMatching(new NginxLookupExtensionMatcher());
-    }
-    public static class NginxLookupExtensionMatcher implements ExtensionUtil.ExtensionMatcher {
-        @Override
-        public boolean matches(ZimbraExtension ext) {
-            return true;
-        }
     }
 
     @Override

--- a/store/src/main/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/store/src/main/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -29,7 +29,6 @@ import com.zimbra.cs.account.ldap.LdapProv;
 import com.zimbra.cs.extension.ExtensionDispatcherServlet;
 import com.zimbra.cs.extension.ExtensionException;
 import com.zimbra.cs.extension.ExtensionHttpHandler;
-import com.zimbra.cs.extension.ExtensionUtil;
 import com.zimbra.cs.extension.ZimbraExtension;
 import com.zimbra.cs.ldap.ILdapContext;
 import com.zimbra.cs.ldap.ZLdapFilter;


### PR DESCRIPTION
Before moving the code of the extension in mailbox, the extension was loaded dynamically so it was auto-registering. Now the mailbox already registers it in Zimbra#init, so there is no need to register it in two places