### PR TITLE
fix(CO-3632): skip attendees with unusable addresses when building notification recipients

### DIFF
--- a/store/src/main/java/com/zimbra/cs/mailbox/calendar/CalendarMailSender.java
+++ b/store/src/main/java/com/zimbra/cs/mailbox/calendar/CalendarMailSender.java
@@ -428,7 +428,13 @@ public class CalendarMailSender {
       throws MailServiceException {
     List<Address> toList = new ArrayList<>(list.size());
     for (ZAttendee attendee : list) {
-      toList.add(attendee.getFriendlyAddress());
+      try {
+        toList.add(attendee.getFriendlyAddress());
+      } catch (MailServiceException e) {
+        ZimbraLog.calendar.warn(
+            "Skipping attendee with unusable address while building recipient list: %s",
+            attendee.getAddress(), e);
+      }
     }
     return toList;
   }


### PR DESCRIPTION
## Summary

`CalendarMailSender.toListFromAttendees()` builds the notification recipient list from the invite's stored attendees. It previously called `getFriendlyAddress()` for every attendee without validating the address first, so a single attendee with a missing or malformed address caused the entire notification to fail with:

> `MailServiceException: Couldn't parse address: No address value`

## Root Cause

This occurs when a calendar resource is deleted and removed from the `galsync` account. The appointment still retains the resource as an attendee, but its email address is no longer available.

As a result:

- Notification generation fails.
- Editing the appointment fails because notifications cannot be sent.
- The appointment effectively becomes un-editable and un-notifiable.

## Changes

- Resolve each attendee address independently when building the recipient list.
- Skip attendees whose addresses cannot be resolved instead of aborting the entire notification.
- Log skipped attendees for troubleshooting.

## Impact

- Notifications continue to be sent to all valid recipients even if one attendee has an invalid or missing address.
- Restores the ability to edit appointments that reference deleted calendar resources.
- Aligns the notification path with the existing indexing (`CalendarItem`) behavior, which already tolerated attendees without usable addresses.

## Related

https://github.com/zextras/carbonio-calendars-ui/pull/814