### PR TITLE
fix(CO-3095): jedis client poisoning

### DIFF
--- a/store/docs/ephemeral-store.md
+++ b/store/docs/ephemeral-store.md
@@ -1,0 +1,144 @@
+# Ephemeral Store
+
+The ephemeral store is the subsystem used to read/write short-lived and dynamic attributes outside the regular LDAP attribute model. It provides a common API (`EphemeralStore`) and multiple backends (LDAP, Redis, in-memory), plus migration support between backends.
+
+## What it is used for
+
+At runtime, account/domain entry code calls `EphemeralStore` through `Entry` methods such as:
+
+- `getEphemeralAttr(...)`
+- `modifyEphemeralAttr(...)`
+- `deleteEphemeralAttr(...)`
+- `purgeEphemeralAttr(...)`
+- `hasEphemeralAttr(...)`
+
+These methods build an `EphemeralLocation` (`LdapEntryLocation` for LDAP entries), create an `EphemeralKey`, and delegate to the active backend store instance.
+
+## Core model
+
+- `EphemeralKey`: logical key + optional dynamic component.
+- `EphemeralInput`: key + value + optional expiration.
+- `EphemeralLocation`: hierarchy identifying where data belongs.
+- `EphemeralResult`: typed accessors (`getValue`, `getLongValue`, `getBoolValue`, etc.) over returned value(s).
+
+Expiration can be absolute or relative (`EphemeralInput.AbsoluteExpiration`, `RelativeExpiration`).
+
+## Store interface
+
+`EphemeralStore` defines:
+
+- `get`
+- `set`
+- `update`
+- `delete`
+- `has`
+- `purgeExpired`
+- `deleteData`
+
+Backends implement the same contract with different storage/encoding behavior.
+
+## Backend selection and lifecycle
+
+Backend resolution is driven by URL prefix in `zimbraEphemeralBackendURL`:
+
+- `ldap:...` -> `LdapEphemeralStore.Factory`
+- `redis:...` -> `RedisEphemeralStoreFactory`
+
+Factories are registered in `EphemeralStore.factories`. `EphemeralStore.getFactory()` creates and caches a global factory for the process, calls `startup()`, and returns backend stores via `factory.getStore()`.
+
+Thread-safety for factory lifecycle:
+
+- `factory` is `volatile`
+- `getFactory(...)`, `setFactory(...)`, and `clearFactory()` are synchronized
+
+This guarantees safe global initialization/clear under concurrent access.
+
+`EphemeralBackendCheck` validates backend URL changes, ensures the backend can be initialized (`factory.test(url)`), manages migration constraints, and updates `zimbraPreviousEphemeralBackendURL`.
+
+## Backend implementations
+
+### 1) LDAP backend (`LdapEphemeralStore`)
+
+Used for legacy/default behavior and compatible with LDAP-provisioned entries.
+
+- Uses `LdapAttributeEncoder`.
+- Stores encoded values inside LDAP multivalued attributes.
+- Uses `DynamicResultsHelper` to:
+  - filter dynamic key matches
+  - decode values
+  - purge expired values
+  - clean unparseable values
+- `deleteData(...)` is intentionally a no-op; LDAP-side cleanup is handled by provisioning flows.
+
+### 2) Redis backend (`RedisEphemeralStore`)
+
+Used for external ephemeral storage with native key expiration.
+
+- Uses `JedisPool` (shared, thread-safe pool).
+- Each operation borrows its own `Jedis` in try-with-resources.
+- Key format: `locationPart|ephemeralKey[|dynamicComponent]`
+- `set(...)`:
+  - no expiration -> `SET`
+  - expiration -> `PSETEX` using relative TTL
+  - non-positive TTL is rejected and logged
+- `purgeExpired(...)` is a no-op (Redis TTL handles expiration)
+- `deleteData(...)` scans keys by location pattern and deletes in batches via `UNLINK` (non-blocking delete)
+- Factory is singleton-per-process and synchronized on create/shutdown
+
+Pool tuning values come from config:
+
+- `getSSDBResourcePoolSize()`
+- `getSSDBResourcePoolTimeout()`
+
+### 3) In-memory backend (`InMemoryEphemeralStore`)
+
+Mainly for tests/local scenarios.
+
+- Uses a `Map<String, Multimap<String, String>>` grouped by location
+- Uses `DynamicExpirationEncoder`
+- Supports dynamic/expiration semantics by encoding data into values
+
+## Encoding and dynamic keys
+
+Some backends (LDAP/in-memory) cannot model dynamic keys and TTL natively. They rely on encoder/decoder logic:
+
+- `AttributeEncoder` abstraction
+- `DynamicExpirationEncoder` and `DynamicExpirationValueEncoder`
+- `DynamicResultsHelper` to interpret and filter encoded values
+
+For LDAP-specific attributes, `LdapAttributeEncoder` has custom decode rules for:
+
+- `zimbraAuthTokens`
+- `zimbraCsrfTokenData`
+
+## Migration and forwarding mode
+
+When migration metadata indicates a migration URL/status (`IN_PROGRESS` or `COMPLETED`), `EphemeralStore.setFactory(...)` can wrap the active backend in `ForwardingEphemeralStore`.
+
+Forwarding behavior:
+
+- Reads (`get`, `has`) from current store only.
+- Writes/deletes/purge/deleteData go to current store first, then are attempted on future store.
+- Failures on future store are logged at debug level and do not fail the primary operation.
+
+Migration logic in `AttributeMigration` uses `ZimbraMigrationCallback` to:
+
+1. validate destination backend
+2. set migration backend type
+3. write converted `EphemeralInput` values into destination store
+
+## Operational notes
+
+- Use `EphemeralStore.canConnectToURL(...)` / `factory.test(url)` for backend URL validation.
+- `EphemeralStore.clearFactory()` shuts down and resets the global factory.
+- `Zimbra` shutdown path calls ephemeral factory shutdown.
+
+## Relevant classes
+
+- `com.zimbra.cs.ephemeral.EphemeralStore`
+- `com.zimbra.cs.ephemeral.LdapEphemeralStore`
+- `com.zextras.mailbox.store.ephemeral.RedisEphemeralStore`
+- `com.zimbra.cs.ephemeral.InMemoryEphemeralStore`
+- `com.zimbra.cs.ephemeral.ForwardingEphemeralStore`
+- `com.zimbra.cs.account.callback.EphemeralBackendCheck`
+- `com.zimbra.cs.ephemeral.migrate.AttributeMigration`

