### PR TITLE
feat(IN-1096): resolve all Maven deps through the Nexus mirror

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -877,13 +877,21 @@
   </dependencyManagement>
 
   <!--
-    JFrog stays the deploy target during the parallel-run window: `mvn deploy`
-    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog()
-    mirrors the same artifacts to Nexus best-effort. At cutover this block flips to
+    DEPLOY: JFrog stays the deploy target during the parallel-run window (PR #1112): `mvn deploy`
+    publishes here, and jenkins-lib-common's nexusHelper.uploadMavenFromDeployLog() mirrors the
+    same artifacts to Nexus best-effort. At cutover this block flips to
     https://repo.zextras.tools/repository/public-maven-repo/ (release) and
-    .../maven-snapshots/ (snapshot), and the mirror call is dropped.
-    The <id>artifactory</id> below must match the <server> id configured in the
-    jenkins-maven-settings.xml credential.
+    .../maven-snapshots/ (snapshot).
+    The <id>artifactory</id> below must match the <server> id in jenkins-maven-settings.xml.
+
+    RESOLUTION: <repositories> and <pluginRepositories> are intentionally absent. Dependency and
+    plugin resolution is supplied entirely by the Maven client settings.xml — the Jenkins file
+    credentials nexus-maven-settings.xml / jenkins-maven-settings.xml injected at Jenkinsfile
+    ~line 172 — via a single <mirror id="nexus-mirror"><mirrorOf>*</mirrorOf></mirror> pointing
+    at https://repo.zextras.tools/repository/java-sdk/ (a Nexus group that includes the
+    maven-central proxy). WARNING: a build run WITHOUT that settings.xml resolves straight from
+    Maven Central and silently bypasses Nexus. This change must NOT be merged until the
+    maven-central proxy repository exists inside the java-sdk group in Nexus.
   -->
   <distributionManagement>
     <repository>
@@ -895,54 +903,6 @@
       <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
     </snapshotRepository>
   </distributionManagement>
-
-
-  <repositories>
-    <repository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-    <repository>
-      <id>fuse</id>
-      <url>https://repo.fusesource.com/maven2/</url>
-    </repository>
-    <repository>
-      <id>zextras-java-sdk</id>
-      <name>Zextras Java SDK (Nexus group)</name>
-      <url>https://repo.zextras.tools/repository/java-sdk/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>zextras-public-snapshots</id>
-      <name>Zextras public maven snapshot repository</name>
-      <url>https://repo.zextras.tools/repository/maven-snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>fuse</id>
-      <url>https://repo.fusesource.com/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>zextras-java-sdk</id>
-      <url>https://repo.zextras.tools/repository/java-sdk/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <!-- Define common plugins used by each project -->
   <build>


### PR DESCRIPTION
Follow-up to #1112. Makes Nexus a **true** Maven mirror ([guide](https://maven.apache.org/guides/mini/guide-mirror-settings.html)) so `pom.xml` can drop every repository declaration.

Based on `IN-1096` so the diff stays scoped; GitHub retargets this to `devel` when #1112 merges.

> [!IMPORTANT]
> **Correction to the original description of this PR.** It claimed resolution was already supplied by the settings.xml injected in the `Jenkinsfile`. That was wrong, and PR #1112 build **#4** proved it — see below. Only the deploy stage passed `-s`. The Jenkinsfile fix is now part of this PR.

## :warning: Blocked on infra — do not merge yet

### 1. Nexus has no Maven proxy repository at all

`GET /service/rest/v1/repositories` returns `type: hosted` for every `maven2` repo. The only groups (`maven-public`, `java-sdk`) aggregate hosted repos and proxy nothing:

```
GET /repository/java-sdk/junit/junit/4.13.2/junit-4.13.2.pom     -> 404
GET /repository/maven-public/.../maven-clean-plugin-3.2.0.pom    -> 404
```

A `maven-central` proxy (`https://repo1.maven.org/maven2/`) must be added and appended as the **last** member of the `java-sdk` group, so hosted internal artifacts keep precedence. Terraform patch is ready in `infra-nexus`.

