### PR TITLE
feat(CO-4037): audit log for folder import/export operations

### DIFF
--- a/store/src/main/java/com/zextras/mailbox/audit/ImportExportAuditLog.java
+++ b/store/src/main/java/com/zextras/mailbox/audit/ImportExportAuditLog.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package com.zextras.mailbox.audit;
+
+import com.zimbra.common.util.Log;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.mailbox.Folder;
+import com.zimbra.cs.service.UserServletContext;
+import com.zimbra.cs.service.formatter.FormatterFactory.FormatType;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Audit trail for folder import/export operations performed through the UserServlet, so
+ * administrators can monitor which users imported or exported which folders.
+ */
+public class ImportExportAuditLog {
+
+  public enum Outcome {
+    SUCCESS,
+    ERROR,
+    PARTIAL
+  }
+
+  private static final Set<FormatType> AUDITED_FORMATS =
+      EnumSet.of(
+          FormatType.TGZ,
+          FormatType.TAR,
+          FormatType.ZIP,
+          FormatType.CSV,
+          FormatType.ICS,
+          FormatType.VCF,
+          FormatType.LDIF,
+          FormatType.NETSCAPELDIF);
+
+  private final Log log;
+
+  public ImportExportAuditLog(Log log) {
+    this.log = log;
+  }
+
+  public boolean isAuditable(UserServletContext context) {
+    return context.target instanceof Folder
+        && context.formatter != null
+        && AUDITED_FORMATS.contains(context.formatter.getType());
+  }
+
+  public void logExport(UserServletContext context, boolean failed, long size) {
+    log.info(buildLine("FolderExport", context, failed, size));
+  }
+
+  public void logImport(UserServletContext context, boolean failed, long size) {
+    log.info(buildLine("FolderImport", context, failed, size));
+  }
+
+  private String buildLine(String cmd, UserServletContext context, boolean failed, long size) {
+    return ZimbraLog.encodeAttrs(
+        new String[] {
+          "cmd", cmd,
+          "account", targetAccountName(context),
+          "authAccount", authAccountName(context),
+          "folder", ((Folder) context.target).getPath(),
+          "fmt", context.formatter.getType().toString(),
+          "outcome", resolveOutcome(context, failed).name().toLowerCase(Locale.ROOT),
+          "size", String.valueOf(size)
+        });
+  }
+
+  private Outcome resolveOutcome(UserServletContext context, boolean failed) {
+    if (failed || context.getLoggedError() != null) {
+      return Outcome.ERROR;
+    }
+    if (context.hasPartialResults()) {
+      return Outcome.PARTIAL;
+    }
+    return Outcome.SUCCESS;
+  }
+
+  private String targetAccountName(UserServletContext context) {
+    return context.targetAccount != null ? context.targetAccount.getName() : context.accountPath;
+  }
+
+  private String authAccountName(UserServletContext context) {
+    return context.getAuthAccount() != null ? context.getAuthAccount().getName() : "anonymous";
+  }
+}

