### PR TITLE
fix(deps): bump preview SDK to 2.0.2-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
       <dependency>
         <groupId>com.zextras.carbonio.preview</groupId>
         <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
-        <version>2.0.1-1</version>
+        <version>2.0.2-1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -554,8 +554,8 @@
       </dependency>
       <dependency>
         <groupId>com.zextras.carbonio.preview</groupId>
-        <artifactId>carbonio-preview-sdk</artifactId>
-        <version>1.0.4</version>
+        <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
+        <version>2.0.1-1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -186,8 +186,20 @@
     </dependency>
 
     <dependency>
-      <artifactId>carbonio-preview-sdk</artifactId>
+      <artifactId>carbonio-preview-ce-rest-sdk</artifactId>
       <groupId>com.zextras.carbonio.preview</groupId>
+      <exclusions>
+        <!-- store already depends directly on io.swagger.core.v3:swagger-annotations for its own
+             internal REST API OpenAPI annotations; swagger-annotations-jakarta ships the exact same
+             io.swagger.v3.oas.annotations.* package, which would otherwise put duplicate/conflicting
+             classes on the classpath. The preview SDK's hand-written PreviewClient wrapper we use
+             never touches its generated OpenAPI/REST-model classes (the ones that need this
+             dependency), so it is safe to exclude here. -->
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-annotations-jakarta</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewHandler.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewHandler.java
@@ -2,10 +2,8 @@ package com.zimbra.cs.service.servlet.preview;
 
 import static com.zimbra.cs.servlet.ZimbraServlet.proxyServletRequest;
 
-import com.zextras.carbonio.preview.PreviewClient;
-import com.zextras.carbonio.preview.exceptions.BadRequest;
-import com.zextras.carbonio.preview.exceptions.ItemNotFound;
-import com.zextras.carbonio.preview.exceptions.ValidationError;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewException;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.Log;
@@ -156,12 +154,13 @@ public class PreviewHandler {
     mimePartTry.mapTry(Utils::mapMimePartResponseToDataBlob)
         .flatMapTry(attachmentDataBlob -> getAttachmentPreview(request, attachmentDataBlob))
         .onSuccess(previewDataBlob -> respondWithSuccess(response, request, previewDataBlob))
-        .onFailure(BadRequest.class,
-            ex -> respondWithError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex.getMessage()))
-        .onFailure(ItemNotFound.class,
-            ex -> respondWithError(request, response, HttpServletResponse.SC_NOT_FOUND, ex.getMessage()))
-        .onFailure(ValidationError.class,
-            ex -> respondWithError(request, response, HttpServletResponse.SC_UNAUTHORIZED, ex.getMessage()))
+        .onFailure(PreviewException.class, ex -> {
+          if (ex.isNotFound()) {
+            respondWithError(request, response, HttpServletResponse.SC_NOT_FOUND, ex.getMessage());
+          } else if (ex.isBadRequest()) {
+            respondWithError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+          }
+        })
         .onFailure(ex -> {
           var message = ex.getMessage();
           if (ex instanceof NullPointerException || message == null || message.trim().isEmpty()) {
@@ -237,12 +236,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postThumbnailOfImage(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(previewArea, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(previewArea, queryParameters)))
           .flatMapTry(
               thumbnailOfImage ->
                   Utils.mapPreviewResponseToDataBlob(
-                      thumbnailOfImage.get(), attachmentFileName, dispositionType));
+                      thumbnailOfImage, attachmentFileName, dispositionType));
     }
 
     if (pdfThumbnailMatcher.find()) {
@@ -253,12 +251,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postThumbnailOfPdf(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(previewArea, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(previewArea, queryParameters)))
           .flatMapTry(
               thumbnailOfPdf ->
                   Utils.mapPreviewResponseToDataBlob(
-                      thumbnailOfPdf.get(), attachmentFileName, dispositionType));
+                      thumbnailOfPdf, attachmentFileName, dispositionType));
     }
 
     if (documentThumbnailMatcher.find()) {
@@ -269,12 +266,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postThumbnailOfDocument(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(previewArea, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(previewArea, queryParameters)))
           .flatMapTry(
               thumbnailOfDocument ->
                   Utils.mapPreviewResponseToDataBlob(
-                      thumbnailOfDocument.get(), attachmentFileName, dispositionType));
+                      thumbnailOfDocument, attachmentFileName, dispositionType));
     }
 
     if (imagePreviewMatcher.find()) {
@@ -286,12 +282,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postPreviewOfImage(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(previewArea, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(previewArea, queryParameters)))
           .flatMapTry(
               previewOfImage ->
                   Utils.mapPreviewResponseToDataBlob(
-                      previewOfImage.get(), attachmentFileName, dispositionType));
+                      previewOfImage, attachmentFileName, dispositionType));
     }
 
     if (pdfPreviewMatcher.find()) {
@@ -301,12 +296,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postPreviewOfPdf(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(null, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(null, queryParameters)))
           .flatMapTry(
               previewOfPdf ->
                   Utils.mapPreviewResponseToDataBlob(
-                      previewOfPdf.get(), attachmentFileName, dispositionType));
+                      previewOfPdf, attachmentFileName, dispositionType));
     }
 
     if (documentPreviewMatcher.find()) {
@@ -316,12 +310,11 @@ public class PreviewHandler {
               () ->
                   previewClient.postPreviewOfDocument(
                       attachmentMimePartInputStream,
-                      Utils.generateQuery(null, queryParameters),
-                      attachmentFileName))
+                      Utils.generateQuery(null, queryParameters)))
           .flatMapTry(
               previewOfDocument ->
                   Utils.mapPreviewResponseToDataBlob(
-                      previewOfDocument.get(), attachmentFileName, dispositionType));
+                      previewOfDocument, attachmentFileName, dispositionType));
     }
 
     return Try.failure(ServiceException.INVALID_REQUEST("[" + requestId + "] Cannot handle request", null));

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewQueryParameters.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewQueryParameters.java
@@ -1,7 +1,7 @@
 package com.zimbra.cs.service.servlet.preview;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.zextras.carbonio.preview.queries.Query;
