### PR TITLE
feat(CO-4180): enforce import/export folder attrs on archive REST endpoints

### DIFF
--- a/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -278,9 +278,31 @@ public abstract class ArchiveFormatter extends Formatter {
   protected abstract ArchiveOutputStream getOutputStream(UserServletContext context, String charset)
       throws IOException;
 
+  private static void checkExportFolderFeatureEnabled(UserServletContext context)
+      throws UserServletException {
+    if (context.targetAccount != null && !context.targetAccount.isFeatureExportFolderEnabled()) {
+      throw new UserServletException(
+          HttpServletResponse.SC_FORBIDDEN,
+          "export folder feature is disabled (zimbraFeatureExportFolderEnabled)");
+    }
+  }
+
+  private static void checkImportFolderFeatureEnabled(UserServletContext context)
+      throws UserServletException {
+    if (context.targetAccount != null && !context.targetAccount.isFeatureImportFolderEnabled()) {
+      throw new UserServletException(
+          HttpServletResponse.SC_FORBIDDEN,
+          "import folder feature is disabled (zimbraFeatureImportFolderEnabled)");
+    }
+  }
+
   @Override
   public void formatCallback(UserServletContext context)
       throws IOException, ServiceException, UserServletException {
+    // part-based archives bundle attachments of a single message; they are not a folder export
+    if (!context.hasPart()) {
+      checkExportFolderFeatureEnabled(context);
+    }
     // Disable the jetty timeout
     disableJettyTimeout(context);
 
@@ -977,7 +999,9 @@ public abstract class ArchiveFormatter extends Formatter {
 
   @Override
   public void saveCallback(UserServletContext context, String contentType, Folder fldr, String file)
-      throws IOException, ServiceException {
+      throws IOException, ServiceException, UserServletException {
+
+    checkImportFolderFeatureEnabled(context);
 
     // Disable the jetty timeout
     disableJettyTimeout(context);

--- a/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
+++ b/store/src/main/java/com/zimbra/cs/service/formatter/ArchiveFormatter.java
@@ -283,7 +283,7 @@ public abstract class ArchiveFormatter extends Formatter {
     if (context.targetAccount != null && !context.targetAccount.isFeatureExportFolderEnabled()) {
       throw new UserServletException(
           HttpServletResponse.SC_FORBIDDEN,
-          "export folder feature is disabled (zimbraFeatureExportFolderEnabled)");
+          "export folder feature is disabled");
     }
   }
 
@@ -292,7 +292,7 @@ public abstract class ArchiveFormatter extends Formatter {
     if (context.targetAccount != null && !context.targetAccount.isFeatureImportFolderEnabled()) {
       throw new UserServletException(
           HttpServletResponse.SC_FORBIDDEN,
-          "import folder feature is disabled (zimbraFeatureImportFolderEnabled)");
+          "import folder feature is disabled");
     }
   }
 

--- a/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
+++ b/store/src/test/java/com/zimbra/cs/service/UserServletTest.java
@@ -254,6 +254,52 @@ class UserServletTest extends MailboxTestSuite {
 	}
 
 	@Test
+	void shouldExportFolderAsTgzWhenExportFolderFeatureEnabled() throws Exception {
+		addMessageToTestAccountInbox();
+
+		final HttpResponse response =
+				getUserServletRequest(server.getURI().toString() + "~/Inbox?auth=co&fmt=tgz");
+
+		assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+	}
+
+	@Test
+	void shouldRejectFolderExportWhenExportFolderFeatureDisabled() throws Exception {
+		addMessageToTestAccountInbox();
+		testAccount.setFeatureExportFolderEnabled(false);
+
+		final HttpResponse response =
+				getUserServletRequest(server.getURI().toString() + "~/Inbox?auth=co&fmt=tgz");
+
+		assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusLine().getStatusCode());
+		final String body = new String(response.getEntity().getContent().readAllBytes());
+		assertTrue(body.contains("export folder feature is disabled"));
+	}
+
+	@Test
+	void shouldRejectArchiveImportWhenImportFolderFeatureDisabled() throws Exception {
+		testAccount.setFeatureImportFolderEnabled(false);
+
+		final HttpResponse response =
+				postUserServletRequest(
+						server.getURI().toString() + "~/calendar?auth=co&fmt=zip", "UploadCalendar.zip");
+
+		assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusLine().getStatusCode());
+
+		final HttpResponse getCalendarsResponse = this.defaultUserCalendarRequest();
+		final String calendarResponse =
+				new String(getCalendarsResponse.getEntity().getContent().readAllBytes());
+		assertEquals("{}", calendarResponse);
+	}
+
+	private void addMessageToTestAccountInbox() throws Exception {
+		var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
+		testAccountMailbox.addMessage(null,
+				MailboxTestUtil.generateMessageWithAttachment("message to export"),
+				MailboxTest.STANDARD_DELIVERY_OPTIONS, null);
+	}
+
+	@Test
 	void should_return404_when_asked_attachment_does_not_exits() throws Exception {
 		var testAccountMailbox = MailboxManager.getInstance().getMailboxByAccount(testAccount);
 


### PR DESCRIPTION
Enforces `zimbraFeatureImportFolderEnabled` / `zimbraFeatureExportFolderEnabled`  server-side, so REST calls that bypass the UI are rejected when the feature is disabled.

### Changes
- `ArchiveFormatter` (base of `tgz`/`zip`/`tar` formatters, used by `UserServlet` `GET|POST /home/{user}/{folder}?fmt=...`):
- **Export**: returns `403 Forbidden` — `export folder feature is disabled` — when disabled on the target account.
- **Import**: returns `403 Forbidden` — `import folder feature is disabled` — when disabled on the target account.
- Part-based downloads (`?part=...&fmt=zip`, attachment bundles of a single message) are not folder exports and remain unaffected.
- Checks run against the **target account**, so they also cover delegated/shared and anonymous access.

### Attribute granularity (for docs)
Both attributes are defined at **account and COS level only** (`accountInherited`), not domain. Default: `TRUE`.

### Tests
`UserServletTest` (real Jetty + real accounts): export OK when enabled, `403` + explicit message when disabled, archive import `403` and nothing imported when disabled.