### PR TITLE
fix(IN-1096): bump jenkins-lib-common to v4.1.4 to unblock the Nexus maven mirror

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v4.1.3',
+        identifier: 'jenkins-lib-common@v4.1.4',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Bumps `jenkins-lib-common` `v4.1.3` → `v4.1.4`. One line.

## Why

Tag **4.31.0 #1** deployed every Maven artifact to JFrog and mirrored **none** of them to Nexus — while reporting `SUCCESS`.

| | 4.31.0 |
|---|---|
| JFrog `public-maven-repo` | ✅ `zm-common`, `zm-soap`, `zm-client`, `zm-store`, `right-manager`, … |
| Nexus `public-maven-repo` | ❌ **0 items** (also 0 for 4.30.0 — the maven mirror has never worked) |

From that build's console:

```
[nexusHelper] WARNING: could not read or parse common/.flattened-pom.xml for zm-common:4.31.0
  (Scripts not permitted to use new groovy.util.XmlSlurper boolean boolean) — skipping the whole coordinate
[nexusHelper] WARNING: could not read or parse store/.flattened-pom.xml for zm-store:4.31.0 (...)
[nexusHelper] No coordinate has both its artifact(s) and its POM available — nothing to mirror to Nexus
```

`nexusHelper._groupIdFromPom` used `new XmlSlurper(false, false)`. This `Jenkinsfile` loads the library **dynamically** (`retriever: modernSCM(...)`), which runs it **inside the Groovy sandbox** — only trusted Global Pipeline Libraries bypass it, and that constructor has no script-security whitelist entry. So every coordinate lost its POM, `uploadMavenFromDeployLog`'s per-coordinate guard swallowed the failure by design (a bad POM must not fail a build whose deploy already succeeded), and the mirror silently published nothing while the build stayed green.

Fixed upstream in zextras/jenkins-lib-common#155 (merged, released as `v4.1.4`): the groupId is parsed textually, accepted only at project level, so a dependency's or parent's groupId can never be published as the artifact's own.

## What this does NOT change

- `<distributionManagement>` still targets JFrog for the parallel-run window.
- Dependency resolution still comes from the Nexus `<repositories>` declared in `pom.xml` by #1112.
- The deploy side was never at fault: the `Uploaded to artifactory:` and `Installing …` lines the mirror parses were all present and correct in 4.31.0 #1. Only the POM read was blocked.

## Verification

- `v4.1.4` is tagged and contains the fix: `_projectLevelGroupId` present, no `new XmlSlurper(...)` call remaining (only a doc-comment mention).
- Upstream suite on that tag: **290 tests, 0 failures**, including 8 new cases covering flatten-maven-plugin's output shape where `<parent>` precedes the project's own `groupId`.
- End-to-end proof requires a tag build, since `Publish to maven` only runs on `buildingTag()` or `PLAYGROUND`. A `PLAYGROUND=true` run exercises the same code path against `pg-public-maven-repo` and is the cheap pre-merge check.

## Still outstanding after this merges

**4.31.0's artifacts remain missing from Nexus.** This bump fixes the *next* tag, not the one already cut. Nexus never received them, so `ALLOW_ONCE` is not yet an obstacle — but replaying the tag build would re-deploy to JFrog, which may reject overwriting a released version. They likely need mirroring out-of-band from the JFrog copies.