+import com.zextras.carbonio.preview.sdk.Query;
 import java.util.Optional;
 import javax.swing.text.html.Option;
 

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/PreviewServlet.java
@@ -1,6 +1,6 @@
 package com.zimbra.cs.service.servlet.preview;
 
-import com.zextras.carbonio.preview.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.Log;
 import com.zimbra.common.util.LogFactory;
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * <pre>
  *
- *   Based on Carbonio Preview SDK 1.0.2
+ *   Based on Carbonio Preview CE REST SDK 2.0.1-1
  *
  *   The API is the almost same as of preview service(https://zextras.atlassian.net/wiki/spaces/SW/pages/2353430753/Preview+API)
  *   with few modification that let us make it use as preview service for mailbox attachments.

--- a/store/src/main/java/com/zimbra/cs/service/servlet/preview/Utils.java
+++ b/store/src/main/java/com/zimbra/cs/service/servlet/preview/Utils.java
@@ -1,8 +1,9 @@
 package com.zimbra.cs.service.servlet.preview;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zextras.carbonio.preview.queries.Query;
-import com.zextras.carbonio.preview.queries.Query.QueryBuilder;
+import com.zextras.carbonio.preview.sdk.PreviewResponse;
+import com.zextras.carbonio.preview.sdk.Query;
+import com.zextras.carbonio.preview.sdk.QueryBuilder;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.service.util.ItemId;
@@ -165,15 +166,15 @@ class Utils {
   }
 
   /**
-   * Maps preview service's {@link com.zextras.carbonio.preview.queries.BlobResponse} to {@link DataBlob}.
+   * Maps preview service's {@link PreviewResponse} to {@link DataBlob}.
    *
-   * @param response        preview service's {@link com.zextras.carbonio.preview.queries.BlobResponse}
+   * @param response        preview service's {@link PreviewResponse}
    * @param fileName        filename that we want to assign to our {@link DataBlob} object
    * @param dispositionType disposition will be: attachment or inline(default)
    * @return mapped {@link DataBlob} object
    */
   static Try<DataBlob> mapPreviewResponseToDataBlob(
-      com.zextras.carbonio.preview.queries.BlobResponse response, String fileName, String dispositionType) {
+      PreviewResponse response, String fileName, String dispositionType) {
     return Try.of(() -> new DataBlob(
         response.getContent(),
         fileName,
@@ -214,15 +215,15 @@ class Utils {
   static Query generateQuery(String optArea, PreviewQueryParameters queryParameters) {
     var parameterBuilder = new QueryBuilder();
     if (optArea != null) {
-      parameterBuilder.setPreviewArea(optArea);
+      parameterBuilder.area(optArea);
     }
-    queryParameters.getQuality().ifPresent(parameterBuilder::setQuality);
-    queryParameters.getOutputFormat().ifPresent(parameterBuilder::setOutputFormat);
-    queryParameters.getCrop().ifPresent(parameterBuilder::setCrop);
-    queryParameters.getShape().ifPresent(parameterBuilder::setShape);
-    queryParameters.getFirstPage().ifPresent(parameterBuilder::setFirstPage);
-    queryParameters.getLastPage().ifPresent(parameterBuilder::setLastPage);
-    queryParameters.getLangTag().ifPresent(parameterBuilder::setLangTag);
+    queryParameters.getQuality().ifPresent(parameterBuilder::quality);
+    queryParameters.getOutputFormat().ifPresent(parameterBuilder::outputFormat);
+    queryParameters.getCrop().ifPresent(parameterBuilder::crop);
+    queryParameters.getShape().ifPresent(parameterBuilder::shape);
+    queryParameters.getFirstPage().ifPresent(parameterBuilder::firstPage);
+    queryParameters.getLastPage().ifPresent(parameterBuilder::lastPage);
+    queryParameters.getLangTag().ifPresent(parameterBuilder::langTag);
     return parameterBuilder.build();
   }
 

--- a/store/src/test/java/com/zimbra/cs/service/servlet/preview/PreviewHandlerTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/servlet/preview/PreviewHandlerTest.java
@@ -1,7 +1,6 @@
 package com.zimbra.cs.service.servlet.preview;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -9,10 +8,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.zextras.carbonio.preview.PreviewClient;
-import com.zextras.carbonio.preview.exceptions.InternalServerError;
-import com.zextras.carbonio.preview.exceptions.ItemNotFound;
-import com.zextras.carbonio.preview.queries.Query;
+import com.zextras.carbonio.preview.sdk.PreviewClient;
+import com.zextras.carbonio.preview.sdk.PreviewException;
+import com.zextras.carbonio.preview.sdk.PreviewResponse;
+import com.zextras.carbonio.preview.sdk.Query;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.account.AuthToken;
@@ -60,8 +59,8 @@ class PreviewHandlerTest {
   private MimePart mimePart;
   @Mock
   private ItemIdFactory itemIdFactory;
-  @Mock
-  private com.zextras.carbonio.preview.queries.BlobResponse blobResponse;
+  private final PreviewResponse blobResponse =
+      new PreviewResponse(InputStream.nullInputStream(), 0L, "image/jpeg");
   @InjectMocks
   private PreviewHandler previewHandler;
 
@@ -258,7 +257,7 @@ class PreviewHandlerTest {
     when(itemId.isLocal()).thenReturn(true);
     when(itemIdFactory.create("27310", "accountId")).thenReturn(itemId);
     when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
-        .thenReturn(Try.failure(new ItemNotFound()));
+        .thenReturn(Try.failure(new RuntimeException()));
 
     previewHandler.handle(request, response);
 
@@ -280,8 +279,8 @@ class PreviewHandlerTest {
     when(itemIdFactory.create("27310", "accountId")).thenReturn(itemId);
     when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
-    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), any(String.class)))
-        .thenReturn(Try.failure(new InternalServerError()));
+    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class)))
+        .thenThrow(new PreviewException(500, null));
 
     previewHandler.handle(request, response);
 
@@ -307,8 +306,7 @@ class PreviewHandlerTest {
     when(mimePart.getSize()).thenReturn(200);
     when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
-    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), anyString())).thenReturn(
-        Try.success(blobResponse));
+    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class))).thenReturn(blobResponse);
 
     var previewHandlerSpy = spy(previewHandler);
     previewHandlerSpy.handle(request, response);
