### PR TITLE
fix(ci): bump jenkins-lib-common to v2.8.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v2.8.7',
+        identifier: 'jenkins-lib-common@v2.8.8',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Root cause

The `4.27.12` tag build (#4) failed during the Rocky package upload stage with:

```
InvalidFileSpecException: A file spec must contain at least one files group
```

The Rocky packages built successfully, but `yapHelper.packages()` resolved **0 packages**, producing an empty Artifactory file spec. The log showed the CPS mismatch warning:

```
expected to call java.util.LinkedHashSet.add but wound up catching com.zextras.jenkins.PackageInfo.hashCode
```

Jenkins' CPS bytecode transformer was intercepting `PackageInfo.hashCode()` during `LinkedHashSet.add()`, silently breaking the set and returning an empty result.

## Fix

`jenkins-lib-common@v2.8.3` fixed this with `@NonCPS` on `PackageInfo.equals/hashCode/toString`. `v2.8.4` extended that to getter methods. This PR bumps to `v2.8.8` (latest), which includes all those fixes plus unrelated improvements through v2.8.8.