--- a/store/docs/ephemeral-store.md
+++ b/store/docs/ephemeral-store.md
@@ -46,13 +46,6 @@ Backend resolution is driven by URL prefix in `zimbraEphemeralBackendURL`:
 
 Factories are registered in `EphemeralStore.factories`. `EphemeralStore.getFactory()` creates and caches a global factory for the process, calls `startup()`, and returns backend stores via `factory.getStore()`.
 
-Thread-safety for factory lifecycle:
-
-- `factory` is `volatile`
-- `getFactory(...)`, `setFactory(...)`, and `clearFactory()` are synchronized
-
-This guarantees safe global initialization/clear under concurrent access.
-
 `EphemeralBackendCheck` validates backend URL changes, ensures the backend can be initialized (`factory.test(url)`), manages migration constraints, and updates `zimbraPreviousEphemeralBackendURL`.
 
 ## Backend implementations
@@ -83,7 +76,7 @@ Used for external ephemeral storage with native key expiration.
   - non-positive TTL is rejected and logged
 - `purgeExpired(...)` is a no-op (Redis TTL handles expiration)
 - `deleteData(...)` scans keys by location pattern and deletes in batches via `UNLINK` (non-blocking delete)
-- Factory is singleton-per-process and synchronized on create/shutdown
+- Factory is singleton-per-process
 
 Pool tuning values come from config:
 
