### PR TITLE
feat(IN-1096): resolve Maven deps from Nexus, mirror deploys to Nexus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ target/
 /attribute-manager/
 /store/cacerts
 /store/cacerts_trusted
+
+# Local Maven settings — contain Nexus credentials, never commit
+nexus-maven-settings.xml

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -12,6 +12,8 @@
              is re-expanded into the installed/deployed pom even on a cache hit.
              Omitting it publishes a pom with unresolved ${revision} (invalid pom). -->
         <plugin artifactId="flatten-maven-plugin"/>
+        <plugin artifactId="maven-install-plugin"/>
+        <plugin artifactId="maven-deploy-plugin"/>
       </plugins>
     </runAlways>
   </executionControl>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v3.0.2',
+        identifier: 'jenkins-lib-common@v4.1.3',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
@@ -160,13 +160,23 @@ pipeline {
 
                 stage('Publish to maven') {
                     when {
-                        buildingTag()
+                        anyOf {
+                            buildingTag()
+                            expression { params.PLAYGROUND }
+                        }
                     }
                     steps {
                         container('jdk-21') {
-                            withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                                script {
-                                    sh "mvn ${MVN_OPTS} -s " + SETTINGS_PATH + " deploy -DskipTests=true"
+                            script {
+                                boolean pg = params.PLAYGROUND
+                                withCredentials([file(credentialsId: pg ? 'nexus-maven-settings.xml' : 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                                    sh """#!/bin/bash
+                                        set -o pipefail
+                                        mvn ${MVN_OPTS} -s \$SETTINGS_PATH deploy -DskipTests=true ${pg ? '-DaltDeploymentRepository=nexus-prod::https://repo.zextras.tools/repository/pg-public-maven-repo/' : ''} | tee mvn-deploy.log
+                                    """
+                                }
+                                if (!pg) {
+                                    nexusHelper.uploadMavenFromDeployLog(readFile('mvn-deploy.log'))
                                 }
                             }
                         }

--- a/packages/yap.json
+++ b/packages/yap.json
@@ -3,7 +3,7 @@
   "description": "Zextras Suite",
   "name": "carbonio-mailbox",
   "output": "artifacts",
-  "skipDeps": ["pending-setups", "service-discover", "service-discover-base"],
+  "skipDeps": ["carbonio-core", "pending-setups", "service-discover", "service-discover-base"],
   "projects": [
     {
       "name": "appserver-conf"

--- a/pom.xml
+++ b/pom.xml
@@ -877,21 +877,13 @@
   </dependencyManagement>
 
   <!--
-    DEPLOY: JFrog stays the deploy target during the parallel-run window (PR #1112): `mvn deploy`
-    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog() mirrors the
-    same artifacts to Nexus best-effort. At cutover this block flips to
+    JFrog stays the deploy target during the parallel-run window: `mvn deploy`
+    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog()
+    mirrors the same artifacts to Nexus best-effort. At cutover this block flips to
     https://repo.zextras.tools/repository/public-maven-repo/ (release) and
-    .../maven-snapshots/ (snapshot).
-    The <id>artifactory</id> below must match the <server> id in jenkins-maven-settings.xml.
-
-    RESOLUTION: <repositories> and <pluginRepositories> are intentionally absent. Dependency and
-    plugin resolution is supplied entirely by the Maven client settings.xml — the Jenkins file
-    credentials nexus-maven-settings.xml / jenkins-maven-settings.xml injected at Jenkinsfile
-    ~line 172 — via a single <mirror id="nexus-mirror"><mirrorOf>*</mirrorOf></mirror> pointing
-    at https://repo.zextras.tools/repository/java-sdk/ (a Nexus group that includes the
-    maven-central proxy). WARNING: a build run WITHOUT that settings.xml resolves straight from
-    Maven Central and silently bypasses Nexus. This change must NOT be merged until the
-    maven-central proxy repository exists inside the java-sdk group in Nexus.
+    .../maven-snapshots/ (snapshot), and the mirror call is dropped.
+    The <id>artifactory</id> below must match the <server> id configured in the
+    jenkins-maven-settings.xml credential.
   -->
   <distributionManagement>
     <repository>
@@ -903,6 +895,54 @@
       <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
     </snapshotRepository>
   </distributionManagement>
+
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>fuse</id>
+      <url>https://repo.fusesource.com/maven2/</url>
+    </repository>
+    <repository>
+      <id>zextras-java-sdk</id>
+      <name>Zextras Java SDK (Nexus group)</name>
+      <url>https://repo.zextras.tools/repository/java-sdk/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>zextras-public-snapshots</id>
+      <name>Zextras public maven snapshot repository</name>
+      <url>https://repo.zextras.tools/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>fuse</id>
+      <url>https://repo.fusesource.com/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>zextras-java-sdk</id>
+      <url>https://repo.zextras.tools/repository/java-sdk/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <!-- Define common plugins used by each project -->
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -877,13 +877,21 @@
   </dependencyManagement>
 
   <!--
-    JFrog stays the deploy target during the parallel-run window: `mvn deploy`
-    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog()
-    mirrors the same artifacts to Nexus best-effort. At cutover this block flips to
+    DEPLOY: JFrog stays the deploy target during the parallel-run window (PR #1112): `mvn deploy`
+    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog() mirrors the
+    same artifacts to Nexus best-effort. At cutover this block flips to
     https://repo.zextras.tools/repository/public-maven-repo/ (release) and
-    .../maven-snapshots/ (snapshot), and the mirror call is dropped.
-    The <id>artifactory</id> below must match the <server> id configured in the
-    jenkins-maven-settings.xml credential.
+    .../maven-snapshots/ (snapshot).
+    The <id>artifactory</id> below must match the <server> id in jenkins-maven-settings.xml.
+
+    RESOLUTION: <repositories> and <pluginRepositories> are intentionally absent. Dependency and
+    plugin resolution is supplied entirely by the Maven client settings.xml — the Jenkins file
+    credentials nexus-maven-settings.xml / jenkins-maven-settings.xml injected at Jenkinsfile
+    ~line 172 — via a single <mirror id="nexus-mirror"><mirrorOf>*</mirrorOf></mirror> pointing
+    at https://repo.zextras.tools/repository/java-sdk/ (a Nexus group that includes the
+    maven-central proxy). WARNING: a build run WITHOUT that settings.xml resolves straight from
+    Maven Central and silently bypasses Nexus. This change must NOT be merged until the
+    maven-central proxy repository exists inside the java-sdk group in Nexus.
   -->
   <distributionManagement>
     <repository>
@@ -895,54 +903,6 @@
       <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
     </snapshotRepository>
   </distributionManagement>
-
-
-  <repositories>
-    <repository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-    <repository>
-      <id>fuse</id>
-      <url>https://repo.fusesource.com/maven2/</url>
-    </repository>
-    <repository>
-      <id>zextras-java-sdk</id>
-      <name>Zextras Java SDK (Nexus group)</name>
-      <url>https://repo.zextras.tools/repository/java-sdk/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>zextras-public-snapshots</id>
-      <name>Zextras public maven snapshot repository</name>
-      <url>https://repo.zextras.tools/repository/maven-snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>fuse</id>
-      <url>https://repo.fusesource.com/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>zextras-java-sdk</id>
-      <url>https://repo.zextras.tools/repository/java-sdk/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <!-- Define common plugins used by each project -->
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -876,15 +876,24 @@
     </dependencies>
   </dependencyManagement>
 
+  <!--
+    JFrog stays the deploy target during the parallel-run window: `mvn deploy`
+    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog()
+    mirrors the same artifacts to Nexus best-effort. At cutover this block flips to
+    https://repo.zextras.tools/repository/public-maven-repo/ (release) and
+    .../maven-snapshots/ (snapshot), and the mirror call is dropped.
+    The <id>artifactory</id> below must match the <server> id configured in the
+    jenkins-maven-settings.xml credential.
+  -->
   <distributionManagement>
     <repository>
       <id>artifactory</id>
       <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
     </repository>
-      <snapshotRepository>
-        <id>artifactory</id>
-        <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
-      </snapshotRepository>
+    <snapshotRepository>
+      <id>artifactory</id>
+      <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
+    </snapshotRepository>
   </distributionManagement>
 
 
@@ -899,12 +908,19 @@
     </repository>
     <repository>
       <id>zextras-java-sdk</id>
-      <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
+      <name>Zextras Java SDK (Nexus group)</name>
+      <url>https://repo.zextras.tools/repository/java-sdk/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
     <repository>
       <id>zextras-public-snapshots</id>
       <name>Zextras public maven snapshot repository</name>
-      <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
+      <url>https://repo.zextras.tools/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -924,7 +940,7 @@
     </pluginRepository>
     <pluginRepository>
       <id>zextras-java-sdk</id>
-      <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
+      <url>https://repo.zextras.tools/repository/java-sdk/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
- pom.xml: repositories/pluginRepositories resolve from repo.zextras.tools (java-sdk group, maven-snapshots). distributionManagement still targets JFrog for the parallel-run window; the cutover URLs are documented inline.
- Jenkinsfile: bump jenkins-lib-common to v4.1.3. Tag builds deploy to JFrog, then nexusHelper.uploadMavenFromDeployLog() mirrors the same artifacts to Nexus.
- .mvn/maven-build-cache-config.xml: run maven-install-plugin and maven-deploy-plugin always, so a build-cache hit still publishes.