### PR TITLE
chore(deps): update jenkins-lib-common to v2.8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v2.8.6',
+        identifier: 'jenkins-lib-common@v2.8.7',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v2.8.2',
+        identifier: 'jenkins-lib-common@v2.8.6',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Description

Upgrade `jenkins-lib-common` from `v2.8.2` to `v2.8.7`.

### Changes applied

- Updated library version reference to `v2.8.7`

### Breaking changes in this upgrade

| Version | Change | Action Taken |
|---------|--------|--------------|
| v2.0.0 | Trunk-based branch guards replace `devel*`/`release*` | N/A — already trunk-based |
| v2.8.0 | `uploadStage(packages:)` removed, hard-errors at runtime | N/A — `uploadStage` already uses `yapPath:`, no `packages:` arg present |

### Verification

- [x] Jenkinsfile syntax is valid
- [x] No `packages:` arg in `uploadStage()` calls
- [x] No orphaned `yapHelper.getPackageNames()` calls
- [x] PR build passes

## Type of change

- [x] Chore / CI (`chore:` / `ci:` / `test:` → no release)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is rebased on latest default branch with a linear history

## Notes for reviewers

Automated lib-common upgrade (built on top of Renovate's v2.8.6 bump). The `uploadStage` in this repo already uses the new `yapPath:` parameter — no migration needed. Please verify the Upload stage runs correctly on the PR build.
