### PR TITLE
fix: [CO-3822] add isExternalVirtualAccount field to accountInfo response

### DIFF
--- a/store/internal-api-openapi.yaml
+++ b/store/internal-api-openapi.yaml
@@ -231,6 +231,8 @@ components:
         sessionLifetimeMs:
           type: integer
           format: int64
+        isExternalVirtualAccount:
+          type: boolean
     ErrorResponse:
       type: object
       properties:

--- a/store/src/main/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponse.java
+++ b/store/src/main/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponse.java
@@ -12,7 +12,9 @@ public record AccountInfoResponse(String id, String name, String displayName, St
 																	String domainId, String domain, AccountStatus status,
 																	boolean isGlobalAdmin,
 																	boolean isExternal, String locale, Map<String, Boolean> features,
-																	Map<String, String> capabilities, Long sessionLifetimeMs) {
+																	Map<String, String> capabilities, Long sessionLifetimeMs,
+																	boolean isExternalVirtualAccount
+																	) {
 
 	public static AccountInfoResponse from(Account account) throws ServiceException {
 		return AccountInfoResponse.withLifetime(account, null);
@@ -43,6 +45,6 @@ public record AccountInfoResponse(String id, String name, String displayName, St
 		return new AccountInfoResponse(account.getId(), account.getName(), account.getDisplayName(),
 				account.getCOSId(), account.getDomainId(), account.getPublicServiceUrl(),
 				account.getAccountStatus(), account.isIsAdminAccount(), isExternal,
-				account.getLocale().toString(), features, capabilities, sessionLifetimeMs);
+				account.getLocale().toString(), features, capabilities, sessionLifetimeMs, account.isIsExternalVirtualAccount());
 	}
 }

--- a/store/src/test/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponseTest.java
+++ b/store/src/test/java/com/zextras/mailbox/api/rest/resource/dto/AccountInfoResponseTest.java
@@ -1,0 +1,22 @@
+package com.zextras.mailbox.api.rest.resource.dto;
+
+import com.zextras.mailbox.MailboxTestSuite;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AccountInfoResponseTest extends MailboxTestSuite {
+
+	// Note: add more tests on mapping?
+
+	@Test
+	void isExternalVirtualAccount() throws ServiceException {
+		final Account account = createAccount().create();
+		account.setIsExternalVirtualAccount(false);
+
+		final AccountInfoResponse from = AccountInfoResponse.from(account);
+		Assertions.assertFalse(from.isExternalVirtualAccount());
+	}
+
+}


### PR DESCRIPTION
- user management uses this field, not isExternalAccount

I've added the test just to prove that it actually maps that value, although I am not so sure about the need of it