@@ -335,8 +333,8 @@ class PreviewHandlerTest {
     when(mimePart.getSize()).thenReturn(200);
     when(attachmentService.getAttachmentByItemId(itemId.getAccountId(), authToken, itemId, "2"))
         .thenReturn(Try.success(mimePart));
-    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class), anyString())).thenReturn(
-        Try.failure(new InternalServerError()));
+    when(previewClient.postPreviewOfImage(any(InputStream.class), any(Query.class)))
+        .thenThrow(new PreviewException(500, null));
 
     previewHandler.handle(request, response);
 

--- a/store/src/test/java/com/zimbra/cs/service/servlet/preview/UtilsTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/servlet/preview/UtilsTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.zextras.carbonio.preview.queries.Query;
+import com.zextras.carbonio.preview.sdk.Query;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Assertions;
@@ -136,7 +136,7 @@ class UtilsTest {
     final PreviewQueryParameters queryParameters = Utils.parseQueryParameters(query);
     final Query parameters = Utils.generateQuery("", queryParameters);
 
-    Assertions.assertEquals("1", parameters.getLangTag().get());
+    Assertions.assertEquals("1", parameters.getLangTag());
   }
 
 }


### PR DESCRIPTION
Bump the preview dependency to the released split REST SDK **carbonio-preview-ce-rest-sdk:2.0.2-1**.

The Python→Go preview rewrite replaced the single `carbonio-preview-sdk` with two edition-specific REST SDKs; `2.0.2-1` carries the enum-case lowercasing fix in the SDK `QueryBuilder` (quality/shape/output_format/service_type), so uppercase enum names sent by consumers no longer trigger the preview service's 422.

Branch = current `devel` + the SDK migration/bump. Compiled + unit-tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)