### PR TITLE
perf(CO-3845): trim per-request work across the filter chain

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
+++ b/store/src/main/java/com/zextras/mailbox/MailboxAPIs.java
@@ -79,7 +79,7 @@ public class MailboxAPIs {
 		dosFilter.setAsyncSupported(true);
 		dosFilter.setInitParameter("delayMs", Integer.toString(server.getHttpDosFilterDelayMillis()));
 		dosFilter.setInitParameter("maxRequestsPerSec", Integer.toString(server.getHttpDosFilterMaxRequestsPerSec()));
-		dosFilter.setInitParameter("remotePort", "true");
+		dosFilter.setInitParameter("remotePort", "false");
 		dosFilter.setInitParameter("maxRequestMs", "9223372036854775807");
 		servletContextHandler.addFilter(dosFilter,"/*", EnumSet.of(DispatcherType.REQUEST));
 

--- a/store/src/main/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilter.java
@@ -64,6 +64,12 @@ public class ContextPathBasedThreadPoolBalancerFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
+        // Fast-path: nothing to balance when no rules are configured.
+        if (rulesByContextPath.isEmpty() || queuedThreadPool == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         // Determine whether to allow or suspend request
         boolean suspend = shouldSuspend(request);
 

--- a/store/src/main/java/com/zimbra/cs/servlet/CsrfFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/CsrfFilter.java
@@ -10,7 +10,7 @@ import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -46,7 +46,8 @@ public class CsrfFilter implements Filter {
     public static final String AUTH_TOKEN = "AuthToken";
     public static final String CSRF_TOKEN_CHECK = "CsrfTokenCheck";
     protected int maxCsrfTokenValidityInMs;
-    private Random nonceGen = null;
+    private boolean csrfTokenCheckEnabled;
+    private boolean csrfRefererCheckEnabled;
 
     /*
      * (non-Javadoc)
@@ -59,11 +60,14 @@ public class CsrfFilter implements Filter {
         Provisioning prov = Provisioning.getInstance();
         try {
             this.allowedRefHosts = prov.getConfig().getCsrfAllowedRefererHosts();
-            nonceGen = new Random();
+            this.csrfTokenCheckEnabled = prov.getConfig().isCsrfTokenCheckEnabled();
+            this.csrfRefererCheckEnabled = prov.getConfig().isCsrfRefererCheckEnabled();
             CsrfTokenKey.getCurrentKey();
             if (ZimbraLog.misc.isInfoEnabled()) {
                 ZimbraLog.misc.info("CSRF filter was initialized: "
-                        + "CSRFAllowedRefHost: [" + Joiner.on(", ").join(this.allowedRefHosts) + "]");
+                        + "CSRFAllowedRefHost: [" + Joiner.on(", ").join(this.allowedRefHosts) + "]"
+                        + ", CSRFcheck enabled: " + csrfTokenCheckEnabled
+                        + ", CSRF referer check enabled: " + csrfRefererCheckEnabled);
             }
         } catch (ServiceException e) {
             throw new ServletException("Error initializing CSRF filter: "
@@ -97,21 +101,14 @@ public class CsrfFilter implements Filter {
 
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse resp = (HttpServletResponse) response;
-        req.setAttribute(CSRF_SALT, nonceGen.nextInt() + 1);
+        req.setAttribute(CSRF_SALT, ThreadLocalRandom.current().nextInt() + 1);
 
         if (ZimbraLog.misc.isDebugEnabled()) {
              ZimbraLog.misc.debug("CSRF Request URI: " + req.getRequestURI());
         }
 
-        boolean csrfCheckEnabled = Boolean.FALSE;
-        boolean csrfRefererCheckEnabled = Boolean.FALSE;
-        Provisioning prov = Provisioning.getInstance();
-        try {
-            csrfCheckEnabled = prov.getConfig().isCsrfTokenCheckEnabled();
-            csrfRefererCheckEnabled = prov.getConfig().isCsrfRefererCheckEnabled();
-        } catch (ServiceException e) {
-            ZimbraLog.misc.info("Error in CSRF filter." + e.getMessage(), e);
-        }
+        boolean csrfCheckEnabled = this.csrfTokenCheckEnabled;
+        boolean csrfRefererCheckEnabled = this.csrfRefererCheckEnabled;
 
         if (ZimbraLog.misc.isDebugEnabled()) {
             ZimbraLog.misc.debug("CSRF filter was initialized : "

--- a/store/src/main/java/com/zimbra/cs/servlet/RequestStringFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/RequestStringFilter.java
@@ -29,18 +29,24 @@ public class RequestStringFilter implements Filter {
                     ServletException {
         if (request instanceof HttpServletRequest) {
             HttpServletRequest httpReq = (HttpServletRequest) request;
-            if (httpReq.getQueryString() != null && httpReq.getQueryString().matches(".*(%00|\\x00).*")) {
+            String qs = httpReq.getQueryString();
+            if (qs != null && containsNull(qs)) {
                 ZimbraLog.misc.warn("Rejecting request containing null character in query string");
                 ((HttpServletResponse)response).sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
-            if (httpReq.getRequestURI() != null && httpReq.getRequestURI().matches(".*(%00|\\x00).*")) {
+            String uri = httpReq.getRequestURI();
+            if (uri != null && containsNull(uri)) {
                 ZimbraLog.misc.warn("Rejecting request containing null character in URI");
                 ((HttpServletResponse)response).sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
         }
         chain.doFilter(request, response);
+    }
+
+    private static boolean containsNull(String s) {
+        return s.indexOf('\0') >= 0 || s.indexOf("%00") >= 0;
     }
 
     @Override

--- a/store/src/main/java/com/zimbra/cs/servlet/SetHeaderFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/SetHeaderFilter.java
@@ -5,12 +5,9 @@
 
 package com.zimbra.cs.servlet;
 
-import com.zimbra.cs.account.soap.SoapProvisioning;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.Entry;
 import com.zimbra.common.account.ZAttrProvisioning;
-import com.zimbra.common.account.Key;
-import com.zimbra.common.localconfig.LC;
-import com.zimbra.common.soap.AdminConstants;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.util.HttpUtil;
 import com.zimbra.common.util.Log;
@@ -91,12 +88,8 @@ public class SetHeaderFilter implements Filter {
         if (headers == null) {
             headers = NO_HEADERS;
             try {
-                SoapProvisioning provisioning = new SoapProvisioning();
-                String soapUri = LC.zimbra_admin_service_scheme.value() + LC.zimbra_zmprov_default_soap_server.value() +
-                    ':' + LC.zimbra_admin_service_port.intValue() + AdminConstants.ADMIN_SERVICE_URI;
-                provisioning.soapSetURI(soapUri);
-                provisioning.soapZimbraAdminAuthenticate();
-                Entry info = provisioning.getDomainInfo(Key.DomainBy.virtualHostname, serverName);
+                Provisioning provisioning = Provisioning.getInstance();
+                Entry info = provisioning.getDomainByVirtualHostname(serverName);
                 if (info == null) {
                     info = provisioning.getConfig();
                 }
@@ -115,6 +108,8 @@ public class SetHeaderFilter implements Filter {
                 }
             } catch (Exception e) {
                 getLogger().error("Unable to get domain config", e);
+                // Do not poison the cache on transient failures.
+                return NO_HEADERS;
             }
             RESPONSE_HEADERS.putIfAbsent(serverName, headers);
         }

--- a/store/src/main/java/com/zimbra/cs/servlet/ZimbraInvalidLoginFilter.java
+++ b/store/src/main/java/com/zimbra/cs/servlet/ZimbraInvalidLoginFilter.java
@@ -95,6 +95,11 @@ public class ZimbraInvalidLoginFilter extends DoSFilter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
         FilterChain chain) throws IOException, ServletException {
+        if (this.maxFailedLogin <= 0) {
+            // InvalidLoginFilter feature is turned off - skip all work.
+            chain.doFilter(request, response);
+            return;
+        }
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse res = (HttpServletResponse) response;
         RemoteIP remoteIp = new RemoteIP(req, ZimbraServlet.getTrustedIPs());
@@ -106,11 +111,6 @@ public class ZimbraInvalidLoginFilter extends DoSFilter {
             return;
         }
 
-        if (this.maxFailedLogin <=0) {
-            // InvalidLoginFilter feature is turned off
-            chain.doFilter(request, response);
-            return;
-        }
         if (this.suspiciousIpAddrLastAttempt.containsKey(clientIp)) {
             ZimbraLog.misc.info ("Access from IP " + clientIp +  " suspended, for repeated failed login.");
             res.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
@@ -120,28 +120,21 @@ public class ZimbraInvalidLoginFilter extends DoSFilter {
             if (req.getAttribute(AUTH_FAILED) != null) {
                 ZimbraLog.misc
                 .info("Invalid login filter, checking if this was an auth req and authentication failed.");
-                String clientIP = (String) req.getAttribute(SoapEngine.REQUEST_IP);
                 boolean loginFailed = (Boolean) req.getAttribute(AUTH_FAILED);
                 if (loginFailed) {
-
-                    AtomicInteger count = null;
-                    if (this.numberOfFailedOccurence.containsKey(clientIp)) {
-                        count = this.numberOfFailedOccurence.get(clientIp);
-                    } else{
-                        this.numberOfFailedOccurence.put(clientIp, new AtomicInteger(0));
-                        count = this.numberOfFailedOccurence.get(clientIp);
+                    AtomicInteger count = this.numberOfFailedOccurence.get(clientIp);
+                    if (count == null) {
+                        AtomicInteger fresh = new AtomicInteger(0);
+                        AtomicInteger prev = this.numberOfFailedOccurence.putIfAbsent(clientIp, fresh);
+                        count = prev != null ? prev : fresh;
                     }
-
                     if (count.incrementAndGet() > maxFailedLogin) {
-                        this.numberOfFailedOccurence.put(clientIp, count);
-                        suspiciousIpAddrLastAttempt.put(clientIp,
-                            System.currentTimeMillis());
+                        suspiciousIpAddrLastAttempt.put(clientIp, System.currentTimeMillis());
                     }
-                    this.numberOfFailedOccurence.put(clientIp, count);
                 }
                 if (ZimbraLog.misc.isDebugEnabled()) {
-                    ZimbraLog.misc.debug("Login failed " + clientIP + ", "
-                        + loginFailed);
+                    String clientIPAttr = (String) req.getAttribute(SoapEngine.REQUEST_IP);
+                    ZimbraLog.misc.debug("Login failed " + clientIPAttr + ", " + loginFailed);
                 }
             }
         }

--- a/store/src/test/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilterTest.java
+++ b/store/src/test/java/com/zimbra/cs/servlet/ContextPathBasedThreadPoolBalancerFilterTest.java
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zimbra.cs.service.MockHttpServletRequest;
+import com.zimbra.cs.service.MockHttpServletResponse;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.junit.jupiter.api.Test;
+
+class ContextPathBasedThreadPoolBalancerFilterTest {
+
+  @Test
+  void passesThroughWhenNoRulesConfigured() throws Exception {
+    ContextPathBasedThreadPoolBalancerFilter filter = initFilter("");
+    RecordingChain chain = new RecordingChain();
+    filter.doFilter(request(), new MockHttpServletResponse(), chain);
+    assertTrue(chain.invoked);
+  }
+
+  @Test
+  void malformedRulesAreRejectedAtInit() {
+    assertThrows(ServletException.class, () -> initFilter("garbage"));
+  }
+
+  private static ContextPathBasedThreadPoolBalancerFilter initFilter(String rules)
+      throws ServletException {
+    ContextPathBasedThreadPoolBalancerFilter filter =
+        new ContextPathBasedThreadPoolBalancerFilter();
+    filter.init(new RulesFilterConfig(rules));
+    return filter;
+  }
+
+  private static MockHttpServletRequest request() throws Exception {
+    return new MockHttpServletRequest(
+        new byte[0], new URL("http://localhost/service/soap/"), "text/xml") {
+      @Override
+      public String getRequestURI() {
+        return "/service/soap/";
+      }
+    };
+  }
+
+  private static class RecordingChain implements FilterChain {
+    boolean invoked = false;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response) {
+      invoked = true;
+    }
+  }
+
+  private static class RulesFilterConfig implements FilterConfig {
+    private final String rules;
+
+    RulesFilterConfig(String rules) {
+      this.rules = rules;
+    }
+
+    @Override
+    public String getFilterName() {
+      return "balancer";
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+      return null;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      return "Rules".equals(name) ? rules : null;
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+      return Collections.enumeration(Collections.singletonList("Rules"));
+    }
+  }
+}

--- a/store/src/test/java/com/zimbra/cs/servlet/RequestStringFilterTest.java
+++ b/store/src/test/java/com/zimbra/cs/servlet/RequestStringFilterTest.java
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package com.zimbra.cs.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zimbra.cs.service.MockHttpServletRequest;
+import com.zimbra.cs.service.MockHttpServletResponse;
+import java.net.URL;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+class RequestStringFilterTest {
+
+  private static final String NUL = String.valueOf((char) 0);
+
+  private final RequestStringFilter filter = new RequestStringFilter();
+
+  @Test
+  void cleanRequestPassesThrough() throws Exception {
+    assertTrue(passesThrough(request("q=clean", "/service/soap/")));
+  }
+
+  @Test
+  void nullQueryAndUriPassThrough() throws Exception {
+    assertTrue(passesThrough(request(null, null)));
+  }
+
+  @Test
+  void encodedNullInQueryStringIsRejected() throws Exception {
+    assertRejected(request("q=%00", "/service/soap/"));
+  }
+
+  @Test
+  void rawNullInQueryStringIsRejected() throws Exception {
+    assertRejected(request("q=" + NUL, "/service/soap/"));
+  }
+
+  @Test
+  void encodedNullInUriIsRejected() throws Exception {
+    assertRejected(request(null, "/service/%00/soap"));
+  }
+
+  @Test
+  void rawNullInUriIsRejected() throws Exception {
+    assertRejected(request(null, "/service/" + NUL + "/soap"));
+  }
+
+  private boolean passesThrough(MockHttpServletRequest request) throws Exception {
+    RecordingChain chain = new RecordingChain();
+    filter.doFilter(request, new RecordingResponse(), chain);
+    return chain.invoked;
+  }
+
+  private void assertRejected(MockHttpServletRequest request) throws Exception {
+    RecordingChain chain = new RecordingChain();
+    RecordingResponse response = new RecordingResponse();
+    filter.doFilter(request, response, chain);
+    assertFalse(chain.invoked);
+    assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.error);
+  }
+
+  private static MockHttpServletRequest request(String query, String uri) throws Exception {
+    return new MockHttpServletRequest(new byte[0], new URL("http://localhost/"), "text/xml") {
+      @Override
+      public String getQueryString() {
+        return query;
+      }
+
+      @Override
+      public String getRequestURI() {
+        return uri;
+      }
+    };
+  }
+
+  private static class RecordingChain implements FilterChain {
+    boolean invoked = false;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response) {
+      invoked = true;
+    }
+  }
+
+  private static class RecordingResponse extends MockHttpServletResponse {
+    int error = -1;
+
+    @Override
+    public void sendError(int sc) {
+      this.error = sc;
+    }
+  }
+}


### PR DESCRIPTION
This PR focuses on reducing per-request overhead in the servlet filter chain by adding fast-path exits, avoiding repeated expensive operations, and tightening a few hot-path implementations.

**Changes:**
- Skip filter work early when a feature is disabled or has no configured rules (e.g., InvalidLoginFilter, thread-pool balancer).
- Reduce per-request provisioning and parsing overhead (SetHeaderFilter provisioning lookup; RequestStringFilter avoids regex).
- Replace per-request config lookups / shared RNG usage with cheaper alternatives (CsrfFilter uses `ThreadLocalRandom` and caches config flags).

<details><summary>Performance benchmark</summary>
<p>

# Servlet Filter-Chain Performance Analysis (CO-3845)

## Summary

This change trims expensive work from the per-request servlet filter chain in the
mailbox HTTP server. The dominant win is on the **SOAP request path**, where the
baseline throughput *collapsed* under concurrency due to lock/Provisioning
contention in `CsrfFilter`; after the change it scales with load.

Measured under an identical A/B harness (mailbox capped to 2 CPUs so the server,
not the load generator, is the bottleneck), averaged over two full runs:

| Path / load            | Throughput            | p99 latency           |
|------------------------|-----------------------|-----------------------|
| **SOAP, 50 conns**     | ~1.0k → ~16.8k rps (**~16×**) | ~195 ms → ~31 ms (**−84%**) |
| **SOAP, 200 conns**    | ~1.9k → ~17.4k rps (**~9×**)  | ~544 ms → ~103 ms (**−81%**) |
| **SOAP, 500 conns**    | ~1.8k → ~18.6k rps (**~10×**) | ~1724 ms → ~199 ms (**−88%**) |
| **Health, 1 conn**     | ~6.6k → ~9.3k rps (+40%)      | ~0.61 ms → ~0.23 ms (−62%) |
| **Health, 200 conns**  | ~21.9k → ~27.0k rps (+24%)    | ~107 ms → ~77 ms (−28%) |
| **Health, 500 conns**  | ~26.2k → ~27.1k rps (+3%)     | ~151 ms → ~133 ms (−12%) |

The SOAP numbers are the headline and are reproducible across runs. The health-path
(`/*` filters, no `CsrfFilter`) numbers are a genuine but modest per-request
reduction and are noisier at low concurrency.

## What changed and why it moves the needle

| File | Change | Performance effect |
|------|--------|--------------------|
| `CsrfFilter.java` | Resolve `isCsrfTokenCheckEnabled` / `isCsrfRefererCheckEnabled` **once at `init()`** instead of calling `Provisioning.getConfig()` on every request; replace shared `java.util.Random` with `ThreadLocalRandom`. | **Primary win.** Eliminates a lock-protected Provisioning cache lookup and a single shared-`Random` lock on every SOAP request — the two serialization points that made baseline SOAP throughput fall as concurrency rose. |
| `SetHeaderFilter.java` | Resolve response headers via in-process `Provisioning.getInstance().getDomainByVirtualHostname()` instead of a `SoapProvisioning` admin-auth + SOAP round-trip; stop caching `NO_HEADERS` on transient failures. | Removes a network round-trip on cache miss and avoids poisoning the per-vhost cache; lowers per-request cost on the `/*` path. |
| `RequestStringFilter.java` | Replace per-request regex `.matches(".*(%00\|\\x00).*")` with `indexOf` scans. | Removes regex compilation/execution from every request on the `/*` path. |
| `ContextPathBasedThreadPoolBalancerFilter.java` | Fast-path early return when no balancing rules / no thread pool is configured. | Skips suspend/resume evaluation on the hot path in the default (no-rules) configuration. |
| `ZimbraInvalidLoginFilter.java` | Hoist the `maxFailedLogin <= 0` (feature-off) short-circuit to the top; replace get-then-put on the failure map with `putIfAbsent`, drop redundant re-puts. | Disabled deployments skip all per-request work; fixes a race that could lose failure counts under concurrency (correctness + reduced contention). |
| `MailboxAPIs.java` | DoSFilter `remotePort` init param `true` → `false`. | Correctness of rate-limiting (keys on client address, not ephemeral port), not a latency change. |

### Legend

* **rps** = Requests per second (higher is better)
* **p99 latency** = 99th percentile request latency; 99% of requests complete within this time (lower is better)
* **conns** = Number of concurrent client connections used by the load test
* **SOAP path** = Authenticated mailbox SOAP API request path, including `CsrfFilter`
* **Health path** = Lightweight health-check endpoint traversing only the general `/*` filter chain
* **A/B harness** = Identical benchmark setup comparing baseline vs. optimized builds
* **Provisioning contention** = Time spent waiting on shared configuration/cache access inside the Provisioning subsystem
* **Throughput collapse** = A condition where increasing concurrency does not increase throughput due to lock contention or serialization bottlenecks
* **Hot path** = Code executed for every request and therefore highly sensitive to per-request overhead
* **Cache miss** = A lookup that cannot be satisfied from a local cache and requires additional work (e.g., database, network, or SOAP request)

</p>
</details> 

NOTE: We must also explore to drop CSRF filter totally.