### PR TITLE
chore (docker): centralize localconfig env path

### DIFF
--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -45,7 +45,7 @@ ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -Xss256k \
     -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-    -Dzimbra.config=\${CARBONIO_LOCALCONFIG_PATH} \
+    -Dzimbra.config=\${LOCALCONFIG_PATH} \
     -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
     -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 
@@ -92,7 +92,7 @@ COPY docker/mailbox/log4j.properties /opt/zextras/conf/log4j.properties
 COPY docker/mailbox/localconfig/localconfig.xml /localconfig/localconfig.xml
 COPY packages/appserver-service/otel.properties /etc/carbonio/mailbox/otel.properties
 
-ENV CARBONIO_LOCALCONFIG_PATH=/localconfig/localconfig.xml \
+ENV LOCALCONFIG_PATH=/localconfig/localconfig.xml \
     LDAP_URL="ldap://openldap:1389" \
     LDAP_ROOT_PASSWORD=qh6hWZvc \
     LDAP_ADMIN_PASSWORD=password \

--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -45,7 +45,7 @@ ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -Xss256k \
     -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-    -Dzimbra.config=\${CARBONIO_LOCALCONFIG_PATH:-/localconfig/localconfig.xml} \
+    -Dzimbra.config=\${CARBONIO_LOCALCONFIG_PATH} \
     -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
     -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 

--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -45,18 +45,26 @@ ARG BASE_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -Xss256k \
     -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-    -Dzimbra.config=/localconfig/localconfig.xml \
+    -Dzimbra.config=\${CARBONIO_LOCALCONFIG_PATH:-/localconfig/localconfig.xml} \
     -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
     -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 
 RUN mkdir -p /staging/usr/bin && \
-    printf '#!/bin/sh\njava %s com.zimbra.cs.account.ProvUtil "$@"\n' "${BASE_JAVA_ARGS}" > /staging/usr/bin/zmprov && \
+    printf '#!/bin/sh\njava %s com.zimbra.cs.account.ProvUtil "$@"\n' \
+      "${BASE_JAVA_ARGS}" \
+      > /staging/usr/bin/zmprov && \
     chmod +x /staging/usr/bin/zmprov && \
-    printf '#!/bin/sh\njava %s com.zimbra.cs.localconfig.LocalConfigCLI "$@"\n' "${BASE_JAVA_ARGS}" > /staging/usr/bin/zmlocalconfig && \
+    printf '#!/bin/sh\njava %s com.zimbra.cs.localconfig.LocalConfigCLI "$@"\n' \
+      "${BASE_JAVA_ARGS}" \
+      > /staging/usr/bin/zmlocalconfig && \
     chmod +x /staging/usr/bin/zmlocalconfig && \
-    printf '#!/bin/sh\njava %s com.zimbra.cs.util.GalSyncAccountUtil "$@"\n' "${BASE_JAVA_ARGS}" > /staging/usr/bin/zmgsautil && \
+    printf '#!/bin/sh\njava %s com.zimbra.cs.util.GalSyncAccountUtil "$@"\n' \
+      "${BASE_JAVA_ARGS}" \
+      > /staging/usr/bin/zmgsautil && \
     chmod +x /staging/usr/bin/zmgsautil && \
-    printf '#!/bin/sh\njava %s com.zimbra.cs.zclient.ZMailboxUtil "$@"\n' "${BASE_JAVA_ARGS}" > /staging/usr/bin/zmmailbox && \
+    printf '#!/bin/sh\njava %s com.zimbra.cs.zclient.ZMailboxUtil "$@"\n' \
+      "${BASE_JAVA_ARGS}" \
+      > /staging/usr/bin/zmmailbox && \
     chmod +x /staging/usr/bin/zmmailbox
 
 # Generate keystore using Alpine-based builder stage
@@ -84,7 +92,8 @@ COPY docker/mailbox/log4j.properties /opt/zextras/conf/log4j.properties
 COPY docker/mailbox/localconfig/localconfig.xml /localconfig/localconfig.xml
 COPY packages/appserver-service/otel.properties /etc/carbonio/mailbox/otel.properties
 
-ENV LDAP_URL="ldap://openldap:1389" \
+ENV CARBONIO_LOCALCONFIG_PATH=/localconfig/localconfig.xml \
+    LDAP_URL="ldap://openldap:1389" \
     LDAP_ROOT_PASSWORD=qh6hWZvc \
     LDAP_ADMIN_PASSWORD=password \
     MARIADB_ROOT_PASSWORD=password \

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
-localconfig_path="${CARBONIO_LOCALCONFIG_PATH:-/localconfig/localconfig.xml}"
+localconfig_path="${CARBONIO_LOCALCONFIG_PATH}"
 
 sed -i -e "s#LDAP_URL#${LDAP_URL}#g" "${localconfig_path}"
 sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" "${localconfig_path}"

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
-localconfig_path="${CARBONIO_LOCALCONFIG_PATH}"
+localconfig_path="${LOCALCONFIG_PATH}"
 
 sed -i -e "s#LDAP_URL#${LDAP_URL}#g" "${localconfig_path}"
 sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" "${localconfig_path}"

