### PR TITLE
fix: [CO-3846] order carbonio-appserver after its mailbox sidecar (cold-boot DB race)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v2.10.0',
+        identifier: 'jenkins-lib-common@v3.0.1',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',

--- a/packages/appserver-service/carbonio-appserver.service
+++ b/packages/appserver-service/carbonio-appserver.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Carbonio Appserver Daemon
-After=carbonio-appserver-db.service carbonio-configd.service
+# carbonio-mailbox-sidecar provides the outbound DB mesh path (carbonio-mailbox-db)
+# that mailboxd needs during its Zextras bootstrap; it must be up first.
+After=carbonio-appserver-db.service carbonio-configd.service carbonio-mailbox-sidecar.service
 Wants=carbonio-appserver-db.service carbonio-configd.service carbonio-mailbox-sidecar.service carbonio-mailbox-internal-api-sidecar.service
 PartOf=carbonio-appserver.target
 

--- a/packages/appserver-service/carbonio-mailbox-sidecar.service
+++ b/packages/appserver-service/carbonio-mailbox-sidecar.service
@@ -2,7 +2,7 @@
 Description=Carbonio Mailbox Sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
-After=network-online.target service-discover.service carbonio-appserver.service
+After=network-online.target service-discover.service
 PartOf=service-discover.target
 
 [Service]


### PR DESCRIPTION
carbonio-mailbox-sidecar.service (the appserver's own Envoy sidecar, which provides the outbound mesh path to the carbonio-mailbox-db core PostgreSQL) was ordered After=carbonio-appserver.service. mailboxd needs that DB during its Zextras bootstrap, so the proxy came up too late at cold boot: the bootstrap hit a PostgreSQL "connection attempt failed", logged FATAL "Unable to initialize zextras" / "Critical Exception on Startup", and aborted before registering the /zx/auth route and binding the address-book port (8388). The Consul health checks for carbonio-auth (HTTP :8742/zx/auth/health/live) and carbonio-address-book (TCP :8388) then failed persistently until a manual `systemctl restart carbonio-appserver.target`.

Break the inverted ordering:
- carbonio-mailbox-sidecar.service: drop After=carbonio-appserver.service so the sidecar (and the DB mesh path) can start independently/earlier.
- carbonio-appserver.service: add After=carbonio-mailbox-sidecar.service so mailboxd starts after its DB proxy.

Verified with systemd-analyze verify that the post-change graph has no ordering cycle (re-adding the old edge reproduces the cycle), and on a single-server reboot the appserver bootstrap reaches the DB and registers /zx/auth + 8388 without a manual restart.

Note: full robustness against transient mesh/DB warmup still warrants making the Zextras DB bootstrap (carbonio-advanced) retry instead of fatally aborting; that is tracked separately.