### PR TITLE
ci: use mavenDeploy from jenkins-lib-common v4.3.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v4.3.0',
+        identifier: 'jenkins-lib-common@v4.3.1',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@v4.1.4',
+        identifier: 'jenkins-lib-common@v4.3.0',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
@@ -166,19 +166,15 @@ pipeline {
                         }
                     }
                     steps {
-                        container('jdk-21') {
-                            script {
-                                boolean pg = params.PLAYGROUND
-                                withCredentials([file(credentialsId: pg ? 'nexus-maven-settings.xml' : 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                                    sh """#!/bin/bash
-                                        set -o pipefail
-                                        mvn ${MVN_OPTS} -s \$SETTINGS_PATH deploy -DskipTests=true ${pg ? '-DaltDeploymentRepository=nexus-prod::https://repo.zextras.tools/repository/pg-public-maven-repo/' : ''} | tee mvn-deploy.log
-                                    """
-                                }
-                                if (!pg) {
-                                    nexusHelper.uploadMavenFromDeployLog(readFile('mvn-deploy.log'))
-                                }
-                            }
+                        script {
+                            boolean pg = params.PLAYGROUND
+                            mavenDeploy(
+                                    container: 'jdk-21',
+                                    credentialsId: pg ? 'nexus-maven-settings.xml' : 'jenkins-maven-settings.xml',
+                                    mvnOpts: MVN_OPTS,
+                                    extraArgs: '-DskipTests=true' + (pg ? ' -DaltDeploymentRepository=nexus-prod::https://repo.zextras.tools/repository/pg-public-maven-repo/' : ''),
+                                    mirrorToNexus: !pg,
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
Bumps the `jenkins-lib-common` pin to `v4.3.0` and replaces the hand-rolled `mvn deploy` block in the `Publish to maven` stage with a single `mavenDeploy(...)` call. This repo is the reference implementation the new shared var was modeled on ([docs/api/maven-deploy.md](https://github.com/zextras/jenkins-lib-common/blob/v4.3.0/docs/api/maven-deploy.md) uses this exact PLAYGROUND pattern as its example).

This is a de-duplication, not a bug fix — the existing block already works correctly.

**Preserved semantics:**
- Stage `when { anyOf { buildingTag(); expression { params.PLAYGROUND } } }` — unchanged.
- Conditional credential: `nexus-maven-settings.xml` under PLAYGROUND, `jenkins-maven-settings.xml` otherwise.
- `-DskipTests=true` plus the conditional `-DaltDeploymentRepository=nexus-prod::https://repo.zextras.tools/repository/pg-public-maven-repo/` under PLAYGROUND, mapped to `extraArgs`.
- `mvnOpts: MVN_OPTS` (`-Ddebug=0 -Dis-production=1 -Pprod`).
- `mirrorToNexus: !pg` — under PLAYGROUND the deploy already goes straight to Nexus via `-DaltDeploymentRepository`, so mirroring is skipped there to avoid a double upload. Outside PLAYGROUND (tag builds), the mirror still runs.
- `container: 'jdk-21'`.

**One behavioral wrinkle, called out explicitly:** `mavenDeploy` invokes `nexusHelper.uploadMavenFromDeployLog` *after* the `container()` closure exits (a deliberate, uniform choice across all `mavenDeploy` callers — see the library docs). This repo's previous hand-rolled code called the mirror *from inside* `container('jdk-21')`, and mailbox's tag builds show that in-container call working. So this is a consistency change to match the shared helper's behavior, not a fix for a known failure in this repo.

Refs IN-1168: https://zextras.atlassian.net/browse/IN-1168

**Not merging this PR** — opened for review/evidence gathering only.

**Verification:** the stage only runs on `buildingTag()` or `params.PLAYGROUND`; this branch is neither, so a normal build of this PR will not exercise the changed stage. See the job report for a PLAYGROUND build's log evidence (or an honest note if one could not safely be triggered).