--- a/docker/mailbox/entrypoint.sh
+++ b/docker/mailbox/entrypoint.sh
@@ -5,17 +5,19 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
-sed -i -e "s#LDAP_URL#${LDAP_URL}#g" /localconfig/localconfig.xml
-sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" /localconfig/localconfig.xml
-sed -i -e "s/LDAP_ADMIN_PASSWORD/${LDAP_ADMIN_PASSWORD}/g" /localconfig/localconfig.xml
-sed -i -e "s/MARIADB_ROOT_PASSWORD/${MARIADB_ROOT_PASSWORD}/g" /localconfig/localconfig.xml
-sed -i -e "s/MARIADB_URL/${MARIADB_URL}/g" /localconfig/localconfig.xml
-sed -i -e "s/MARIADB_PORT/${MARIADB_PORT}/g" /localconfig/localconfig.xml
-sed -i -e "s/SERVER_HOSTNAME/${HOSTNAME}/g" /localconfig/localconfig.xml
-sed -i -e "s#CARBONIO_FILES_SERVICE_URL#${CARBONIO_FILES_SERVICE_URL}#g" /localconfig/localconfig.xml
-sed -i -e "s#CARBONIO_PREVIEW_SERVICE_URL#${CARBONIO_PREVIEW_SERVICE_URL}#g" /localconfig/localconfig.xml
-sed -i -e "s#CARBONIO_MAILBOX_INTERNAL_API_HOST#${CARBONIO_MAILBOX_INTERNAL_API_HOST}#g" /localconfig/localconfig.xml
-sed -i -e "s#CARBONIO_MAILBOX_INTERNAL_API_PORT#${CARBONIO_MAILBOX_INTERNAL_API_PORT}#g" /localconfig/localconfig.xml
+localconfig_path="${CARBONIO_LOCALCONFIG_PATH:-/localconfig/localconfig.xml}"
+
+sed -i -e "s#LDAP_URL#${LDAP_URL}#g" "${localconfig_path}"
+sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" "${localconfig_path}"
+sed -i -e "s/LDAP_ADMIN_PASSWORD/${LDAP_ADMIN_PASSWORD}/g" "${localconfig_path}"
+sed -i -e "s/MARIADB_ROOT_PASSWORD/${MARIADB_ROOT_PASSWORD}/g" "${localconfig_path}"
+sed -i -e "s/MARIADB_URL/${MARIADB_URL}/g" "${localconfig_path}"
+sed -i -e "s/MARIADB_PORT/${MARIADB_PORT}/g" "${localconfig_path}"
+sed -i -e "s/SERVER_HOSTNAME/${HOSTNAME}/g" "${localconfig_path}"
+sed -i -e "s#CARBONIO_FILES_SERVICE_URL#${CARBONIO_FILES_SERVICE_URL}#g" "${localconfig_path}"
+sed -i -e "s#CARBONIO_PREVIEW_SERVICE_URL#${CARBONIO_PREVIEW_SERVICE_URL}#g" "${localconfig_path}"
+sed -i -e "s#CARBONIO_MAILBOX_INTERNAL_API_HOST#${CARBONIO_MAILBOX_INTERNAL_API_HOST}#g" "${localconfig_path}"
+sed -i -e "s#CARBONIO_MAILBOX_INTERNAL_API_PORT#${CARBONIO_MAILBOX_INTERNAL_API_PORT}#g" "${localconfig_path}"
 
 SERVER_EXISTS=$(/usr/bin/zmprov -l gs "${HOSTNAME}" 2>&1)
 if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
@@ -37,7 +39,7 @@ JAVA_OPTS="-Dfile.encoding=UTF-8 -server \
                          --enable-preview --enable-native-access=ALL-UNNAMED \
                          --add-opens java.base/java.lang=ALL-UNNAMED \
                          ${MAILBOXD_JAVA_OPTS} -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-                         -Dzimbra.config=/localconfig/localconfig.xml \
+                         -Dzimbra.config=${localconfig_path} \
                          -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
                          -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
 


### PR DESCRIPTION
Centralize the mailbox localconfig path via the LOCALCONFIG_PATH environment variable and use it consistently for mailbox startup and generated CLI wrappers (zmprov, zmlocalconfig, zmgsautil, zmmailbox).

This lets derived images, such as carbonio-advanced, inherit the configured path instead of duplicating /localconfig/localconfig.xml.