### PR TITLE
chore: retarget devel branch refs to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     }
 
     triggers {
-        cron(env.BRANCH_NAME == 'devel' ? 'H 5 * * *' : '')
+        cron(env.BRANCH_IS_PRIMARY == 'true' ? 'H 5 * * *' : '')
     }
 
     stages {

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,7 +8,7 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-  branches: ['devel'],
+  branches: ['main'],
   tagFormat: "${version}",
   plugins: [
     [


### PR DESCRIPTION
Ahead of the devel→main default-branch rename. Jenkinsfile's nightly cron gate (`env.BRANCH_NAME == 'devel' ? 'H 5 * * *' : ''`) now uses `env.BRANCH_IS_PRIMARY == 'true'` instead of a hardcoded branch name. `release.config.mjs` branches retargeted to `main`.

Not touched: `build_packages.sh`'s `repo.area51-zextras.com/devel` apt URL — that's a Nexus/area51 package-channel path, not this repo's git branch. Also not touched: the four sidecar Dockerfiles' `FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel` — that's an external dependency's branch tag, out of scope for this repo's own rename.