### PR TITLE
test(store): run tests with forkCount=2

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -911,7 +911,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>2</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dzimbra.config=${project.basedir}/src/test/resources/localconfig-test.xml
@@ -928,7 +928,7 @@ EOF
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>2</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} --enable-preview --enable-native-access=ALL-UNNAMED -Xmx2g -Dserver.dir=${project.basedir}
             -Dlog4j.configurationFile=${project.basedir}/src/test/resources/log4j-test.properties


### PR DESCRIPTION
Changes:
- Run store surefire + failsafe with `forkCount=2`

Why:
Connector ports are now randomized per instance (merged), so tests can run 2-wide. Local A/B: ~15-18% faster on both the unit and api/flaky tiers; `forkCount=4` gave no further gain (unit tier regressed), so 2 is the sweet spot.

Result: API tests time cut by 50% on a first run (~1 minute less)