### PR TITLE
test(store): randomize fixed connector ports in test harness

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -911,7 +911,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>2</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -928,7 +928,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>2</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -911,7 +911,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
@@ -928,7 +928,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties

--- a/store/src/test/java/com/zextras/mailbox/MailboxEnvironmentSetupHelper.java
+++ b/store/src/test/java/com/zextras/mailbox/MailboxEnvironmentSetupHelper.java
@@ -113,6 +113,10 @@ public class MailboxEnvironmentSetupHelper {
 										ZAttrProvisioning.A_zimbraMailPort, String.valueOf(userHttpPort),
 										ZAttrProvisioning.A_zimbraMailSSLPort, String.valueOf(userHttpsPort),
 										ZAttrProvisioning.A_zimbraAdminPort, String.valueOf(adminPort),
+										// Randomize MTA-auth (default 7073) and extensions (default 7072) connector
+										// ports too, so concurrent test forks don't collide on these fixed defaults.
+										ZAttrProvisioning.A_zimbraMtaAuthPort, String.valueOf(PortUtil.findFreePort()),
+										ZAttrProvisioning.A_zimbraExtensionBindPort, String.valueOf(PortUtil.findFreePort()),
 										ZAttrProvisioning.A_zimbraMailMode, "both",
 										ZAttrProvisioning.A_zimbraPop3SSLServerEnabled, "FALSE",
 										ZAttrProvisioning.A_zimbraImapSSLServerEnabled, "FALSE")));


### PR DESCRIPTION
## Changes
- Randomize `zimbraMtaAuthPort` (was fixed 7073) in the test setup
- Randomize `zimbraExtensionBindPort` (was fixed 7072) in the test setup

## Why
Both were pinned to fixed defaults on 0.0.0.0 and collide when tests run concurrently. Randomizing them (like the mail/admin ports already are) removes the collision and unblocks parallelizing the tests later.

I tried increasing forkCount on store (it is 1), but wall clock time improves slightly so not worth it.