### PR TITLE
fix(docker): ship contact-fields.xml in mailbox image

### DIFF
--- a/docker/mailbox/Dockerfile
+++ b/docker/mailbox/Dockerfile
@@ -30,6 +30,7 @@ RUN cp /build/store/target/zm-store.jar /staging/opt/zextras/mailbox/jars/mailbo
     cp /build/store/conf/globs2.zimbra /staging/opt/zextras/conf/msgs/globs2.zimbra && \
     cp /build/store/conf/owasp_policy.xml /staging/opt/zextras/conf/owasp_policy.xml && \
     cp /build/store/conf/datasource.xml /staging/opt/zextras/conf/ && \
+    cp /build/store/conf/contacts/contact-fields.xml /staging/opt/zextras/conf/contact-fields.xml && \
     cp /build/store/db/create_database.sql /staging/opt/zextras/db/
 
 # Generate CLI scripts in build stage


### PR DESCRIPTION
`ContactCSV` loads the CSV mapping from `/opt/zextras/conf/contact-fields.xml` (zimbra_csv_mapping_file localconfig default). The docker image did not stage this file, so contact CSV import failed with `mail.UNABLE_TO_IMPORT_CONTACTS` and CSV export produced empty output.