--- a/store/src/main/java/com/zextras/mailbox/audit/SizeTrackingHttpServletResponse.java
+++ b/store/src/main/java/com/zextras/mailbox/audit/SizeTrackingHttpServletResponse.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package com.zextras.mailbox.audit;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+/**
+ * Response wrapper that tracks how much content is sent to the client, counting bytes written to
+ * the output stream and characters written through the writer.
+ */
+public class SizeTrackingHttpServletResponse extends HttpServletResponseWrapper {
+
+  private long size = 0;
+
+  public SizeTrackingHttpServletResponse(HttpServletResponse response) {
+    super(response);
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  @Override
+  public ServletOutputStream getOutputStream() throws IOException {
+    ServletOutputStream out = super.getOutputStream();
+    return new ServletOutputStream() {
+      @Override
+      public boolean isReady() {
+        return out.isReady();
+      }
+
+      @Override
+      public void setWriteListener(WriteListener writeListener) {
+        out.setWriteListener(writeListener);
+      }
+
+      @Override
+      public void write(int b) throws IOException {
+        out.write(b);
+        size++;
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+        size += len;
+      }
+
+      @Override
+      public void flush() throws IOException {
+        out.flush();
+      }
+
+      @Override
+      public void close() throws IOException {
+        out.close();
+      }
+    };
+  }
+
+  @Override
+  public PrintWriter getWriter() throws IOException {
+    PrintWriter writer = super.getWriter();
+    return new PrintWriter(writer) {
+      @Override
+      public void write(int c) {
+        super.write(c);
+        size++;
+      }
+
+      @Override
+      public void write(char[] buf, int off, int len) {
+        super.write(buf, off, len);
+        size += len;
+      }
+
+      @Override
+      public void write(String s, int off, int len) {
+        super.write(s, off, len);
+        size += len;
+      }
+    };
+  }
+}

--- a/store/src/main/java/com/zimbra/cs/service/UserServlet.java
+++ b/store/src/main/java/com/zimbra/cs/service/UserServlet.java
@@ -5,6 +5,7 @@
 
 package com.zimbra.cs.service;
 
+import com.zextras.mailbox.audit.SizeTrackingHttpServletResponse;
 import com.zimbra.client.ZFolder;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.account.Key.AccountBy;
@@ -328,7 +329,7 @@ public class UserServlet extends ZimbraServlet {
     ZimbraLog.clearContext();
     addRemoteIpToLoggingContext(req);
     try {
-      context = createContext(req, resp, this);
+      context = createContext(req, new SizeTrackingHttpServletResponse(resp), this);
       if (!checkAuthentication(context)) {
         sendError(context, req, resp, L10nUtil.getMessage(MsgKey.errMustAuthenticate, req));
         return;

--- a/store/src/main/java/com/zimbra/cs/service/UserServletContext.java
+++ b/store/src/main/java/com/zimbra/cs/service/UserServletContext.java
@@ -54,7 +54,7 @@ import com.zimbra.cs.servlet.util.CsrfUtil;
 
 public class UserServletContext {
     public final HttpServletRequest req;
-    public HttpServletResponse resp;
+    public final HttpServletResponse resp;
     public final UserServlet servlet;
     public final Map<String, String> params;
     public FormatType format;

--- a/store/src/main/java/com/zimbra/cs/service/UserServletContext.java
+++ b/store/src/main/java/com/zimbra/cs/service/UserServletContext.java
@@ -54,7 +54,7 @@ import com.zimbra.cs.servlet.util.CsrfUtil;
 
 public class UserServletContext {
     public final HttpServletRequest req;
-    public final HttpServletResponse resp;
+    public HttpServletResponse resp;
     public final UserServlet servlet;
     public final Map<String, String> params;
     public FormatType format;
@@ -86,6 +86,8 @@ public class UserServletContext {
     private long mEndTime = -2;
     private Throwable error;
     private boolean csrfAuthSucceeded;
+    private UploadInputStream uploadInputStream;
+    private boolean partialResults;
 
 
 
@@ -707,6 +709,10 @@ public class UserServletContext {
             }
             return in;
         }
+
+        long getBytesRead() {
+            return curSize;
+        }
     }
 
     public InputStream getRequestInputStream()
@@ -775,7 +781,8 @@ public class UserServletContext {
                         is.close();
                         is = null;
                     } else {
-                        is = new UploadInputStream(fis.openStream(), limit);
+                        uploadInputStream = new UploadInputStream(fis.openStream(), limit);
+                        is = uploadInputStream;
                         break;
                     }
                 }
@@ -794,10 +801,11 @@ public class UserServletContext {
             filename = ctype.getParameter("name");
             if (filename == null || filename.trim().equals(""))
                 filename = new ContentDisposition(req.getHeader("Content-Disposition")).getParameter("filename");
-            is = new UploadInputStream(contentEncoding != null &&
+            uploadInputStream = new UploadInputStream(contentEncoding != null &&
                 contentEncoding.contains("gzip") ?
                 new GZIPInputStream(req.getInputStream()) :
                     req.getInputStream(), limit);
+            is = uploadInputStream;
         }
         if (filename == null || filename.trim().equals(""))
             filename = "unknown";
@@ -815,6 +823,21 @@ public class UserServletContext {
 
     public Throwable getLoggedError() {
         return error;
+    }
+
+    public long getRequestBodySize() {
+        if (uploadInputStream != null) {
+            return uploadInputStream.getBytesRead();
+        }
+        return Math.max(req.getContentLength(), 0);
+    }
+
+    public void recordPartialResults() {
+        partialResults = true;
+    }
+
+    public boolean hasPartialResults() {
+        return partialResults;
     }
 
     @Override

--- a/store/src/main/java/com/zimbra/cs/service/formatter/Formatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/Formatter.java
@@ -127,11 +127,6 @@ public abstract class Formatter {
   public final void format(UserServletContext context)
       throws UserServletException, IOException, ServletException, ServiceException {
 
-    SizeTrackingHttpServletResponse sizeTrackingResponse = null;
-    if (auditLog.isAuditable(context)) {
-      sizeTrackingResponse = new SizeTrackingHttpServletResponse(context.resp);
-      context.resp = sizeTrackingResponse;
-    }
     boolean failed = false;
     try {
       formatStarted(context);
@@ -141,7 +136,8 @@ public abstract class Formatter {
       failed = true;
       updateClient(context, e);
     } finally {
-      if (sizeTrackingResponse != null) {
+      if (auditLog.isAuditable(context)
+          && context.resp instanceof SizeTrackingHttpServletResponse sizeTrackingResponse) {
         auditLog.logExport(context, failed, sizeTrackingResponse.getSize());
       }
       formatEnded(context);

--- a/store/src/main/java/com/zimbra/cs/service/formatter/Formatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/Formatter.java
@@ -5,6 +5,8 @@
 
 package com.zimbra.cs.service.formatter;
 
+import com.zextras.mailbox.audit.ImportExportAuditLog;
+import com.zextras.mailbox.audit.SizeTrackingHttpServletResponse;
 import com.zimbra.common.mime.MimeConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.SoapProtocol;
@@ -54,6 +56,8 @@ public abstract class Formatter {
   private final Pattern ALLOWED_CALLBACK_CHARS = Pattern.compile("^[a-zA-Z0-9_.-]+$");
 
   private static String PROGRESS = "-progress";
+
+  private static final ImportExportAuditLog auditLog = new ImportExportAuditLog(ZimbraLog.mailbox);
 
   public String[] getDefaultMimeTypes() {
     return new String[0];
@@ -123,13 +127,23 @@ public abstract class Formatter {
   public final void format(UserServletContext context)
       throws UserServletException, IOException, ServletException, ServiceException {
 
+    SizeTrackingHttpServletResponse sizeTrackingResponse = null;
+    if (auditLog.isAuditable(context)) {
+      sizeTrackingResponse = new SizeTrackingHttpServletResponse(context.resp);
+      context.resp = sizeTrackingResponse;
+    }
+    boolean failed = false;
     try {
       formatStarted(context);
       formatCallback(context);
       updateClient(context, null);
     } catch (Exception e) {
+      failed = true;
       updateClient(context, e);
     } finally {
+      if (sizeTrackingResponse != null) {
+        auditLog.logExport(context, failed, sizeTrackingResponse.getSize());
+      }
       formatEnded(context);
     }
   }
@@ -138,6 +152,7 @@ public abstract class Formatter {
       UserServletContext context, String contentType, Folder folder, String filename)
       throws UserServletException, IOException, ServletException, ServiceException, HttpException {
 
+    boolean failed = false;
     try {
       saveStarted(context);
       if (context.targetMailbox != null) {
@@ -146,11 +161,16 @@ public abstract class Formatter {
       saveCallback(context, contentType, folder, filename);
       updateClient(context, null);
     } catch (UserServletException e) {
+      failed = true;
       throw new UserServletException(e.getHttpStatusCode(), e.getMessage(), e);
     } catch (Exception e) {
+      failed = true;
       updateClient(context, e);
       saveEnded(context);
     } finally {
+      if (auditLog.isAuditable(context)) {
+        auditLog.logImport(context, failed, context.getRequestBodySize());
+      }
       if (context.targetMailbox != null) {
         try {
           context.targetMailbox.resumeIndexingAndDrainDeferred();
@@ -335,6 +355,9 @@ public abstract class Formatter {
 
   protected void updateClient(UserServletContext context, Exception e, List<ServiceException> w)
       throws UserServletException, IOException, ServletException, ServiceException {
+    if (w != null && !w.isEmpty()) {
+      context.recordPartialResults();
+    }
     String callback = context.params.get(QP_CALLBACK);
     Throwable exception = null;
     PrintWriter out = null;

--- a/store/src/test/java/com/zextras/mailbox/audit/ImportExportAuditLogIT.java
+++ b/store/src/test/java/com/zextras/mailbox/audit/ImportExportAuditLogIT.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.zextras.mailbox.MailboxTestSuite;
 import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.common.util.tar.TarEntry;
+import com.zimbra.common.util.tar.TarOutputStream;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.mailbox.MailboxManager;
@@ -19,7 +21,9 @@ import com.zimbra.cs.mailbox.MailboxTest;
 import com.zimbra.cs.mailbox.MailboxTestUtil;
 import com.zimbra.cs.service.AuthProvider;
 import com.zimbra.cs.service.UserServlet;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.zip.GZIPOutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
@@ -108,6 +112,30 @@ class ImportExportAuditLogIT extends MailboxTestSuite {
   }
 
   @Test
+  void shouldLogSuccessfulIcsExportWrittenThroughWriter() throws Exception {
+    final HttpResponse response = get("~/Calendar?fmt=ics&auth=co");
+
+    assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+    final String line = auditAppender.findLineContaining("cmd=FolderExport;");
+    assertTrue(line.contains("folder=/Calendar;"));
+    assertTrue(line.contains("fmt=ics;"));
+    assertTrue(line.contains("outcome=success;"));
+    assertTrue(exportedSize(line) > 0);
+  }
+
+  @Test
+  void shouldLogPartialOutcomeWhenSomeImportEntriesFail() throws Exception {
+    final HttpResponse response =
+        post("~/Inbox?fmt=tgz&auth=co", new ByteArrayEntity(tgzWithBrokenEntry()));
+
+    assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+    final String line = auditAppender.findLineContaining("cmd=FolderImport;");
+    assertTrue(line.contains("folder=/Inbox;"));
+    assertTrue(line.contains("fmt=tgz;"));
+    assertTrue(line.contains("outcome=partial;"));
+  }
+
+  @Test
   void shouldLogErrorOutcomeWhenImportFails() throws Exception {
     post("~/Calendar?fmt=ics&auth=co", new ByteArrayEntity("not an ics file".getBytes()));
 
@@ -135,6 +163,20 @@ class ImportExportAuditLogIT extends MailboxTestSuite {
             MailboxTest.STANDARD_DELIVERY_OPTIONS,
             null)
         .getId();
+  }
+
+  private byte[] tgzWithBrokenEntry() throws Exception {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    final GZIPOutputStream gzip = new GZIPOutputStream(bytes);
+    try (TarOutputStream tar = new TarOutputStream(gzip, "UTF-8")) {
+      final byte[] content = "broken".getBytes();
+      final TarEntry entry = new TarEntry("broken.err");
+      entry.setSize(content.length);
+      tar.putNextEntry(entry);
+      tar.write(content);
+      tar.closeEntry();
+    }
+    return bytes.toByteArray();
   }
 
   private long exportedSize(String line) {

--- a/store/src/test/java/com/zextras/mailbox/audit/ImportExportAuditLogIT.java
+++ b/store/src/test/java/com/zextras/mailbox/audit/ImportExportAuditLogIT.java
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package com.zextras.mailbox.audit;
+
+import static com.zimbra.common.util.ZimbraCookie.COOKIE_ZM_AUTH_TOKEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zextras.mailbox.MailboxTestSuite;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.mailbox.MailboxManager;
+import com.zimbra.cs.mailbox.MailboxTest;
+import com.zimbra.cs.mailbox.MailboxTestUtil;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.cs.service.UserServlet;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImportExportAuditLogIT extends MailboxTestSuite {
+
+  private static final String SERVER_HOST = "127.0.0.1";
+
+  private Server server;
+  private Account testAccount;
+  private InMemoryAppender auditAppender;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new Server();
+    final ServletHolder servletHolder = new ServletHolder(UserServlet.class);
+    final ServletContextHandler servletContextHandler = new ServletContextHandler();
+    servletContextHandler.addServlet(servletHolder, "/*");
+    server.setHandler(servletContextHandler.getCoreContextHandler());
+    final ServerConnector serverConnector = new ServerConnector(server);
+    serverConnector.setHost(SERVER_HOST);
+    server.setConnectors(new ServerConnector[] {serverConnector});
+    server.start();
+    testAccount = createAccount().create();
+    auditAppender = attachAppenderToMailboxLog();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    detachAppenderFromMailboxLog();
+    server.stop();
+  }
+
+  @Test
+  void shouldLogSuccessfulFolderExport() throws Exception {
+    addMessageToInbox("audit export test");
+
+    final HttpResponse response = get("~/Inbox?fmt=tgz&auth=co");
+
+    assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+    final String line = auditAppender.findLineContaining("cmd=FolderExport;");
+    assertTrue(line.contains("account=" + testAccount.getName() + ";"));
+    assertTrue(line.contains("authAccount=" + testAccount.getName() + ";"));
+    assertTrue(line.contains("folder=/Inbox;"));
+    assertTrue(line.contains("fmt=tgz;"));
+    assertTrue(line.contains("outcome=success;"));
+    assertTrue(exportedSize(line) > 0);
+  }
+
+  @Test
+  void shouldLogSuccessfulFolderImport() throws Exception {
+    final HttpResponse response =
+        post("~/Calendar?fmt=ics&auth=co", new FileEntity(icsTestFile()));
+
+    assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+    final String line = auditAppender.findLineContaining("cmd=FolderImport;");
+    assertTrue(line.contains("account=" + testAccount.getName() + ";"));
+    assertTrue(line.contains("folder=/Calendar;"));
+    assertTrue(line.contains("fmt=ics;"));
+    assertTrue(line.contains("outcome=success;"));
+    assertTrue(exportedSize(line) > 0);
+  }
+
+  @Test
+  void shouldLogErrorOutcomeWhenImportFails() throws Exception {
+    post("~/Calendar?fmt=ics&auth=co", new ByteArrayEntity("not an ics file".getBytes()));
+
+    final String line = auditAppender.findLineContaining("cmd=FolderImport;");
+    assertTrue(line.contains("folder=/Calendar;"));
+    assertTrue(line.contains("outcome=error;"));
+  }
+
+  @Test
+  void shouldNotAuditSingleItemDownload() throws Exception {
+    final int messageId = addMessageToInbox("single message download");
+
+    final HttpResponse response = get("~/?id=" + messageId + "&auth=co");
+
+    assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+    assertTrue(auditAppender.linesContaining("cmd=FolderExport;").isEmpty());
+  }
+
+  private int addMessageToInbox(String subject) throws Exception {
+    final var mailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+    return mailbox
+        .addMessage(
+            null,
+            MailboxTestUtil.generateMessage(subject),
+            MailboxTest.STANDARD_DELIVERY_OPTIONS,
+            null)
+        .getId();
+  }
+
+  private long exportedSize(String line) {
+    final String sizeAttribute = line.substring(line.indexOf("size=") + "size=".length());
+    return Long.parseLong(sizeAttribute.replace(";", "").trim());
+  }
+
+  private File icsTestFile() {
+    return new File(
+        Objects.requireNonNull(
+                this.getClass().getResource("/com/zimbra/cs/service/UploadCalendar.ics"))
+            .getFile());
+  }
+
+  private HttpResponse get(String path) throws Exception {
+    try (CloseableHttpClient client = authenticatedClient()) {
+      final HttpGet httpGet = new HttpGet();
+      httpGet.setURI(URI.create(server.getURI().toString() + path));
+      return client.execute(httpGet);
+    }
+  }
+
+  private HttpResponse post(String path, org.apache.http.HttpEntity entity) throws Exception {
+    try (CloseableHttpClient client = authenticatedClient()) {
+      final HttpPost httpPost = new HttpPost();
+      httpPost.setEntity(entity);
+      httpPost.setURI(URI.create(server.getURI().toString() + path));
+      return client.execute(httpPost);
+    }
+  }
+
+  private CloseableHttpClient authenticatedClient() throws Exception {
+    final AuthToken authToken = AuthProvider.getAuthToken(testAccount);
+    final CookieStore cookieStore = new BasicCookieStore();
+    final BasicClientCookie cookie =
+        new BasicClientCookie(COOKIE_ZM_AUTH_TOKEN, authToken.getEncoded());
+    cookie.setDomain(SERVER_HOST);
+    cookie.setPath("/");
+    cookieStore.addCookie(cookie);
+    return HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+  }
+
+  private InMemoryAppender attachAppenderToMailboxLog() {
+    final InMemoryAppender appender = new InMemoryAppender();
+    appender.start();
+    ZimbraLog.mailbox.setLevel(com.zimbra.common.util.Log.Level.info);
+    ((Logger) LogManager.getLogger("zimbra.mailbox")).addAppender(appender);
+    return appender;
+  }
+
+  private void detachAppenderFromMailboxLog() {
+    ((Logger) LogManager.getLogger("zimbra.mailbox")).removeAppender(auditAppender);
+  }
+
+  private static class InMemoryAppender extends AbstractAppender {
+
+    private final List<String> lines = new CopyOnWriteArrayList<>();
+
+    InMemoryAppender() {
+      super("import-export-audit-test", null, null, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      lines.add(event.getMessage().getFormattedMessage());
+    }
+
+    String findLineContaining(String text) {
+      final List<String> matches = linesContaining(text);
+      assertEquals(1, matches.size(), "expected exactly one audit line containing: " + text);
+      return matches.get(0);
+    }
+
+    List<String> linesContaining(String text) {
+      return lines.stream().filter(line -> line.contains(text)).toList();
+    }
+  }
+}

--- a/store/src/test/java/com/zextras/mailbox/audit/SizeTrackingHttpServletResponseTest.java
+++ b/store/src/test/java/com/zextras/mailbox/audit/SizeTrackingHttpServletResponseTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package com.zextras.mailbox.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zimbra.cs.service.MockHttpServletResponse;
+import java.io.PrintWriter;
+import javax.servlet.ServletOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SizeTrackingHttpServletResponseTest {
+
+  private SizeTrackingHttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    response = new SizeTrackingHttpServletResponse(new MockHttpServletResponse());
+  }
+
+  @Test
+  void shouldCountBytesWrittenToOutputStream() throws Exception {
+    final ServletOutputStream out = response.getOutputStream();
+
+    out.write('a');
+    out.write("hello".getBytes());
+    out.write("full content".getBytes(), 5, 7);
+    out.flush();
+    out.close();
+
+    assertEquals(13, response.getSize());
+  }
+
+  @Test
+  void shouldDelegateOutputStreamReadiness() throws Exception {
+    final ServletOutputStream out = response.getOutputStream();
+
+    assertTrue(out.isReady());
+    out.setWriteListener(null);
+    assertEquals(0, response.getSize());
+  }
+
+  @Test
+  void shouldCountCharactersWrittenThroughWriter() throws Exception {
+    final PrintWriter writer = response.getWriter();
+
+    writer.write('a');
+    writer.print("hello");
+    writer.write(new char[] {'x', 'y', 'z'}, 0, 3);
+    writer.flush();
+
+    assertEquals(9, response.getSize());
+  }
+
+  @Test
+  void shouldAccumulateSizeAcrossStreamAndWriter() throws Exception {
+    response.getOutputStream().write("bytes".getBytes());
+    final PrintWriter writer = response.getWriter();
+    writer.print("chars");
+    writer.flush();
+
+    assertEquals(10, response.getSize());
+  }
+}


### PR DESCRIPTION
## Why

Administrators need a mailbox-server-level audit trail showing **who imported or exported which folders**.

## What

Every folder import/export performed through `UserServlet` now writes one `INFO` entry to `mailbox.log`:

```text
cmd=FolderExport; account=user@example.com; authAccount=admin@example.com; folder=/Inbox; fmt=tgz; outcome=success; size=2495;
```

The audit entry includes:

* **Account** — mailbox owner.
* **Auth account** — authenticated user, including delegated/admin access.
* **Folder** — folder path.
* **Format** — import/export format.
* **Outcome** — `success`, `error`, or `partial` (some items skipped).
* **Size** — transferred size in bytes.

Timestamp and client IP are provided by the standard log context.

## How

* Added `ImportExportAuditLog` (`com.zextras.mailbox.audit`) to emit audit entries from the two choke points used by all formatters:

  * `Formatter.format()` for exports.
  * `Formatter.save()` for imports.
* Auditing is limited to folder-level operations using real import/export formats:
  `tgz`, `tar`, `zip`, `csv`, `ics`, `vcf`, `ldif`, `netscapeldif`.
* Single-item downloads and previews are excluded.
* Added `SizeTrackingHttpServletResponse` to track export bytes.
* Import size is obtained from the existing upload-stream byte counter.
* Extended `UserServletContext` to expose request body size and track partial results.
* `ArchiveFormatter` reports skipped items through `updateClient`, allowing partial operations to be recorded correctly.

## Tests

Added `ImportExportAuditLogIT` using embedded Jetty and a real mailbox, covering:

* Successful `tgz` export.
* Successful `ics` import.
* Failed import → `outcome=error`.
* Single-item download → no audit entry.

Existing `UserServlet` and formatter tests pass.

Also verified on a development server with a real export/import round trip.