@@ -126,6 +119,33 @@ Migration logic in `AttributeMigration` uses `ZimbraMigrationCallback` to:
 1. validate destination backend
 2. set migration backend type
 3. write converted `EphemeralInput` values into destination store
+
+## Usages
+### Recommended usage flow
+
+1. (Optional) Migrate existing ephemeral attributes from LDAP to Redis before switching backend:
+
+```bash
+zmmigrateattrs redis://<redis_host_or_ip>:<redis_port>
+```
+
+For targeted migration:
+
+```bash
+zmmigrateattrs -a <account@example.com> redis://<redis_host_or_ip>:<redis_port>
+```
+
+2. Switch primary ephemeral backend to Redis:
+
+```bash
+carbonio prov mcf zimbraEphemeralBackendUrl redis://<redis_host_or_ip>:<redis_port>
+```
+
+3. If needed, revert backend to LDAP:
+
+```bash
+carbonio prov mcf zimbraEphemeralBackendUrl ldap://default
+```
 
 ## Operational notes
 

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -20,6 +20,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.Jedis;
@@ -28,6 +29,8 @@ import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
 
 public class RedisEphemeralStore extends EphemeralStore {
+
+  private static final int DELETE_BATCH_SIZE = 500;
 
   private final JedisPool jedisPool;
 
@@ -131,8 +134,21 @@ public class RedisEphemeralStore extends EphemeralStore {
     try (var jedisClient = jedisPool.getResource()) {
       final String accessKeyPattern = getLocationPartKey(location) + "|*";
       final Set<String> keysToDelete = getAllKeys(accessKeyPattern, jedisClient);
-      keysToDelete.forEach(jedisClient::del);
-     }
+      if (keysToDelete.isEmpty()) {
+        return;
+      }
+      final List<String> batch = new ArrayList<>(DELETE_BATCH_SIZE);
+      for (String key : keysToDelete) {
+        batch.add(key);
+        if (batch.size() == DELETE_BATCH_SIZE) {
+          jedisClient.unlink(batch.toArray(new String[0]));
+          batch.clear();
+        }
+      }
+      if (!batch.isEmpty()) {
+        jedisClient.unlink(batch.toArray(new String[0]));
+      }
+    }
   }
 
   public static class RedisEphemeralStoreFactory extends Factory {

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -6,6 +6,7 @@
 
 package com.zextras.mailbox.store.ephemeral;
 
+import com.zimbra.common.account.ZAttrProvisioning;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Config;
@@ -116,7 +117,7 @@ public class RedisEphemeralStore extends EphemeralStore {
     // attribute that must be deleted explicitly. Auth/CSRF/JWT tokens all carry an expiration
     // and are evicted by Redis on their own. Deleting this single, deterministically-named key
     // avoids scanning the whole keyspace on every account deletion.
-    final EphemeralKey lastLogonKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
+    final EphemeralKey lastLogonKey = new EphemeralKey(ZAttrProvisioning.A_zimbraLastLogonTimestamp);
     final String accessKey = getAccessKey(location, lastLogonKey);
     try (Jedis jedis = jedisPool.getResource()) {
       jedis.del(accessKey);

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -68,7 +68,7 @@ public class RedisEphemeralStore extends EphemeralStore {
           ZimbraLog.ephemeral.warn("Cannot store value of key " + key + " with expiration " + ttlMillis + " milliseconds");
           return;
          }
-         jedis.psetex(key, ttlMillis, valueToStore + "|" + expiration);
+         jedis.psetex(key, ttlMillis, valueToStore);
       }
     }
   }

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -19,18 +19,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.params.ScanParams;
-import redis.clients.jedis.resps.ScanResult;
 
 public class RedisEphemeralStore extends EphemeralStore {
-
-  private static final int DELETE_BATCH_SIZE = 500;
 
   private final JedisPool jedisPool;
 
@@ -117,37 +110,16 @@ public class RedisEphemeralStore extends EphemeralStore {
     // nothing to do here. Redis deletes expired keys automagically
   }
 
-  private Set<String> getAllKeys(String pattern, Jedis jedisResource) {
-    final ScanParams scanParams = new ScanParams().count(100).match(pattern);
-    final HashSet<String> keysSet = new HashSet<>();
-    String cursor = ScanParams.SCAN_POINTER_START;
-    do {
-      final ScanResult<String> scanResult = jedisResource.scan(cursor, scanParams);
-      keysSet.addAll(scanResult.getResult());
-      cursor = scanResult.getCursor();
-    } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
-    return keysSet;
-  }
-
   @Override
   public void deleteData(EphemeralLocation location) {
-    try (var jedisClient = jedisPool.getResource()) {
-      final String accessKeyPattern = getLocationPartKey(location) + "|*";
-      final Set<String> keysToDelete = getAllKeys(accessKeyPattern, jedisClient);
-      if (keysToDelete.isEmpty()) {
-        return;
-      }
-      final List<String> batch = new ArrayList<>(DELETE_BATCH_SIZE);
-      for (String key : keysToDelete) {
-        batch.add(key);
-        if (batch.size() == DELETE_BATCH_SIZE) {
-          jedisClient.unlink(batch.toArray(new String[0]));
-          batch.clear();
-        }
-      }
-      if (!batch.isEmpty()) {
-        jedisClient.unlink(batch.toArray(new String[0]));
-      }
+    // Only zimbraLastLogonTimestamp is stored without a TTL, so it is the one ephemeral
+    // attribute that must be deleted explicitly. Auth/CSRF/JWT tokens all carry an expiration
+    // and are evicted by Redis on their own. Deleting this single, deterministically-named key
+    // avoids scanning the whole keyspace on every account deletion.
+    final EphemeralKey lastLogonKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
+    final String accessKey = getAccessKey(location, lastLogonKey);
+    try (Jedis jedis = jedisPool.getResource()) {
+      jedis.del(accessKey);
     }
   }
 

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -151,9 +151,14 @@ public class RedisEphemeralStore extends EphemeralStore {
     }
   }
 
+  /** Closes the underlying connection pool. Call on shutdown to release resources. */
+  public void close() {
+    jedisPool.close();
+  }
+
   public static class RedisEphemeralStoreFactory extends Factory {
 
-    private EphemeralStore instance;
+    private RedisEphemeralStore instance;
 
     private static GenericObjectPoolConfig<Jedis> getPoolConfig() throws ServiceException {
       GenericObjectPoolConfig<Jedis> poolConfig = new GenericObjectPoolConfig<>();
@@ -180,7 +185,7 @@ public class RedisEphemeralStore extends EphemeralStore {
         return instance;
       }
     }
-    private EphemeralStore createStore() {
+    private RedisEphemeralStore createStore() {
       final GenericObjectPoolConfig<Jedis> poolConfig;
       try {
         var parsedURI = new URI(getURL());
@@ -197,7 +202,12 @@ public class RedisEphemeralStore extends EphemeralStore {
 
     @Override
     public void shutdown() {
-      instance = null;
+      synchronized (RedisEphemeralStoreFactory.class) {
+        if (instance != null) {
+          instance.close();
+          instance = null;
+        }
+      }
     }
 
     @Override

--- a/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
+++ b/store/src/main/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStore.java
@@ -114,15 +114,15 @@ public class RedisEphemeralStore extends EphemeralStore {
     // nothing to do here. Redis deletes expired keys automagically
   }
 
-  private Set<String> getAllKeys(String pattern, String cursor, Jedis jedisResource) {
+  private Set<String> getAllKeys(String pattern, Jedis jedisResource) {
     final ScanParams scanParams = new ScanParams().count(100).match(pattern);
-
-    final ScanResult<String> scanResult = jedisResource.scan(cursor, scanParams);
-    final HashSet<String> keysSet = new HashSet<>(scanResult.getResult());
-
-    if (!ScanParams.SCAN_POINTER_START.equals(scanResult.getCursor())) {
-      keysSet.addAll(getAllKeys(pattern, scanResult.getCursor(), jedisResource));
-    }
+    final HashSet<String> keysSet = new HashSet<>();
+    String cursor = ScanParams.SCAN_POINTER_START;
+    do {
+      final ScanResult<String> scanResult = jedisResource.scan(cursor, scanParams);
+      keysSet.addAll(scanResult.getResult());
+      cursor = scanResult.getCursor();
+    } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
     return keysSet;
   }
 
@@ -130,7 +130,7 @@ public class RedisEphemeralStore extends EphemeralStore {
   public void deleteData(EphemeralLocation location) {
     try (var jedisClient = jedisPool.getResource()) {
       final String accessKeyPattern = getLocationPartKey(location) + "|*";
-      final Set<String> keysToDelete = getAllKeys(accessKeyPattern, ScanParams.SCAN_POINTER_START, jedisClient);
+      final Set<String> keysToDelete = getAllKeys(accessKeyPattern, jedisClient);
       keysToDelete.forEach(jedisClient::del);
      }
   }

--- a/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -45,7 +45,7 @@ public abstract class EphemeralStore {
     }
 
     private static Map<String, String> factories = new HashMap<>();
-    private static Factory factory;
+    private static volatile Factory factory;
     protected AttributeEncoder encoder;
     static {
         factories.put("ldap", LdapEphemeralStore.Factory.class.getName());
@@ -162,7 +162,7 @@ public abstract class EphemeralStore {
         }
     }
 
-    private static final void setFactory(String factoryClassName, FailureMode onFailure) {
+    private static synchronized void setFactory(String factoryClassName, FailureMode onFailure) {
         if (factoryClassName == null) {
             handleFailure(onFailure, "no EphemeralStore specified", null);
             return;
@@ -181,7 +181,7 @@ public abstract class EphemeralStore {
         setFactory(factoryClass, onFailure);
     }
 
-    public static final void clearFactory() {
+    public static synchronized void clearFactory() {
         if (factory != null) {
             factory.shutdown();
         }
@@ -193,7 +193,7 @@ public abstract class EphemeralStore {
         setFactory(factoryClass, FailureMode.halt);
     }
 
-    public static final void setFactory(Class<? extends Factory> factoryClass, FailureMode onFailure) {
+    public static synchronized void setFactory(Class<? extends Factory> factoryClass, FailureMode onFailure) {
         String className = factoryClass.getDeclaringClass().getSimpleName();
         try {
             boolean useForwarding = false;
@@ -305,7 +305,7 @@ public abstract class EphemeralStore {
         }
     }
 
-    public static Factory getFactory(FailureMode onFailure) throws ServiceException {
+    public static synchronized Factory getFactory(FailureMode onFailure) throws ServiceException {
         if (factory == null) {
             String factoryClass = null;
             String url = Provisioning.getInstance().getConfig().getEphemeralBackendURL();

--- a/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralStore.java
+++ b/store/src/main/java/com/zimbra/cs/ephemeral/EphemeralStore.java
@@ -45,7 +45,7 @@ public abstract class EphemeralStore {
     }
 
     private static Map<String, String> factories = new HashMap<>();
-    private static volatile Factory factory;
+    private static Factory factory;
     protected AttributeEncoder encoder;
     static {
         factories.put("ldap", LdapEphemeralStore.Factory.class.getName());
@@ -162,7 +162,7 @@ public abstract class EphemeralStore {
         }
     }
 
-    private static synchronized void setFactory(String factoryClassName, FailureMode onFailure) {
+    private static final void setFactory(String factoryClassName, FailureMode onFailure) {
         if (factoryClassName == null) {
             handleFailure(onFailure, "no EphemeralStore specified", null);
             return;
@@ -181,7 +181,7 @@ public abstract class EphemeralStore {
         setFactory(factoryClass, onFailure);
     }
 
-    public static synchronized void clearFactory() {
+    public static final void clearFactory() {
         if (factory != null) {
             factory.shutdown();
         }
@@ -193,7 +193,7 @@ public abstract class EphemeralStore {
         setFactory(factoryClass, FailureMode.halt);
     }
 
-    public static synchronized void setFactory(Class<? extends Factory> factoryClass, FailureMode onFailure) {
+    public static final void setFactory(Class<? extends Factory> factoryClass, FailureMode onFailure) {
         String className = factoryClass.getDeclaringClass().getSimpleName();
         try {
             boolean useForwarding = false;
@@ -305,7 +305,7 @@ public abstract class EphemeralStore {
         }
     }
 
-    public static synchronized Factory getFactory(FailureMode onFailure) throws ServiceException {
+    public static Factory getFactory(FailureMode onFailure) throws ServiceException {
         if (factory == null) {
             String factoryClass = null;
             String url = Provisioning.getInstance().getConfig().getEphemeralBackendURL();

--- a/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
+++ b/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
@@ -169,18 +169,26 @@ class RedisEphemeralStoreTest {
   }
 
   @Test
-  void shouldOnlyDeleteLocationData() throws ServiceException {
-    redisEphemeralStore.set(new EphemeralInput(randomKey(), "myValue"), location);
-    redisEphemeralStore.set(new EphemeralInput(randomKey(), "myValue2"), location);
+  void deleteData_shouldDeleteLastLogonTimestamp_OnlyForGivenLocation() throws ServiceException {
+    final EphemeralKey lastLogon = new EphemeralKey("zimbraLastLogonTimestamp");
+    redisEphemeralStore.set(new EphemeralInput(lastLogon, "20251112020029.000Z"), location);
     final EphemeralLocation otherLocation = new TestLocation(new String[] {UUID.randomUUID().toString()});
-    redisEphemeralStore.set(new EphemeralInput(randomKey(), "otherLocation"), otherLocation);
+    redisEphemeralStore.set(new EphemeralInput(lastLogon, "20251112020030.000Z"), otherLocation);
 
     redisEphemeralStore.deleteData(location);
 
-    Assertions.assertEquals(1, jedisClient.keys("*").size());
-    final String keyinredis = getFirstKeyInRedis();
-    final String valueInRedis = jedisClient.get(keyinredis);
-    Assertions.assertEquals("otherLocation", valueInRedis);
+    Assertions.assertFalse(redisEphemeralStore.has(lastLogon, location));
+    Assertions.assertTrue(redisEphemeralStore.has(lastLogon, otherLocation));
+  }
+
+  @Test
+  void deleteData_shouldLeaveExpiringTokenData_ToBeEvictedByTtl() throws ServiceException {
+    final EphemeralKey authToken = new EphemeralKey("zimbraAuthTokens", "1125774878");
+    redisEphemeralStore.set(new EphemeralInput(authToken, "carbonio"), location);
+
+    redisEphemeralStore.deleteData(location);
+
+    Assertions.assertTrue(redisEphemeralStore.has(authToken, location));
   }
 
   private static class MockExpiration extends Expiration {

--- a/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
+++ b/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
@@ -99,14 +99,50 @@ class RedisEphemeralStoreTest {
 
   @ParameterizedTest
   @MethodSource("generateInput")
-  void set_shouldStoreExpiration_WhenPresent(EphemeralInput input) throws ServiceException {
+  void set_shouldStoreExpiration_AsRedisTtl(EphemeralInput input) throws ServiceException {
     long futureExpiry = System.currentTimeMillis() + 10_000L; // 10 seconds from now
     input.setExpiration(new AbsoluteExpiration(futureExpiry));
     redisEphemeralStore.set(input, location);
 
     final EphemeralResult ephemeralResult =
         redisEphemeralStore.get(input.getEphemeralKey(), location);
-    Assertions.assertEquals(input.getValue() + "|" + futureExpiry, ephemeralResult.getValue());
+    Assertions.assertEquals(input.getValue().toString(), ephemeralResult.getValue());
+  }
+
+  /**
+   * CO-3095: a value stored with an expiration must round-trip unchanged. The expiration belongs in
+   * the Redis TTL, not appended to the value. Reproduces the production failure where
+   * {@code LastLogon} read back "{@code <timestamp>|<epochMillis>}" and failed to parse it.
+   */
+  @Test
+  void get_shouldReturnValueWithoutExpirationSuffix_WhenExpirationPresent()
+      throws ServiceException {
+    final EphemeralKey key = new EphemeralKey("zimbraLastLogonTimestamp");
+    final String lastLogonTimestamp = "20251112020029.000Z";
+    final EphemeralInput input = new EphemeralInput(key, lastLogonTimestamp);
+    input.setExpiration(new AbsoluteExpiration(System.currentTimeMillis() + 10_000L));
+
+    redisEphemeralStore.set(input, location);
+
+    final EphemeralResult result = redisEphemeralStore.get(key, location);
+    Assertions.assertEquals(lastLogonTimestamp, result.getValue());
+  }
+
+  /**
+   * CO-3095: storing with an expiration must still apply the TTL while keeping the value clean, so
+   * the fix for the value format cannot regress key expiration.
+   */
+  @Test
+  void set_shouldNotStoreTtl_IntoValue() throws ServiceException {
+    final EphemeralKey key = new EphemeralKey("zimbraLastLogonTimestamp");
+    final String value = "20251112020029.000Z";
+    final EphemeralInput input = new EphemeralInput(key, value);
+    input.setExpiration(new AbsoluteExpiration(System.currentTimeMillis() + 10_000L));
+
+    redisEphemeralStore.set(input, location);
+
+    final String storedKey = getFirstKeyInRedis();
+    Assertions.assertEquals(value, jedisClient.get(storedKey));
   }
 
   @Test
@@ -303,14 +339,14 @@ class RedisEphemeralStoreTest {
 
   @ParameterizedTest
   @MethodSource("generateInput")
-  void update_shouldStoreExpiration_WhenPresent(EphemeralInput input) throws ServiceException {
+  void update_shouldStoreExpiration_AsRedisTtl(EphemeralInput input) throws ServiceException {
     long futureExpiry = System.currentTimeMillis() + 10_000L; // 10 seconds from now
     input.setExpiration(new AbsoluteExpiration(futureExpiry));
     redisEphemeralStore.update(input, location);
 
     final EphemeralResult ephemeralResult =
         redisEphemeralStore.get(input.getEphemeralKey(), location);
-    Assertions.assertEquals(input.getValue() + "|" + futureExpiry, ephemeralResult.getValue());
+    Assertions.assertEquals(input.getValue().toString(), ephemeralResult.getValue());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
While using the jedis client we somehow got some jedis client pollution.

Quote:
```
a desynchronized connection  handing back another command's reply, fixed by the SCAN change.
```
**We noticed the deleteData needed to perfrom a scan, because Redis does not allow a wildcard delete.
In the end we adopted the legacy way, even though it is ugly and does not reflect the interface**, and deleted only last logon timestamp, which does not have expirations. All other keys have an expiration and will be deleted automatically.

## Other changes

- set ephemeral key with expiration in TTL (not in value) -> latent bug, but not the main issue
- Reuse same connection on bulk delete
- Scan batch improvement
- close jedis pool on shutdown