### PR TITLE
ci: run all tests in a single stage (no group split)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,24 +78,15 @@ pipeline {
             }
         }
 
-        stage('UT, IT') {
+        stage('Tests') {
             steps {
                 container('jdk-21') {
-                    sh "mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -DexcludedGroups=api,flaky,e2e"
+                    sh "mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify"
                 }
                 junit allowEmptyResults: true,
                         testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
             }
         }
-        stage('Flaky, API, E2E tests') {
-                    steps {
-                        container('jdk-21') {
-                            sh "cd store && mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=flaky,api && mvn ${MVN_OPTS} jacoco:prepare-agent surefire:test failsafe:integration-test failsafe:verify -Dgroups=e2e"
-                        }
-                        junit allowEmptyResults: true,
-                                testResults: '**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml'
-                    }
-                }
 
         stage('Build and Package API Docs') {
             steps {


### PR DESCRIPTION
Changes:
- Merge `UT, IT` and `Flaky, API, E2E tests` into one `Tests` stage that runs the whole suite in a single Maven invocation (drop the `excludedGroups`/`groups` split).

Why:
The flaky/e2e group split was a quarantine (CO-2658). With `AccountServiceIT` de-flaked and `forkCount=2` in place, run everything together — simpler pipeline, one boot/compile instead of two. This PR's CI run is the test of whether the combined suite is stable.