### PR TITLE
chore(deps): bump mailbox-attribute-manager to 5.3.1 (CO-4174)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
       <dependency>
         <groupId>com.zextras</groupId>
         <artifactId>mailbox-attribute-manager</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1</version>
       </dependency>
       <dependency>
         <groupId>com.zextras</groupId>


### PR DESCRIPTION
Final piece of [CO-4174](https://zextras.atlassian.net/browse/CO-4174) (Bloccante, 26.9.0, blocks QA-1006). Depends on carbonio-directory-server [#49](https://github.com/zextras/carbonio-directory-server/pull/49), released as **5.3.1**.

## Why

`carbonio-storages-ui` never loads in the webclient shell. It declares `attrKey: "carbonioFeatureStoragesEnabled"`, and the shell filters every micro-app through that attribute before loading it (`carbonio-shell-ui/src/boot/app/load-apps.ts:18-33`). The attribute did not exist in the Carbonio schema, so GetInfo never published it, `getUserSetting` returned `undefined`, and the app was silently dropped from `appsToLoad` — no `loaded carbonio-storages-ui` line, no Storage tab.

carbonio-directory-server 5.3.1 adds it:

```xml
<attr id="3172" name="carbonioFeatureStoragesEnabled" type="boolean" cardinality="single" optionalIn="account,cos" flags="accountInfo,accountInherited,domainAdminModifiable" since="26.9.0">
  <defaultCOSValue>TRUE</defaultCOSValue>
  <defaultExternalCOSValue>FALSE</defaultExternalCOSValue>
```

## Why this repo needs a change at all

No source edit is required — `ZAttrProvisioning` is *generated*, not checked in. `common/pom.xml:199-220` runs `AttributeManagerUtil -a generateProvisioning` at `generate-sources` into `common/target/generated-sources/zattr/` (gitignored, untracked), and `AttributeManagerUtil` reads the `attrs.xml` bundled **inside the `mailbox-attribute-manager` jar** — the artifact carbonio-directory-server publishes from the file changed in #49.

But `pom.xml:503-507` pins that jar to an **exact** version, not a range and not `${project.version}`:

```xml
<artifactId>mailbox-attribute-manager</artifactId>
<version>5.3.0</version>
```

so it will never pick 5.3.1 up on its own. This one-line bump is the whole change.

(For context: these constants used to be checked in — see `6d2de81` for `carbonioFeatureTasksEnabled` — until `d121b47b1e` "refactor: [CO-2522] move RightManager and attrs.xml files" moved to the generated-from-jar model.)

## Verification

5.3.1 is published to both repositories, and its bundled `attrs.xml` contains the attribute:

```
repo.zextras.tools/repository/java-sdk            5.3.1 jar: 200
zextras.jfrog.io/artifactory/public-maven-repo    5.3.1 jar: 200
unzip -p mailbox-attribute-manager-5.3.1.jar conf/attrs/attrs.xml | grep -c carbonioFeatureStoragesEnabled  ->  1
```

With this bump, `mvn -pl common -am -DskipTests generate-sources` emits the constant:

```java
@ZAttr(id=3172)
public static final String A_carbonioFeatureStoragesEnabled = "carbonioFeatureStoragesEnabled";
```

Note: `mvn -pl store -am generate-sources` fails locally on an unrelated, pre-existing issue — `right-manager:4.35.0-SNAPSHOT` is not resolvable without a full local install. Unrelated to this change; CI builds the full reactor.

## No other change needed

GetInfo has no separate allowlist: `GetInfo.java:259` does `attrMgr.getAttrsWithFlag(AttributeFlag.accountInfo)` and emits every match via `ToXML.encodeAttr` (line 298). The `accountInfo` flag on the new attr is sufficient. The special-casing at lines 273-278 (`zimbraLocale`, `zimbraAttachmentsBlocked`) only computes values, it does not gate inclusion.

## Heads-up for QA

This unblocks the shell from *loading* the app, but `carbonio-storages-ui/src/app/shell-registration.tsx:52` also bails on `isCarbonioCE || totalQuotaEnabled !== true`. Retest needs a non-CE build with the `totalQuota` feature flag enabled, otherwise the symptom looks identical for a different reason.


[CO-4174]: https://zextras.atlassian.net/browse/CO-4174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CO-2522]: https://zextras.atlassian.net/browse/CO-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