### 2. Both Jenkins settings credentials need the mirror

`nexus-maven-settings.xml` **and** `jenkins-maven-settings.xml`. Non-PLAYGROUND builds use the latter, so it is the one that matters for `devel` and tags. Each needs `<mirrorOf>*</mirrorOf>`, a `<server id=nexus-mirror>`, and the snapshot-policy profile.

Merge order: proxy applied → both credentials updated → this PR.

## What the failed build taught us

This landed on `IN-1096` prematurely and broke #1112, which was green at build #2. Build **#4**:

```
[ERROR] dependency: ical4j:ical4j:jar:0.9.16-patched (compile)
[ERROR] 	Could not find artifact ical4j:ical4j:jar:0.9.16-patched in central (https://repo.maven.apache.org/maven2)
[ERROR] dependency: com.zextras:mailbox-attribute-manager:jar:5.0.0 (runtime)
[ERROR] 	Could not find artifact com.zextras:mailbox-attribute-manager:jar:5.0.0 in central (https://repo.maven.apache.org/maven2)
```

The decisive detail is the repository name: **`central (https://repo.maven.apache.org/maven2)`**. The mirror was never consulted, because only the deploy stage passed `-s $SETTINGS_PATH`. Every other stage ran plain `mvn` and was silently resolving the patched `ical4j` and the internal `com.zextras` artifacts out of `pom.xml`'s `<repositories>`.

That is a pre-existing hole worth naming on its own: before this PR, six of seven `mvn` invocations bypassed Nexus entirely, so the JFrog→Nexus migration was only ever half in effect. #1112 has been reverted on `IN-1096` and is green again.

## Changes

**`pom.xml`** — delete `<repositories>` and `<pluginRepositories>` (−54 lines).

| Removed | Why |
|---|---|
| `central` | Comes from the Maven super-POM; `mirrorOf *` already captures it. |
| `fuse` | Dead. `https://repo.fusesource.com/maven2/` returns **404** (live path is `/nexus/content/groups/public/`) and no artifact in the build resolves from it. |
| `zextras-java-sdk`, `zextras-public-snapshots` | Superseded by the mirror. |

`<distributionManagement>` untouched — mirrors govern resolution only, so deploys keep targeting JFrog through #1112's parallel-run window.

**`Jenkinsfile`** — add a `withMavenSettings` helper beside `isBuildingTag()` binding the same PLAYGROUND-conditional credential deploy already chose, and wrap all seven `mvn` invocations (build, UT/IT, flaky/API/E2E, API docs, Sonar, deploy). Deploy drops its duplicate `withCredentials` block.

## Verification

**Mirror captures everything.** Real `mvn` run against the new settings — all traffic through the mirror, and Maven's repository list collapses to two entries with no Central:

```
Downloading from nexus-mirror: https://repo.zextras.tools/repository/java-sdk/org/apache/maven/plugins/maven-metadata.xml
... available from the repositories [local (...), nexus-mirror (https://repo.zextras.tools/repository/java-sdk/)]
```

**Fails without the proxy, as expected** — `maven-clean-plugin:3.2.0 was not found in https://repo.zextras.tools/repository/java-sdk/`.

**Succeeds once Central is reachable through the mirror.** Same settings, mirror URL swapped to a Central-serving endpoint, run against this branch's `pom.xml`:

```
rc=0  BUILD SUCCESS
effective-pom -> repositories: 1, pluginRepositories: 1, ids: ['central'], snapshots enabled: true
```

The profile, not the POM, supplies the repository.

**`Jenkinsfile`** parses under Groovy 4.0.22 at `Phases.CONVERSION`. Declarative-DSL semantics are not covered by that check and will be confirmed by the first PR build.

## Note on snapshots

A mirror rewrites the **URL**, not repository **policies**, and the super-POM's `central` disables snapshots. With POM `<repositories>` gone, the settings profile must redeclare `id=central` with snapshots enabled. `pom.xml` has 0 `-SNAPSHOT` refs today, so this is latent — but without it the first snapshot dependency added after this merge fails with a misleading "not found".
