### PR TITLE
refactor: [CO-3760] dbpool

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/health/DatabaseServiceDependency.java
+++ b/store/src/main/java/com/zextras/mailbox/health/DatabaseServiceDependency.java
@@ -46,7 +46,7 @@ public class DatabaseServiceDependency extends ServiceDependency {
 
   private boolean doCheckStatus() {
     var selectStatement = "com.zimbra.cs.db.HSQLDB".equals(LC.zimbra_class_database.value()) ? "SELECT 1 FROM (VALUES(0)) AS t" : "SELECT 1";
-    try (DbConnection connection = dbPool.getDatabaseConnection();
+    try (DbConnection connection = dbPool.getConnectionInstance();
         PreparedStatement preparedStatement = connection.prepareStatement(selectStatement);
         ResultSet resultSet = preparedStatement.executeQuery()) {
       resultSet.next();

--- a/store/src/main/java/com/zextras/mailbox/servlet/HealthServletModule.java
+++ b/store/src/main/java/com/zextras/mailbox/servlet/HealthServletModule.java
@@ -25,7 +25,7 @@ public class HealthServletModule extends ServletModule {
   @Provides
   @Singleton
   DbPool provideDatabasePool() {
-    return DbPool.newPool();
+    return DbPool.global();
   }
 
   @Provides

--- a/store/src/main/java/com/zextras/mailbox/servlet/HealthServletModule.java
+++ b/store/src/main/java/com/zextras/mailbox/servlet/HealthServletModule.java
@@ -25,7 +25,7 @@ public class HealthServletModule extends ServletModule {
   @Provides
   @Singleton
   DbPool provideDatabasePool() {
-    return new DbPool();
+    return DbPool.newPool();
   }
 
   @Provides

--- a/store/src/main/java/com/zimbra/cs/db/Db.java
+++ b/store/src/main/java/com/zimbra/cs/db/Db.java
@@ -88,6 +88,10 @@ public abstract class Db {
         return getInstance().supportsCapability(capability);
     }
 
+    public boolean instanceSupports(Db.Capability capability) {
+        return this.supportsCapability(capability);
+    }
+
     abstract boolean supportsCapability(Db.Capability capability);
 
     /** Returns whether the given {@link SQLException} is an instance of the

--- a/store/src/main/java/com/zimbra/cs/db/DbPool.java
+++ b/store/src/main/java/com/zimbra/cs/db/DbPool.java
@@ -38,10 +38,104 @@ public class DbPool {
     private static GenericObjectPool sConnectionPool;
     private static boolean sIsInitialized;
 
+
     private static boolean isShutdown;
     private static boolean isUsageWarningEnabled = true;
 
     static ValueCounter<String> sConnectionStackCounter = new ValueCounter<>();
+
+    // instance level
+    private final Db db;
+    private final PoolingDataSource connectionPool;
+    private final GenericObjectPool poolManager;
+
+    private DbPool(Db db, PoolingDataSource connectionPool, GenericObjectPool poolManager) {
+        this.db = db;
+        this.connectionPool = connectionPool;
+        this.poolManager = poolManager;
+    }
+
+    public static DbPool newPool(Db db) {
+        PoolConfig pconfig = db.getPoolConfig();
+        var connectionPool = new GenericObjectPool(null, pconfig.mPoolSize, pconfig.whenExhaustedAction, -1, pconfig.mPoolSize);
+        ConnectionFactory cfac = ZimbraConnectionFactory.getConnectionFactory(pconfig);
+
+        boolean defAutoCommit = false, defReadOnly = false;
+        new PoolableConnectionFactory(cfac, connectionPool, null, null, defReadOnly, defAutoCommit);
+
+        PoolingDataSource pds = new PoolingDataSource(connectionPool);
+        pds.setAccessToUnderlyingConnectionAllowed(true);
+
+        final DbPool dbPool = new DbPool(db, pds, connectionPool);
+
+        System.setProperty("jdbc.drivers", pconfig.mDriverClassName);
+
+        sRootUrl = pconfig.mRootUrl;
+        sLoggerRootUrl = pconfig.mLoggerUrl;
+        waitForDatabase(dbPool);
+        return dbPool;
+    }
+
+    public static DbPool newPool() {
+        return newPool(Db.getInstance());
+    }
+
+    public DbConnection getConnectionInstance() throws ServiceException {
+        return getConnectionInstance(null);
+    }
+
+    public DbConnection getConnectionInstance(Mailbox mbox) throws ServiceException {
+        Integer mboxId = mbox != null ? mbox.getId() : -1; //-1 == zimbra db and/or initialization where mbox isn't known yet
+        try {
+            long start = ZimbraPerf.STOPWATCH_DB_CONN.start();
+
+            // If the connection pool is overutilized, warn about potential leaks
+            PoolingDataSource pool = this.connectionPool;
+            // TODO: think about warn about overutilized connections
+            // checkPoolUsage();
+
+            Connection dbconn = null;
+            DbConnection conn = null;
+            try {
+                dbconn = pool.getConnection();
+
+                if (dbconn.getAutoCommit() != false)
+                    dbconn.setAutoCommit(false);
+
+                // We want READ COMMITTED transaction isolation level for duplicate
+                // handling code in BucketBlobStore.newBlobInfo().
+                if (db.instanceSupports(Db.Capability.READ_COMMITTED_ISOLATION))
+                    dbconn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+
+                conn = new DbConnection(dbconn, mboxId);
+            } catch (SQLException e) {
+                try {
+                    if (dbconn != null && !dbconn.isClosed())
+                        dbconn.close();
+                } catch (SQLException e2) {
+                    ZimbraLog.sqltrace.warn("DB connection close caught exception", e);
+                }
+                throw ServiceException.FAILURE("getting database connection", e);
+            }
+
+            // If we're debugging, update the counter with the current stack trace
+            if (ZimbraLog.dbconn.isDebugEnabled()) {
+                Throwable t = new Throwable();
+                conn.setStackTrace(t);
+
+                String stackTrace = SystemUtil.getStackTrace(t);
+                synchronized (sConnectionStackCounter) {
+                    sConnectionStackCounter.increment(stackTrace);
+                }
+            }
+
+            ZimbraPerf.STOPWATCH_DB_CONN.stop(start);
+            return conn;
+        } catch (ServiceException se) {
+            //if connection open fails unlock
+            throw se;
+        }
+    }
 
     public static class DbConnection implements AutoCloseable {
         private final Connection connection;
@@ -215,6 +309,25 @@ public class DbPool {
         waitForDatabase();
     }
 
+    private static void waitForDatabase(DbPool dbPool) {
+        DbConnection conn = null;
+        final int RETRY_SECONDS = 5;
+
+        while (conn == null) {
+            try {
+                conn = dbPool.getConnectionInstance();
+            } catch (ServiceException e) {
+                ZimbraLog.misc.warn("Could not establish a connection to the database.  Retrying in %d seconds.",
+                    RETRY_SECONDS, e);
+                try {
+                    Thread.sleep(RETRY_SECONDS * 1000);
+                } catch (InterruptedException e2) {
+                }
+            }
+        }
+
+        DbPool.quietClose(conn);
+    }
     private static void waitForDatabase() {
         DbConnection conn = null;
         final int RETRY_SECONDS = 5;
@@ -515,6 +628,14 @@ public class DbPool {
     public static synchronized void shutdown() throws Exception {
         isShutdown = true;
         close();
+    }
+
+    public void shutdownInstance() throws Exception {
+        synchronized (this) {
+            if (this.poolManager != null) {
+                poolManager.close();
+            }
+        }
     }
 
     @VisibleForTesting

--- a/store/src/main/java/com/zimbra/cs/db/DbPool.java
+++ b/store/src/main/java/com/zimbra/cs/db/DbPool.java
@@ -32,30 +32,27 @@ import org.apache.commons.pool.impl.GenericObjectPool;
  */
 public class DbPool {
 
-    private static PoolingDataSource sPoolingDataSource;
-    private static String sRootUrl;
-    private static String sLoggerRootUrl;
-    private static GenericObjectPool sConnectionPool;
-    private static boolean sIsInitialized;
-
-
-    private static boolean isShutdown;
+    private static DbPool dbPool;
     private static boolean isUsageWarningEnabled = true;
 
     static ValueCounter<String> sConnectionStackCounter = new ValueCounter<>();
 
     // instance level
     private final Db db;
-    private final PoolingDataSource connectionPool;
-    private final GenericObjectPool poolManager;
+    private final PoolingDataSource dataSource;
+    private final GenericObjectPool pool;
+    private final String sRootUrl;
+    private final String sLoggerRootUrl;
 
-    private DbPool(Db db, PoolingDataSource connectionPool, GenericObjectPool poolManager) {
+    private DbPool(Db db, PoolingDataSource dataSource, GenericObjectPool pool) {
         this.db = db;
-        this.connectionPool = connectionPool;
-        this.poolManager = poolManager;
+        this.dataSource = dataSource;
+        this.pool = pool;
+        sRootUrl = db.getPoolConfig().mRootUrl;
+        sLoggerRootUrl = db.getPoolConfig().mLoggerUrl;
     }
 
-    public static DbPool newPool(Db db) {
+    static DbPool newPool(Db db) {
         PoolConfig pconfig = db.getPoolConfig();
         var connectionPool = new GenericObjectPool(null, pconfig.mPoolSize, pconfig.whenExhaustedAction, -1, pconfig.mPoolSize);
         ConnectionFactory cfac = ZimbraConnectionFactory.getConnectionFactory(pconfig);
@@ -69,14 +66,14 @@ public class DbPool {
         final DbPool dbPool = new DbPool(db, pds, connectionPool);
 
         System.setProperty("jdbc.drivers", pconfig.mDriverClassName);
-
-        sRootUrl = pconfig.mRootUrl;
-        sLoggerRootUrl = pconfig.mLoggerUrl;
         waitForDatabase(dbPool);
         return dbPool;
     }
 
-    public static DbPool newPool() {
+	/**
+	 * @return a new pool for local usage. No singleton.
+	 */
+    private static DbPool newPool() {
         return newPool(Db.getInstance());
     }
 
@@ -90,14 +87,12 @@ public class DbPool {
             long start = ZimbraPerf.STOPWATCH_DB_CONN.start();
 
             // If the connection pool is overutilized, warn about potential leaks
-            PoolingDataSource pool = this.connectionPool;
-            // TODO: think about warn about overutilized connections
-            // checkPoolUsage();
+            checkPoolUsage();
 
             Connection dbconn = null;
             DbConnection conn = null;
             try {
-                dbconn = pool.getConnection();
+                dbconn = this.dataSource.getConnection();
 
                 if (dbconn.getAutoCommit() != false)
                     dbconn.setAutoCommit(false);
@@ -291,22 +286,14 @@ public class DbPool {
     /**
      * Initializes the connection pool.  Applications that access the
      * database must call this method before calling {@link DbPool#getConnection}.
-     * If database was previously shutdown then {@link #isShutdown} is set to false.
+     * Allocates a global pool as singleton.
      *
      */
-    public static synchronized void startup() {
-        isShutdown = false;
-        if (isInitialized()) {
-            return;
+    public static synchronized DbPool global() {
+        if (dbPool == null) {
+            dbPool = newPool();
         }
-        PoolConfig pconfig = Db.getInstance().getPoolConfig();
-
-        System.setProperty("jdbc.drivers", pconfig.mDriverClassName);
-
-        sRootUrl = pconfig.mRootUrl;
-        sLoggerRootUrl = pconfig.mLoggerUrl;
-        sIsInitialized = true;
-        waitForDatabase();
+        return dbPool;
     }
 
     private static void waitForDatabase(DbPool dbPool) {
@@ -328,28 +315,9 @@ public class DbPool {
 
         DbPool.quietClose(conn);
     }
-    private static void waitForDatabase() {
-        DbConnection conn = null;
-        final int RETRY_SECONDS = 5;
-
-        while (conn == null) {
-            try {
-                conn = DbPool.getConnection();
-            } catch (ServiceException e) {
-                ZimbraLog.misc.warn("Could not establish a connection to the database.  Retrying in %d seconds.",
-                    RETRY_SECONDS, e);
-                try {
-                    Thread.sleep(RETRY_SECONDS * 1000);
-                } catch (InterruptedException e2) {
-                }
-            }
-        }
-
-        DbPool.quietClose(conn);
-    }
 
     private static boolean isInitialized() {
-        return sIsInitialized;
+        return dbPool != null;
     }
 
     /**
@@ -362,32 +330,6 @@ public class DbPool {
         } catch (ServiceException e) {
             ZimbraLog.system.warn("Unable to set slow SQL threshold.", e);
         }
-    }
-
-    /** Initializes the connection pool. */
-    private static synchronized PoolingDataSource getPool() {
-        if (isShutdown)
-            throw new RuntimeException("DbPool permanently shutdown");
-
-        if (sPoolingDataSource != null)
-            return sPoolingDataSource;
-
-        PoolConfig pconfig = Db.getInstance().getPoolConfig();
-        sConnectionPool = new GenericObjectPool(null, pconfig.mPoolSize, pconfig.whenExhaustedAction, -1, pconfig.mPoolSize);
-        ConnectionFactory cfac = ZimbraConnectionFactory.getConnectionFactory(pconfig);
-
-        boolean defAutoCommit = false, defReadOnly = false;
-        new PoolableConnectionFactory(cfac, sConnectionPool, null, null, defReadOnly, defAutoCommit);
-
-        PoolingDataSource pds = new PoolingDataSource(sConnectionPool);
-        pds.setAccessToUnderlyingConnectionAllowed(true);
-
-        sPoolingDataSource = pds;
-
-        if (pconfig.mSupportsStatsCallback)
-            ZimbraPerf.addStatsCallback(new DbStats());
-
-        return sPoolingDataSource;
     }
 
     /**
@@ -418,60 +360,13 @@ public class DbPool {
         if (!isInitialized()) {
             throw ServiceException.FAILURE("Database connection pool not initialized.", null);
         }
-        Integer mboxId = mbox != null ? mbox.getId() : -1; //-1 == zimbra db and/or initialization where mbox isn't known yet
-        try {
-            long start = ZimbraPerf.STOPWATCH_DB_CONN.start();
-
-            // If the connection pool is overutilized, warn about potential leaks
-            PoolingDataSource pool = getPool();
-            checkPoolUsage();
-
-            Connection dbconn = null;
-            DbConnection conn = null;
-            try {
-                dbconn = pool.getConnection();
-
-                if (dbconn.getAutoCommit() != false)
-                    dbconn.setAutoCommit(false);
-
-                // We want READ COMMITTED transaction isolation level for duplicate
-                // handling code in BucketBlobStore.newBlobInfo().
-                if (Db.supports(Db.Capability.READ_COMMITTED_ISOLATION))
-                    dbconn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
-
-                conn = new DbConnection(dbconn, mboxId);
-            } catch (SQLException e) {
-                try {
-                    if (dbconn != null && !dbconn.isClosed())
-                        dbconn.close();
-                } catch (SQLException e2) {
-                    ZimbraLog.sqltrace.warn("DB connection close caught exception", e);
-                }
-                throw ServiceException.FAILURE("getting database connection", e);
-            }
-
-            // If we're debugging, update the counter with the current stack trace
-            if (ZimbraLog.dbconn.isDebugEnabled()) {
-                Throwable t = new Throwable();
-                conn.setStackTrace(t);
-
-                String stackTrace = SystemUtil.getStackTrace(t);
-                synchronized (sConnectionStackCounter) {
-                    sConnectionStackCounter.increment(stackTrace);
-                }
-            }
-
-            ZimbraPerf.STOPWATCH_DB_CONN.stop(start);
-            return conn;
-        } catch (ServiceException se) {
-            //if connection open fails unlock
-            throw se;
-        }
+        return dbPool.getConnectionInstance(mbox);
     }
 
-    private static void checkPoolUsage() {
-        int numActive = sConnectionPool.getNumActive();
-        int maxActive = sConnectionPool.getMaxActive();
+    private void checkPoolUsage() {
+        final GenericObjectPool poolStats = this.pool;
+        int numActive = poolStats.getNumActive();
+        int maxActive = poolStats.getMaxActive();
 
         if (numActive <= maxActive * 0.75)
             return;
@@ -512,7 +407,8 @@ public class DbPool {
         try {
             String user = LC.zimbra_mysql_user.value();
             String pwd = LC.zimbra_mysql_password.value();
-            Connection conn = DriverManager.getConnection(sRootUrl + "?user=" + user + "&password=" + pwd);
+            Connection conn = DriverManager.getConnection(
+                dbPool.sRootUrl + "?user=" + user + "&password=" + pwd);
             conn.setAutoCommit(false);
             return new DbConnection(conn);
         } catch (SQLException e) {
@@ -530,7 +426,7 @@ public class DbPool {
         try {
             String user = LC.zimbra_mysql_user.value();
             String pwd = null;
-            Connection conn = DriverManager.getConnection(sLoggerRootUrl + "?user=" + user + "&password=" + pwd);
+            Connection conn = DriverManager.getConnection(dbPool.sLoggerRootUrl + "?user=" + user + "&password=" + pwd);
             return new DbConnection(conn);
         } catch (SQLException e) {
             throw ServiceException.FAILURE("getting database logger connection", e);
@@ -608,42 +504,25 @@ public class DbPool {
      * Returns the number of connections currently in use.
      */
     public static int getSize() {
-        return sConnectionPool.getNumActive();
-    }
-
-    /**
-     * This is only to be used by DbOfflineMigration to completely close connection to Derby.
-     * Note that this doesn't permanently shutdown.  A new getPool() call will restart connections.
-     *
-     * @throws Exception
-     */
-    static synchronized void close() throws Exception {
-        if (sConnectionPool != null) {
-            sConnectionPool.close();
-            sConnectionPool = null;
-        }
-        sPoolingDataSource = null;
+        return dbPool.pool.getNumActive();
     }
 
     public static synchronized void shutdown() throws Exception {
-        isShutdown = true;
-        close();
+        dbPool.shutdownInstance();
     }
 
     public void shutdownInstance() throws Exception {
         synchronized (this) {
-            if (this.poolManager != null) {
-                poolManager.close();
+            if (this.pool != null) {
+                pool.close();
             }
         }
     }
 
     @VisibleForTesting
     public static synchronized void shutDownAndClear() throws Exception {
-        // TODO: avoid all this static an singleton usages
-        DbPool.shutdown();
-        isShutdown = false;
-        sIsInitialized = false;
+        dbPool.shutdownInstance();
+        dbPool = null;
         ZimbraConnectionFactory.close();
         Db.setInstance(null);
     }

--- a/store/src/main/java/com/zimbra/cs/db/DbPool.java
+++ b/store/src/main/java/com/zimbra/cs/db/DbPool.java
@@ -54,6 +54,7 @@ public class DbPool {
 
     static DbPool newPool(Db db) {
         PoolConfig pconfig = db.getPoolConfig();
+        System.setProperty("jdbc.drivers", pconfig.mDriverClassName);
         var connectionPool = new GenericObjectPool(null, pconfig.mPoolSize, pconfig.whenExhaustedAction, -1, pconfig.mPoolSize);
         ConnectionFactory cfac = ZimbraConnectionFactory.getConnectionFactory(pconfig);
 
@@ -65,7 +66,7 @@ public class DbPool {
 
         final DbPool dbPool = new DbPool(db, pds, connectionPool);
 
-        System.setProperty("jdbc.drivers", pconfig.mDriverClassName);
+
         waitForDatabase(dbPool);
         return dbPool;
     }
@@ -509,6 +510,7 @@ public class DbPool {
 
     public static synchronized void shutdown() throws Exception {
         dbPool.shutdownInstance();
+        dbPool = null;
     }
 
     public void shutdownInstance() throws Exception {
@@ -521,8 +523,7 @@ public class DbPool {
 
     @VisibleForTesting
     public static synchronized void shutDownAndClear() throws Exception {
-        dbPool.shutdownInstance();
-        dbPool = null;
+        shutdown();
         ZimbraConnectionFactory.close();
         Db.setInstance(null);
     }

--- a/store/src/main/java/com/zimbra/cs/mailbox/util/MetadataDump.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/util/MetadataDump.java
@@ -348,7 +348,7 @@ public final class MetadataDump {
             }
 
             // Get data from db.
-            DbPool.startup();
+            DbPool.global();
             DbConnection conn = null;
 
             try {

--- a/store/src/main/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
+++ b/store/src/main/java/com/zimbra/cs/redolog/util/PlaybackUtil.java
@@ -383,7 +383,7 @@ public class PlaybackUtil {
             loggerConfig.removeAppender(consoleAppender.get().getName());
             }
 
-        DbPool.startup();
+        DbPool.global();
         Zimbra.startupCLI();
     }
 

--- a/store/src/main/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
+++ b/store/src/main/java/com/zimbra/cs/store/file/BlobConsistencyUtil.java
@@ -185,7 +185,7 @@ public class BlobConsistencyUtil {
             mailboxIds = getAllMailboxIds(prov);
         }
         try {
-        	DbPool.startup();
+        	DbPool.global();
         	for (int mboxId : mailboxIds) {
         		System.out.println("Checking mailbox " + mboxId + ".");
         		checkMailbox(mboxId, prov);

--- a/store/src/main/java/com/zimbra/cs/util/Zimbra.java
+++ b/store/src/main/java/com/zimbra/cs/util/Zimbra.java
@@ -205,7 +205,7 @@ public final class Zimbra {
 
     ZimbraPerf.prepare(ZimbraPerf.ServerID.ZIMBRA);
 
-    DbPool.startup();
+    DbPool.global();
 
     app.initializeZimbraDb(forMailboxd);
 

--- a/store/src/test/java/com/zextras/mailbox/health/DatabaseServiceDependencyTest.java
+++ b/store/src/test/java/com/zextras/mailbox/health/DatabaseServiceDependencyTest.java
@@ -44,7 +44,7 @@ class DatabaseServiceDependencyTest {
     assertHealthy(databaseService);
 
     timer.timeElapsed(CacheIntervalMillis_1000 + 500L);
-    Mockito.when(dbPool.getDatabaseConnection())
+    Mockito.when(dbPool.getConnectionInstance())
         .thenThrow(ServiceException.FAILURE("Oops, cannot open connection to database"));
 
     assertUnhealthy(databaseService);
@@ -63,7 +63,7 @@ class DatabaseServiceDependencyTest {
     assertHealthy(databaseService);
 
     timer.timeElapsed(500L);
-    Mockito.when(dbPool.getDatabaseConnection())
+    Mockito.when(dbPool.getConnectionInstance())
         .thenThrow(ServiceException.FAILURE("Ooops, query failed"));
 
     assertHealthy(databaseService);
@@ -73,7 +73,7 @@ class DatabaseServiceDependencyTest {
   void shouldNotBeLiveAndReadyIfDbPoolConnectionCannotBeTaken() throws Exception {
     final DbPool dbPool = Mockito.mock(DbPool.class);
     final ServiceException dbConnectionException = Mockito.mock(ServiceException.class);
-    Mockito.when(dbPool.getDatabaseConnection()).thenThrow(dbConnectionException);
+    Mockito.when(dbPool.getConnectionInstance()).thenThrow(dbConnectionException);
 
     final DatabaseServiceDependency databaseService =
         new DatabaseServiceDependency(dbPool, System::currentTimeMillis);
@@ -85,7 +85,7 @@ class DatabaseServiceDependencyTest {
   void shouldNotBeLiveAndReadyIfPrepareStatementThrowsSqlException() throws Exception {
     final DbPool dbPool = Mockito.mock(DbPool.class);
     final DbConnection dbConnection = Mockito.mock(DbConnection.class);
-    Mockito.when(dbPool.getDatabaseConnection()).thenReturn(dbConnection);
+    Mockito.when(dbPool.getConnectionInstance()).thenReturn(dbConnection);
     Mockito.when(dbConnection.prepareStatement(anyString())).thenThrow(new SQLException());
 
     final DatabaseServiceDependency databaseService =
@@ -109,7 +109,7 @@ class DatabaseServiceDependencyTest {
     final DbConnection dbConnection = Mockito.mock(DbConnection.class);
     final PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
     final ResultSet resultSet = Mockito.mock(ResultSet.class);
-    Mockito.when(dbPool.getDatabaseConnection()).thenReturn(dbConnection);
+    Mockito.when(dbPool.getConnectionInstance()).thenReturn(dbConnection);
     Mockito.when(dbConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
     Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
     Mockito.when(resultSet.next()).thenReturn(true);

--- a/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
+++ b/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
@@ -84,6 +84,7 @@ public class HealthServletTest {
 
   @Test
   void liveShouldReturn500WhenDBConnectionFailing() throws Exception {
+    shutdownDb();
     try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
       final HttpGet httpGet = new HttpGet(server.getURI() + "/health/live");
 
@@ -110,6 +111,7 @@ public class HealthServletTest {
 
   @Test
   void readyShouldReturn500WhenDBConnectionFailing() throws Exception {
+    shutdownDb();
     try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
       final HttpGet httpGet = new HttpGet(server.getURI() + "/health/ready");
 
@@ -150,6 +152,11 @@ public class HealthServletTest {
     } finally {
       DbPool.shutDownAndClear();
     }
+  }
+
+
+  private static void shutdownDb() throws Exception {
+    DbPool.shutdown();
   }
 
   private interface ThrowingRunnable {

--- a/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
+++ b/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
@@ -156,7 +156,7 @@ public class HealthServletTest {
 
 
   private static void shutdownDb() throws Exception {
-    DbPool.shutdown();
+    DbPool.shutDownAndClear();
   }
 
   private interface ThrowingRunnable {

--- a/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
+++ b/store/src/test/java/com/zextras/mailbox/servlet/HealthServletTest.java
@@ -142,7 +142,7 @@ public class HealthServletTest {
   }
 
   private void withDb(ThrowingRunnable runnable) throws Exception {
-    DbPool.startup();
+    DbPool.global();
     try {
       runnable.run();
     } catch (Exception e) {

--- a/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/util/MailboxSetupHelper.java
@@ -115,7 +115,7 @@ public class MailboxSetupHelper {
 		Provisioning.setInstance(new LdapProvisioningWithMockMime(ldapClient));
 		this.initData(mailboxTestData);
 		HSQLDB.createDatabase(getVolumeDirectory());
-		DbPool.startup();
+		DbPool.global();
 		MailboxManager.setInstance(new MailboxManager());
 		RedoLogProvider.setInstance(new DefaultRedoLogProvider());
 		RedoLogProvider.getInstance().startup();

--- a/store/src/test/java/com/zimbra/cs/db/DbMailboxTest.java
+++ b/store/src/test/java/com/zimbra/cs/db/DbMailboxTest.java
@@ -30,7 +30,7 @@ public class DbMailboxTest {
 	public static void init() throws Exception {
 		HSQLDB.createDatabase(LC.zimbra_home.value() + "/build/test");
 		LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
-		DbPool.startup();
+		DbPool.global();
 	}
 
 	@BeforeEach

--- a/store/src/test/java/com/zimbra/cs/db/DbPoolTest.java
+++ b/store/src/test/java/com/zimbra/cs/db/DbPoolTest.java
@@ -1,0 +1,16 @@
+package com.zimbra.cs.db;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("e2e")
+class DbPoolTest {
+
+	@Test
+	void whenPoolShutdown_CannotAcquireConnection() throws Exception {
+		DbPool dbPool = DbPool.newPool(new HSQLDB());
+		dbPool.shutdownInstance();
+		Assertions.assertThrows(IllegalStateException.class, dbPool::getConnectionInstance);
+	}
+}

--- a/store/src/test/java/com/zimbra/cs/db/HSQLDB.java
+++ b/store/src/test/java/com/zimbra/cs/db/HSQLDB.java
@@ -34,15 +34,6 @@ import org.hsqldb.cmdline.SqlFile;
  */
 public class HSQLDB extends Db {
 
-
-    @Deprecated
-    public static void createDatabase() throws Exception {
-        final String volumeDirectory = LC.zimbra_home.value() + "/build/test";
-        final String path = new File(volumeDirectory).getAbsolutePath();
-        createDatabase(path);
-    }
-
-
     /**
      * Populates ZIMBRA and MBOXGROUP1 schema.
      */

--- a/store/src/test/java/com/zimbra/cs/db/VersionsTest.java
+++ b/store/src/test/java/com/zimbra/cs/db/VersionsTest.java
@@ -26,7 +26,7 @@ public class VersionsTest {
 	static void setUp() throws Exception {
 		LC.zimbra_class_database.setDefault(HSQLDB.class.getName());
 		HSQLDB.createDatabase(tempDir.getAbsolutePath());
-		DbPool.startup();
+		DbPool.global();
 	}
 
 	@AfterAll


### PR DESCRIPTION
- move db pool as instance
- use singleton pattern (seems counterintuitive, but I need to add it in order to remove others)

The DbPool actually depends on Db for poolconfig settings, that's why DbPool expects a Db instance.

- startup was renamed to global()
- other methods reference the instance methods. Static methods use the singleton.
- newPool() can be used for local setup/lifecycle management
---
## Next

Make Db a singleton and move dbpool in db.
This way we do not have to hold two global instances. Right now the issue is one can exists while the other is shutdown