### PR TITLE
test: kubernetes testcontainer support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,12 @@ pipeline {
         }
 
         stage('UT, IT') {
+            // Container-backed tests (e.g. Redis) spin up real pods through the in-cluster
+            // Kubernetes API (see com.zextras.mailbox.testcontainers.KubernetesPods); the pull
+            // secret lets those pods pull images from the private registry.
+            environment {
+                K8S_IMAGE_PULL_SECRET = 'private-registry-secret'
+            }
             steps {
                 container('jdk-21') {
                     sh "mvn ${MVN_OPTS} verify -DexcludedGroups=api,flaky,e2e"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,9 +71,6 @@ pipeline {
         }
 
         stage('UT, IT') {
-            // Container-backed tests (e.g. Redis) spin up real pods through the in-cluster
-            // Kubernetes API (see com.zextras.mailbox.testcontainers.KubernetesPods); the pull
-            // secret lets those pods pull images from the private registry.
             environment {
                 K8S_IMAGE_PULL_SECRET = 'private-registry-secret'
             }

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -136,19 +136,24 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-mariadb</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-rabbitmq</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.redis</groupId>
       <artifactId>testcontainers-redis</artifactId>
       <version>2.2.4</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Launches sibling pods via the in-cluster Kubernetes API when tests run inside a
+         k3s/crun cluster (no Docker daemon). See com.zextras.mailbox.testcontainers.
+         client-java provides ClientBuilder; client-java-api the openapi models/apis. -->
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>26.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java-api</artifactId>
+      <version>26.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreFactoryTest.java
+++ b/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreFactoryTest.java
@@ -6,8 +6,8 @@
 
 package com.zextras.mailbox.store.ephemeral;
 
-import com.redis.testcontainers.RedisContainer;
 import com.zextras.mailbox.MailboxTestSuite;
+import com.zextras.mailbox.testcontainers.RedisExtension;
 import com.zextras.mailbox.store.ephemeral.RedisEphemeralStore.RedisEphemeralStoreFactory;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.account.Account;
@@ -20,22 +20,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.Jedis;
 
 class RedisEphemeralStoreFactoryTest extends MailboxTestSuite {
 
-	@Container
-	static RedisContainer redisContainer = new RedisContainer(DockerImageName.parse("redis:6.2.6"));
+	@RegisterExtension
+	static final RedisExtension redis = new RedisExtension();
 
 	private static Provisioning provisioning;
 	private static Jedis jedisClient;
 
 	@BeforeAll
 	static void setup() {
-		redisContainer.start();
-		jedisClient = new Jedis("redis://localhost:" + redisContainer.getRedisPort());
+		jedisClient = new Jedis(redis.getHost(), redis.getPort());
 		provisioning = Provisioning.getInstance();
 	}
 
@@ -45,7 +43,7 @@ class RedisEphemeralStoreFactoryTest extends MailboxTestSuite {
 				createAccount().create();
 		provisioning
 				.getConfig()
-				.setEphemeralBackendURL("redis://localhost:" + redisContainer.getRedisPort());
+				.setEphemeralBackendURL("redis://" + redis.getHost() + ":" + redis.getPort());
 		final RedisEphemeralStoreFactory redisEphemeralStoreFactory = new RedisEphemeralStoreFactory();
 
 		final EphemeralStore store = redisEphemeralStoreFactory.getStore();
@@ -58,7 +56,7 @@ class RedisEphemeralStoreFactoryTest extends MailboxTestSuite {
 	void shouldReturnANonWorkingStore_WhenURLInvalid(String prefix) throws ServiceException {
 		final Account account =
 				createAccount().create();
-		provisioning.getConfig().setEphemeralBackendURL(prefix + redisContainer.getRedisPort());
+		provisioning.getConfig().setEphemeralBackendURL(prefix + redis.getPort());
 		final RedisEphemeralStoreFactory redisEphemeralStoreFactory = new RedisEphemeralStoreFactory();
 
 		final EphemeralStore store = redisEphemeralStoreFactory.getStore();
@@ -71,7 +69,7 @@ class RedisEphemeralStoreFactoryTest extends MailboxTestSuite {
 	void shouldNotCreateAdditionalConnections() throws ServiceException {
 		final Account account = createAccount().create();
 		provisioning.getConfig()
-				.setEphemeralBackendURL("redis://localhost:" + redisContainer.getRedisPort());
+				.setEphemeralBackendURL("redis://" + redis.getHost() + ":" + redis.getPort());
 
 		final RedisEphemeralStoreFactory redisEphemeralStoreFactory = new RedisEphemeralStoreFactory();
 

--- a/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
+++ b/store/src/test/java/com/zextras/mailbox/store/ephemeral/RedisEphemeralStoreTest.java
@@ -6,7 +6,7 @@
 
 package com.zextras.mailbox.store.ephemeral;
 
-import com.redis.testcontainers.RedisContainer;
+import com.zextras.mailbox.testcontainers.RedisExtension;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.ephemeral.EphemeralInput;
 import com.zimbra.cs.ephemeral.EphemeralInput.AbsoluteExpiration;
@@ -26,14 +26,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.Jedis;
 
 class RedisEphemeralStoreTest {
 
-  @Container
-  static RedisContainer redisContainer = new RedisContainer(DockerImageName.parse("redis:6.2.6"));
+  @RegisterExtension
+  static final RedisExtension redis = new RedisExtension();
 
   static Jedis jedisClient;
   private TestLocation location;
@@ -41,13 +40,12 @@ class RedisEphemeralStoreTest {
 
   @BeforeAll
   static void setUp() {
-    redisContainer.start();
-    jedisClient = new Jedis("redis://localhost:" + redisContainer.getRedisPort());
+    jedisClient = new Jedis(redis.getHost(), redis.getPort());
   }
 
   @AfterAll
   static void tearDown() {
-    redisContainer.stop();
+    jedisClient.close();
   }
 
   private static EphemeralInput[] generateInput() {
@@ -64,7 +62,7 @@ class RedisEphemeralStoreTest {
     jedisClient.flushAll();
     location = new TestLocation(new String[] {UUID.randomUUID().toString()});
     redisEphemeralStore = RedisEphemeralStore.create(
-        redisContainer.getRedisHost(), redisContainer.getRedisPort(), new GenericObjectPoolConfig<>());
+        redis.getHost(), redis.getPort(), new GenericObjectPoolConfig<>());
   }
   @AfterEach
   void afterEach() {

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/ContainerRuntime.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/ContainerRuntime.java
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+public final class ContainerRuntime {
+
+  private ContainerRuntime() {}
+
+  /**
+   * Returns {@code true} when the JVM runs inside a Kubernetes pod. The kubelet always injects
+   * {@code KUBERNETES_SERVICE_HOST} into in-cluster pods, so tests use it to pick a
+   * Kubernetes-backed resource in CI and fall back to Docker (testcontainers) locally.
+   */
+  public static boolean isKubernetes() {
+    return System.getenv("KUBERNETES_SERVICE_HOST") != null;
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/DockerRedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/DockerRedisResource.java
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+import com.redis.testcontainers.RedisContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** Docker-backed {@link RedisResource} using testcontainers. Used for local runs. */
+public class DockerRedisResource implements RedisResource {
+
+  private final RedisContainer container;
+
+  public DockerRedisResource(String image) {
+    container = new RedisContainer(DockerImageName.parse(image));
+    container.start();
+  }
+
+  @Override
+  public String getHost() {
+    return container.getRedisHost();
+  }
+
+  @Override
+  public int getPort() {
+    return container.getRedisPort();
+  }
+
+  @Override
+  public void close() {
+    container.stop();
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/DockerRedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/DockerRedisResource.java
@@ -7,7 +7,6 @@ package com.zextras.mailbox.testcontainers;
 import com.redis.testcontainers.RedisContainer;
 import org.testcontainers.utility.DockerImageName;
 
-/** Docker-backed {@link RedisResource} using testcontainers. Used for local runs. */
 public class DockerRedisResource implements RedisResource {
 
   private final RedisContainer container;

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesPods.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesPods.java
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerPort;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Launches short-lived pods for integration tests running inside a k3s/crun cluster.
+ *
+ * <p>This is the CI counterpart to testcontainers: where testcontainers needs a Docker daemon
+ * (absent under crun), this creates a real pod through the in-cluster Kubernetes API and waits
+ * until its ports accept connections. Since the test JVM and the launched pod share the cluster
+ * network there is no port mapping — callers connect straight to the pod IP on the container port.
+ *
+ * <p>The pod is scheduled with the {@code crun} RuntimeClass onto a worker node, matching the CI
+ * cluster layout. Override the RuntimeClass with {@code K8S_RUNTIME_CLASS} if your cluster differs.
+ */
+public final class KubernetesPods {
+
+  private static final Logger LOG = Logger.getLogger(KubernetesPods.class.getName());
+
+  private static final String DEFAULT_RUNTIME_CLASS = "crun";
+  private static final Duration RUNNING_TIMEOUT = Duration.ofMinutes(5);
+  private static final Duration PORT_TIMEOUT = Duration.ofMinutes(5);
+  private static final long POLL_INTERVAL_MS = 2_000;
+
+  private KubernetesPods() {}
+
+  public static LaunchedPod start(
+      String namePrefix,
+      String image,
+      List<Integer> ports,
+      Map<String, String> env,
+      List<String> args) {
+    CoreV1Api api = newApi();
+    String namespace = readNamespace();
+    String podName = namePrefix + "-" + System.nanoTime();
+
+    try {
+      api.createNamespacedPod(namespace, buildPod(podName, namespace, image, ports, env, null, args))
+          .execute();
+    } catch (ApiException e) {
+      throw new IllegalStateException("Failed to create pod " + podName + ": " + e.getResponseBody(), e);
+    }
+    LOG.info("Created pod " + podName + " in namespace " + namespace);
+
+    String podIP = waitForRunning(api, namespace, podName);
+    LOG.info("Pod " + podName + " running at IP " + podIP);
+
+    for (int port : ports) {
+      waitForPort(api, namespace, podName, podIP, port);
+    }
+    LOG.info("Pod " + podName + " is ready");
+
+    return new LaunchedPod(api, namespace, podName, podIP);
+  }
+
+  public static LaunchedPod startWithLogReadiness(
+      String namePrefix,
+      String image,
+      List<Integer> ports,
+      Map<String, String> env,
+      List<String> command,
+      List<String> args,
+      String readyLogRegex,
+      Duration readyTimeout) {
+    CoreV1Api api = newApi();
+    String namespace = readNamespace();
+    String podName = namePrefix + "-" + System.nanoTime();
+
+    try {
+      api.createNamespacedPod(
+              namespace, buildPod(podName, namespace, image, ports, env, command, args))
+          .execute();
+    } catch (ApiException e) {
+      throw new IllegalStateException("Failed to create pod " + podName + ": " + e.getResponseBody(), e);
+    }
+    LOG.info("Created pod " + podName + " in namespace " + namespace);
+
+    String podIP = waitForRunning(api, namespace, podName);
+    LOG.info("Pod " + podName + " running at IP " + podIP);
+
+    LaunchedPod pod = new LaunchedPod(api, namespace, podName, podIP);
+    pod.waitForLog(readyLogRegex, readyTimeout);
+    LOG.info("Pod " + podName + " is ready");
+    return pod;
+  }
+
+  private static CoreV1Api newApi() {
+    try {
+      ApiClient client = ClientBuilder.cluster().build();
+      Configuration.setDefaultApiClient(client);
+      return new CoreV1Api();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to build in-cluster Kubernetes client", e);
+    }
+  }
+
+  private static V1Pod buildPod(
+      String podName,
+      String namespace,
+      String image,
+      List<Integer> ports,
+      Map<String, String> env,
+      List<String> command,
+      List<String> args) {
+    List<V1ContainerPort> containerPorts = new ArrayList<>();
+    for (int port : ports) {
+      containerPorts.add(new V1ContainerPort().containerPort(port));
+    }
+    List<V1EnvVar> envVars = new ArrayList<>();
+    env.forEach((k, v) -> envVars.add(new V1EnvVar().name(k).value(v)));
+
+    V1Container container =
+        new V1Container().name("main").image(image).ports(containerPorts).env(envVars);
+    if (command != null && !command.isEmpty()) {
+      container.command(command);
+    }
+    if (args != null && !args.isEmpty()) {
+      container.args(args);
+    }
+
+    V1PodSpec spec =
+        new V1PodSpec()
+            .containers(List.of(container))
+            .restartPolicy("Never")
+            .runtimeClassName(runtimeClass())
+            .nodeSelector(Map.of("node-role.kubernetes.io/worker", "true"));
+    // client-java initializes overhead to an empty HashMap, which the admission webhook rejects
+    // when the crun RuntimeClass defines no overhead. Null it so the field is omitted entirely.
+    spec.setOverhead(null);
+
+    String pullSecret = System.getenv("K8S_IMAGE_PULL_SECRET");
+    if (pullSecret != null && !pullSecret.isBlank()) {
+      spec.imagePullSecrets(List.of(new V1LocalObjectReference().name(pullSecret)));
+    }
+
+    return new V1Pod()
+        .apiVersion("v1")
+        .kind("Pod")
+        .metadata(
+            new V1ObjectMeta()
+                .name(podName)
+                .namespace(namespace)
+                .labels(Map.of("app", podName, "managed-by", "carbonio-mailbox-tests")))
+        .spec(spec);
+  }
+
+  private static String runtimeClass() {
+    String override = System.getenv("K8S_RUNTIME_CLASS");
+    return (override != null && !override.isBlank()) ? override : DEFAULT_RUNTIME_CLASS;
+  }
+
+  private static String waitForRunning(CoreV1Api api, String namespace, String podName) {
+    Instant deadline = Instant.now().plus(RUNNING_TIMEOUT);
+    while (Instant.now().isBefore(deadline)) {
+      try {
+        V1PodStatus status = api.readNamespacedPod(podName, namespace).execute().getStatus();
+        String phase = status != null ? status.getPhase() : null;
+        if ("Running".equals(phase) && status.getPodIP() != null && !status.getPodIP().isBlank()) {
+          return status.getPodIP();
+        }
+        if ("Failed".equals(phase) || "Succeeded".equals(phase)) {
+          deleteSilently(api, namespace, podName);
+          throw new IllegalStateException("Pod " + podName + " entered terminal phase: " + phase);
+        }
+        LOG.info("Waiting for pod " + podName + " (phase: " + phase + ")");
+        sleep();
+      } catch (ApiException e) {
+        throw new IllegalStateException("Error reading pod " + podName + ": " + e.getResponseBody(), e);
+      }
+    }
+    deleteSilently(api, namespace, podName);
+    throw new IllegalStateException("Timeout waiting for pod " + podName + " to be Running");
+  }
+
+  private static void waitForPort(
+      CoreV1Api api, String namespace, String podName, String podIP, int port) {
+    Instant deadline = Instant.now().plus(PORT_TIMEOUT);
+    while (Instant.now().isBefore(deadline)) {
+      try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress(podIP, port), 2_000);
+        return;
+      } catch (IOException notReady) {
+        sleep();
+      }
+    }
+    deleteSilently(api, namespace, podName);
+    throw new IllegalStateException("Timeout waiting for port " + port + " on pod " + podName);
+  }
+
+  private static void deleteSilently(CoreV1Api api, String namespace, String podName) {
+    try {
+      api.deleteNamespacedPod(podName, namespace).execute();
+    } catch (ApiException ignored) {
+      // best-effort cleanup
+    }
+  }
+
+  private static String readNamespace() {
+    try {
+      return Files.readString(Paths.get("/var/run/secrets/kubernetes.io/serviceaccount/namespace"))
+          .strip();
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Failed to read namespace from serviceaccount — is this running inside a pod?", e);
+    }
+  }
+
+  private static void sleep() {
+    try {
+      Thread.sleep(POLL_INTERVAL_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for pod", e);
+    }
+  }
+
+  /** Handle to a running pod: exposes its cluster IP and deletes it on {@link #delete()}. */
+  public static final class LaunchedPod {
+
+    private final CoreV1Api api;
+    private final String namespace;
+    private final String podName;
+    private final String podIP;
+
+    private LaunchedPod(CoreV1Api api, String namespace, String podName, String podIP) {
+      this.api = api;
+      this.namespace = namespace;
+      this.podName = podName;
+      this.podIP = podIP;
+    }
+
+    public String ip() {
+      return podIP;
+    }
+
+    public void waitForLog(String regex, Duration timeout) {
+      Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
+      Instant deadline = Instant.now().plus(timeout);
+      while (Instant.now().isBefore(deadline)) {
+        try {
+          String log = api.readNamespacedPodLog(podName, namespace).container("main").execute();
+          if (log != null && pattern.matcher(log).find()) {
+            return;
+          }
+        } catch (ApiException notReady) {
+          // log endpoint not ready yet
+        }
+        sleep();
+      }
+      deleteSilently(api, namespace, podName);
+      throw new IllegalStateException("Timeout waiting for log /" + regex + "/ on pod " + podName);
+    }
+
+    public void delete() {
+      try {
+        api.deleteNamespacedPod(podName, namespace).execute();
+        LOG.info("Deleted pod " + podName);
+      } catch (ApiException e) {
+        LOG.warning("Failed to delete pod " + podName + ": " + e.getResponseBody());
+      }
+    }
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesRedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesRedisResource.java
@@ -8,7 +8,6 @@ import com.zextras.mailbox.testcontainers.KubernetesPods.LaunchedPod;
 import java.util.List;
 import java.util.Map;
 
-/** Kubernetes-pod-backed {@link RedisResource}. Used when running inside a k3s/crun cluster. */
 public class KubernetesRedisResource implements RedisResource {
 
   private static final int PORT = 6379;

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesRedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/KubernetesRedisResource.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+import com.zextras.mailbox.testcontainers.KubernetesPods.LaunchedPod;
+import java.util.List;
+import java.util.Map;
+
+/** Kubernetes-pod-backed {@link RedisResource}. Used when running inside a k3s/crun cluster. */
+public class KubernetesRedisResource implements RedisResource {
+
+  private static final int PORT = 6379;
+
+  private final LaunchedPod pod;
+
+  public KubernetesRedisResource(String image) {
+    this.pod = KubernetesPods.start("redis-test", image, List.of(PORT), Map.of(), List.of());
+  }
+
+  @Override
+  public String getHost() {
+    return pod.ip();
+  }
+
+  @Override
+  public int getPort() {
+    return PORT;
+  }
+
+  @Override
+  public void close() {
+    pod.delete();
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/RedisExtension.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/RedisExtension.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension providing a shared Redis instance for the whole JVM. It selects a Kubernetes
+ * pod when running inside a cluster ({@link ContainerRuntime#isKubernetes()}) and a Docker
+ * container (testcontainers) otherwise.
+ *
+ * <p>Register it as a static field so tests keep calling {@code getHost()/getPort()}:
+ *
+ * <pre>{@code
+ * @RegisterExtension
+ * static final RedisExtension redis = new RedisExtension();
+ * }</pre>
+ *
+ * <p>The instance is a JVM-wide singleton so it starts once and is torn down on JVM shutdown.
+ */
+public class RedisExtension implements BeforeAllCallback {
+
+  private static final String IMAGE = "redis:6.2.6";
+
+  private static volatile RedisResource shared;
+
+  public static synchronized RedisResource sharedResource() {
+    if (shared == null) {
+      shared =
+          ContainerRuntime.isKubernetes()
+              ? new KubernetesRedisResource(IMAGE)
+              : new DockerRedisResource(IMAGE);
+      Runtime.getRuntime().addShutdownHook(new Thread(shared::close));
+    }
+    return shared;
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    sharedResource();
+  }
+
+  public String getHost() {
+    return sharedResource().getHost();
+  }
+
+  public int getPort() {
+    return sharedResource().getPort();
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/RedisExtension.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/RedisExtension.java
@@ -7,20 +7,6 @@ package com.zextras.mailbox.testcontainers;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-/**
- * JUnit 5 extension providing a shared Redis instance for the whole JVM. It selects a Kubernetes
- * pod when running inside a cluster ({@link ContainerRuntime#isKubernetes()}) and a Docker
- * container (testcontainers) otherwise.
- *
- * <p>Register it as a static field so tests keep calling {@code getHost()/getPort()}:
- *
- * <pre>{@code
- * @RegisterExtension
- * static final RedisExtension redis = new RedisExtension();
- * }</pre>
- *
- * <p>The instance is a JVM-wide singleton so it starts once and is torn down on JVM shutdown.
- */
 public class RedisExtension implements BeforeAllCallback {
 
   private static final String IMAGE = "redis:6.2.6";

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/RedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/RedisResource.java
@@ -4,10 +4,6 @@
 
 package com.zextras.mailbox.testcontainers;
 
-/**
- * A running Redis instance, backed either by a Docker container (testcontainers) or a Kubernetes
- * pod. Tests only need the connection details, so they are agnostic to the backend.
- */
 public interface RedisResource {
 
   String getHost();

--- a/store/src/test/java/com/zextras/mailbox/testcontainers/RedisResource.java
+++ b/store/src/test/java/com/zextras/mailbox/testcontainers/RedisResource.java
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.mailbox.testcontainers;
+
+/**
+ * A running Redis instance, backed either by a Docker container (testcontainers) or a Kubernetes
+ * pod. Tests only need the connection details, so they are agnostic to the backend.
+ */
+public interface RedisResource {
+
+  String getHost();
+
+  int getPort();
+
+  void close();
+}


### PR DESCRIPTION
I didn't consider yet making a java library, but perhaps we should do it.

There are two classes than can be extracted in a library: KubernetesPods and the strategy pattern (ContainerRuntime).

Everything else is just an interface that implements two variations of the contracts: docker or kubernetes.
Every project should maintain their own, based on contract preferences and needs.